### PR TITLE
Re-define spacing to prevent overlapping verse

### DIFF
--- a/src/components/verses/Verse.tsx
+++ b/src/components/verses/Verse.tsx
@@ -7,7 +7,7 @@ import VerseType from '../../../types/VerseType';
 import VerseText from './VerseText';
 
 const VerseContainer = styled(Element)`
-  padding: 2rem 1rem;
+  padding: 1.5rem 1rem;
 `;
 
 type VerseProps = {

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -95,7 +95,7 @@ video {
   font: inherit;
   vertical-align: baseline;
   font-family: "SFProText-Regular", "Helvetica Neue", Helvetica, Arial;
-  line-height: 1.5rem;
+  line-height: 4rem;
 }
 
 /* make sure to set some focus styles for accessibility */


### PR DESCRIPTION
# Issues
Verse (ayah) overlapping with each other makes it unreadable for a long ayah

# Reproduction
- Git clone repo
- Go to Surah Az-Zumar or `http://localhost/39`
- See the overlapping text

Before:
<img width="1176" alt="Screen" src="https://user-images.githubusercontent.com/21690115/83412068-1a10cd80-a44c-11ea-9654-01997caa6235.png">

After changes in this PR: 
<img width="1176" alt="Screen" src="https://user-images.githubusercontent.com/21690115/83412218-4e848980-a44c-11ea-908e-5083f9be351e.png">

cc: @mmahalwy 