### PR TITLE
Add redux-persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-redux": "^7.2.0",
     "react-scroll": "^1.7.16",
     "react-use": "^13.27.0",
+    "redux-persist": "^6.0.0",
     "storybook-styled-components": "^1.1.4",
     "styled-bootstrap-grid": "^3.1.0",
     "styled-breakpoints": "^8.1.0",

--- a/src/pages_/_app.tsx
+++ b/src/pages_/_app.tsx
@@ -2,19 +2,22 @@ import React from 'react';
 import { DefaultSeo } from 'next-seo';
 import { ThemeProvider } from 'styled-components';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 import { theme } from '../utils/styles';
 import { createSEOConfig } from '../utils/seo';
 import Footer from '../components/Footer';
-import store from '../redux/store';
+import store, { persistor } from '../redux/store';
 
 function MyApp({ Component, pageProps }): JSX.Element {
   return (
     <Provider store={store}>
-      <ThemeProvider theme={theme}>
-        <DefaultSeo {...createSEOConfig({})} />
-        <Component {...pageProps} />
-        <Footer />
-      </ThemeProvider>
+      <PersistGate loading={null} persistor={persistor}>
+        <ThemeProvider theme={theme}>
+          <DefaultSeo {...createSEOConfig({})} />
+          <Component {...pageProps} />
+          <Footer />
+        </ThemeProvider>
+      </PersistGate>
     </Provider>
   );
 }

--- a/src/pages_/_app.tsx
+++ b/src/pages_/_app.tsx
@@ -1,24 +1,20 @@
 import React from 'react';
 import { DefaultSeo } from 'next-seo';
 import { ThemeProvider } from 'styled-components';
-import { Provider } from 'react-redux';
-import { PersistGate } from 'redux-persist/integration/react';
 import { theme } from '../utils/styles';
 import { createSEOConfig } from '../utils/seo';
 import Footer from '../components/Footer';
-import store, { persistor } from '../redux/store';
+import ReduxProvider from '../redux/Provider';
 
 function MyApp({ Component, pageProps }): JSX.Element {
   return (
-    <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        <ThemeProvider theme={theme}>
-          <DefaultSeo {...createSEOConfig({})} />
-          <Component {...pageProps} />
-          <Footer />
-        </ThemeProvider>
-      </PersistGate>
-    </Provider>
+    <ReduxProvider>
+      <ThemeProvider theme={theme}>
+        <DefaultSeo {...createSEOConfig({})} />
+        <Component {...pageProps} />
+        <Footer />
+      </ThemeProvider>
+    </ReduxProvider>
   );
 }
 

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -1,0 +1,34 @@
+import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+import store, { persistor } from './store';
+
+/**
+ * A wrapper around the Provider component to skip rendering <PersistGate />
+ * on the server. PersistGate prevents children from rendering until the persisted
+ * state is retrieved from localstorage, this results in an empty DOM for SSR and SSG.
+ * For more info: https://github.com/rt2zz/redux-persist/issues/1008
+ * @param props
+ */
+const ReduxProvider = (props) => {
+  const { children } = props;
+
+  const isClient = !!(
+    typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+  );
+
+  if (isClient) {
+    return (
+      <Provider store={store}>
+        <PersistGate loading={null} persistor={persistor}>
+          {children}
+        </PersistGate>
+      </Provider>
+    );
+  }
+
+  return <Provider store={store}>{children}</Provider>;
+};
+
+export default ReduxProvider;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,6 +1,38 @@
-import { configureStore } from '@reduxjs/toolkit';
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import { configureStore, getDefaultMiddleware, combineReducers } from '@reduxjs/toolkit';
 
-export default configureStore({
-  reducer: {}, // TODO: add reducers here
+const persistConfig = {
+  key: 'root',
+  version: 1,
+  storage,
+  whitelist: [], // Reducers defined here will be have their values saved in local storage and persist across sessions. See: https://github.com/rt2zz/redux-persist#blacklist--whitelist
+};
+
+const rootReducer = combineReducers({}); // TODO: Add our reducers here
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+const store = configureStore({
+  reducer: persistedReducer,
+  middleware: getDefaultMiddleware({
+    serializableCheck: {
+      // Used for Redux-persist, see:https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist
+      ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+    },
+  }),
   devTools: true, // TODO: disable in production builds
 });
+
+export const persistor = persistStore(store);
+
+export default store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11450,6 +11450,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
### Summary
Added [redux-persist](https://github.com/rt2zz/redux-persist) to persist parts of our redux store in localstorage across sessions. This will be useful for adding features such as showing the last read position.

Followed the set-up guide here: https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist.

Will create a follow-up PR insha'Allah to demo the values being saved in localstorage and persisting across sessions. 

### Test Plan
Confirmed that a `persist:root` object is being created in localstorage (see screenshot). No observable changes in the app behavior. Tested the usage and confirmed that the whitelisted values persist in #71. 

### Screenshots

![image](https://user-images.githubusercontent.com/11590314/86459588-4b203e80-bd27-11ea-99dc-493012de3ccc.png)
