### PR TITLE
Disable the redux devtools in production 

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -2,5 +2,5 @@ import { configureStore } from '@reduxjs/toolkit';
 
 export default configureStore({
   reducer: {}, // TODO: add reducers here
-  devTools: true, // TODO: disable in production builds
+  devTools: process.env.NODE_ENV === 'development', // disables the devtools in production
 });


### PR DESCRIPTION
### Summary
TSIA 

### Test Plan
Ran a dev and production run, Confirmed that the devtools configuration returns `true` for development and `false` for production 
