### PR TITLE
Move the Quran Reader styles to redux

### DIFF
--- a/src/components/QuranReader/MushafView.tsx
+++ b/src/components/QuranReader/MushafView.tsx
@@ -18,9 +18,6 @@ const MushafView = ({ verses }: MushafViewProps) => {
 };
 
 const StyledMushafView = styled.div`
-  font-size: 2rem; //TODO (@abdellatif): update to use the theme font size
-  line-height: 3rem; //TODO (@abdellatif): update to use the theme font size
-  letter-spacing: 0.25rem; //TODO (@abdellatif): update to use the theme font size
   max-width: 100%;
   direction: rtl;
   margin: 1rem auto;

--- a/src/components/QuranReader/TranslationView.tsx
+++ b/src/components/QuranReader/TranslationView.tsx
@@ -14,7 +14,6 @@ const TranslationView = ({ verses }: TranslationViewProps) => {
       {verses.map((verse) => (
         <VerseTextContainer key={verse.id}>
           <VerseText verse={verse} fontStyle="uthmani" />
-          {/* TODO (@abdellatif): use the translation from the API */}
           <StyledText>{verse.translations && verse.translations[0]?.text}</StyledText>
           <hr />
         </VerseTextContainer>

--- a/src/components/Verse/VerseText.tsx
+++ b/src/components/Verse/VerseText.tsx
@@ -29,13 +29,13 @@ const VerseText = ({ verse, fontStyle }: VerseTextProps) => {
 };
 
 const StyledVerseText = styled.div<{ styles: QuranReaderStyles }>`
-  display: inline-block;
   line-height: ${(props) => props.styles.quranTextLineHeight}rem;
+  line-break: anywhere;
 `;
 
 const StyledVerseTextContainer = styled.div<{ styles: QuranReaderStyles }>`
+  display: inline-block;
   direction: rtl;
-  line-break: anywhere;
   font-size: ${(props) => props.styles.quranTextFontSize}rem;
   letter-spacing: ${(props) => props.styles.quranTextLetterSpacing}rem;
 `;

--- a/src/components/Verse/VerseText.tsx
+++ b/src/components/Verse/VerseText.tsx
@@ -1,37 +1,43 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
 import VerseType from '../../../types/VerseType';
 import QuranWord from '../dls/QuranWord/QuranWord';
+import { selectQuranReaderStyles, QuranReaderStyles } from '../../redux/slices/QuranReader/styles';
 
 type VerseTextProps = {
   verse: VerseType;
   fontStyle?: 'uthmani' | 'madani' | 'indopak';
 };
 
-const VerseText = ({ verse, fontStyle }: VerseTextProps) => (
-  <StyledVerseTextContainer>
-    <StyledVerseText>
-      {verse.words?.map((word) => (
-        <QuranWord
-          key={[word.position, word.code, word.lineNum].join('-')}
-          word={word}
-          fontStyle={fontStyle}
-        />
-      ))}
-    </StyledVerseText>
-  </StyledVerseTextContainer>
-);
+const VerseText = ({ verse, fontStyle }: VerseTextProps) => {
+  const quranReaderStyles = useSelector(selectQuranReaderStyles);
 
-const StyledVerseText = styled.div`
+  return (
+    <StyledVerseTextContainer styles={quranReaderStyles}>
+      <StyledVerseText styles={quranReaderStyles}>
+        {verse.words?.map((word) => (
+          <QuranWord
+            key={[word.position, word.code, word.lineNum].join('-')}
+            word={word}
+            fontStyle={fontStyle}
+          />
+        ))}
+      </StyledVerseText>
+    </StyledVerseTextContainer>
+  );
+};
+
+const StyledVerseText = styled.div<{ styles: QuranReaderStyles }>`
   display: inline-block;
-  line-height: 3rem; //TODO (@abdellatif): update to use the theme font size
+  line-height: ${(props) => props.styles.quranTextLineHeight}rem;
 `;
 
-const StyledVerseTextContainer = styled.div`
+const StyledVerseTextContainer = styled.div<{ styles: QuranReaderStyles }>`
   direction: rtl;
   line-break: anywhere;
-  font-size: 2rem; //TODO (@abdellatif): update to use the theme font size
-  letter-spacing: 0.25rem; //TODO (@abdellatif): update to use the theme font size
+  font-size: ${(props) => props.styles.quranTextFontSize}rem;
+  letter-spacing: ${(props) => props.styles.quranTextLetterSpacing}rem;
 `;
 
 export default VerseText;

--- a/src/pages_/[chapterId].tsx
+++ b/src/pages_/[chapterId].tsx
@@ -27,7 +27,7 @@ const Chapter: NextPage<ChapterProps> = ({ chapterResponse: { chapter }, versesR
 
   return (
     <Container>
-      <Row>{data.verses && <QuranReader verses={data.verses} view="translation" />}</Row>
+      <Row>{data.verses && <QuranReader verses={data.verses} view="reading" />}</Row>
     </Container>
   );
 };

--- a/src/pages_/[chapterId].tsx
+++ b/src/pages_/[chapterId].tsx
@@ -17,7 +17,7 @@ type ChapterProps = {
 
 const Chapter: NextPage<ChapterProps> = ({ chapterResponse: { chapter }, versesResponse }) => {
   const { data } = useSWR(
-    makeUrl(`/chapters/${chapter.id}/verses?translations=20`), // TODO: select the translation using a helper function
+    makeUrl(`/chapters/${chapter.id}/verses?translations=20`), // TODO: select the translation using the user preference
     fetcher,
     {
       initialData: versesResponse,

--- a/src/redux/slices/QuranReader/styles.ts
+++ b/src/redux/slices/QuranReader/styles.ts
@@ -1,0 +1,52 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const FONT_SCALING_FACTOR = 1.1;
+
+export const quranReaderStylesSlice = createSlice({
+  name: 'quranReaderStyles',
+  initialState: {
+    // the base sizes in rem
+    translationFontSize: 2,
+    quranTextFontSize: 3,
+    quranTextlineHeight: 0.25,
+  },
+  reducers: {
+    increaseTranslationTextSize: (state) => {
+      return {
+        ...state,
+        translationFontSize: state.translationFontSize * FONT_SCALING_FACTOR,
+      };
+    },
+    increaseQuranTextSize: (state) => {
+      return {
+        ...state,
+        quranTextFontSize: state.quranTextFontSize * FONT_SCALING_FACTOR,
+        quranTextlineHeight: state.quranTextlineHeight * FONT_SCALING_FACTOR,
+      };
+    },
+    decreaseTranslationTextSize: (state) => {
+      return {
+        ...state,
+        translationFontSize: state.translationFontSize / FONT_SCALING_FACTOR,
+      };
+    },
+    decreaseQuranTextSize: (state) => {
+      return {
+        ...state,
+        quranTextFontSize: state.quranTextFontSize / FONT_SCALING_FACTOR,
+        quranTextlineHeight: state.quranTextlineHeight / FONT_SCALING_FACTOR,
+      };
+    },
+  },
+});
+
+export const {
+  increaseTranslationTextSize,
+  increaseQuranTextSize,
+  decreaseQuranTextSize,
+  decreaseTranslationTextSize,
+} = quranReaderStylesSlice.actions;
+
+export const selectQuranReaderStyle = (state) => state.quranReaderStyle;
+
+export default quranReaderStylesSlice.reducer;

--- a/src/redux/slices/QuranReader/styles.ts
+++ b/src/redux/slices/QuranReader/styles.ts
@@ -2,14 +2,24 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const FONT_SCALING_FACTOR = 1.1;
 
+export type QuranReaderStyles = {
+  translationFontSize: number;
+  quranTextFontSize: number;
+  quranTextLineHeight: number;
+  quranTextLetterSpacing: number;
+};
+
+const initialState: QuranReaderStyles = {
+  // the base sizes in rem
+  translationFontSize: 1,
+  quranTextFontSize: 2,
+  quranTextLineHeight: 3,
+  quranTextLetterSpacing: 0.25,
+};
+
 export const quranReaderStylesSlice = createSlice({
   name: 'quranReaderStyles',
-  initialState: {
-    // the base sizes in rem
-    translationFontSize: 2,
-    quranTextFontSize: 3,
-    quranTextlineHeight: 0.25,
-  },
+  initialState,
   reducers: {
     increaseTranslationTextSize: (state) => {
       return {
@@ -21,7 +31,8 @@ export const quranReaderStylesSlice = createSlice({
       return {
         ...state,
         quranTextFontSize: state.quranTextFontSize * FONT_SCALING_FACTOR,
-        quranTextlineHeight: state.quranTextlineHeight * FONT_SCALING_FACTOR,
+        quranTextLineHeight: state.quranTextLineHeight * FONT_SCALING_FACTOR,
+        quranTextLetterSpacing: state.quranTextLetterSpacing * FONT_SCALING_FACTOR,
       };
     },
     decreaseTranslationTextSize: (state) => {
@@ -34,7 +45,8 @@ export const quranReaderStylesSlice = createSlice({
       return {
         ...state,
         quranTextFontSize: state.quranTextFontSize / FONT_SCALING_FACTOR,
-        quranTextlineHeight: state.quranTextlineHeight / FONT_SCALING_FACTOR,
+        quranTextLineHeight: state.quranTextLineHeight / FONT_SCALING_FACTOR,
+        quranTextLetterSpacing: state.quranTextLetterSpacing / FONT_SCALING_FACTOR,
       };
     },
   },
@@ -47,6 +59,6 @@ export const {
   decreaseTranslationTextSize,
 } = quranReaderStylesSlice.actions;
 
-export const selectQuranReaderStyle = (state) => state.quranReaderStyle;
+export const selectQuranReaderStyles = (state) => state.quranReaderStyles;
 
 export default quranReaderStylesSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -10,15 +10,18 @@ import {
 } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import { configureStore, getDefaultMiddleware, combineReducers } from '@reduxjs/toolkit';
+import quranReaderStyles from './slices/QuranReader/styles';
 
 const persistConfig = {
   key: 'root',
   version: 1,
   storage,
-  whitelist: [], // Reducers defined here will be have their values saved in local storage and persist across sessions. See: https://github.com/rt2zz/redux-persist#blacklist--whitelist
+  whitelist: ['quranReaderStyles'], // Reducers defined here will be have their values saved in local storage and persist across sessions. See: https://github.com/rt2zz/redux-persist#blacklist--whitelist
 };
 
-const rootReducer = combineReducers({}); // TODO: Add our reducers here
+const rootReducer = combineReducers({
+  quranReaderStyles,
+});
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 


### PR DESCRIPTION
### Summary
Moved the Quran reader styles to redux and persisted it using redux-persist. We might split the translation text and the Quran text into two separate slices in the future. 


### Test Plan
Tested that the styles are loaded in the redux, that they persist across sessions, and that the styles are passed to the styled-components correctly. 

### Screenshots
The styles are maintained in the store: 
![image](https://user-images.githubusercontent.com/11590314/87163569-d79ea400-c2c7-11ea-95cd-c2fa8aea5a57.png)
