### PR TITLE
Migrate the QuranFont to Redux

### DIFF
--- a/src/components/QuranReader/QuranPageView.tsx
+++ b/src/components/QuranReader/QuranPageView.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import VerseType from '../../../types/VerseType';
 import VerseText from '../Verse/VerseText';
-import { QuranFonts } from './types';
 
 type QuranPageViewProps = {
   verses: VerseType[];
@@ -12,8 +11,7 @@ const QuranPageView = ({ verses }: QuranPageViewProps) => {
   return (
     <StyledQuranPageView>
       {verses.map((verse) => (
-        // TODO (@abdellatif): read the font from the user prefernces
-        <VerseText verse={verse} fontStyle={QuranFonts.Uthmani} key={verse.id} />
+        <VerseText verse={verse} key={verse.id} />
       ))}
     </StyledQuranPageView>
   );

--- a/src/components/QuranReader/TranslationView.tsx
+++ b/src/components/QuranReader/TranslationView.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import VerseType from '../../../types/VerseType';
 import VerseText from '../Verse/VerseText';
 import Text from '../dls/Text/Text';
-import { QuranFonts } from './types';
 
 type TranslationViewProps = {
   verses: VerseType[];
@@ -14,8 +13,7 @@ const TranslationView = ({ verses }: TranslationViewProps) => {
     <StyledTranslationView>
       {verses.map((verse) => (
         <VerseTextContainer key={verse.id}>
-          {/* TODO (@abdellatif): get the fonts from the user preferences */}
-          <VerseText verse={verse} fontStyle={QuranFonts.Uthmani} />
+          <VerseText verse={verse} />
           <StyledText>{verse.translations && verse.translations[0]?.text}</StyledText>
           <hr />
         </VerseTextContainer>

--- a/src/components/QuranReader/types.ts
+++ b/src/components/QuranReader/types.ts
@@ -3,10 +3,10 @@ export enum ReadingView {
   QuranPage = 'quranPage', // Displays the Quran text only similar to a physical Quran page
 }
 
-export enum QuranFonts {
+export enum QuranFont {
   Uthmani = 'uthmani',
   Madani = 'madani',
   IndoPak = 'indopak',
 }
 
-export default { ReadingView, QuranFonts };
+export default { ReadingView, QuranFont };

--- a/src/components/Verse/VerseText.tsx
+++ b/src/components/Verse/VerseText.tsx
@@ -4,14 +4,14 @@ import { useSelector } from 'react-redux';
 import VerseType from '../../../types/VerseType';
 import QuranWord from '../dls/QuranWord/QuranWord';
 import { selectQuranReaderStyles, QuranReaderStyles } from '../../redux/slices/QuranReader/styles';
-import { QuranFonts } from '../QuranReader/types';
+import { QuranFont } from '../QuranReader/types';
 
 type VerseTextProps = {
   verse: VerseType;
-  fontStyle?: QuranFonts;
+  fontStyle?: QuranFont;
 };
 
-const VerseText = ({ verse, fontStyle }: VerseTextProps) => {
+const VerseText = ({ verse }: VerseTextProps) => {
   const quranReaderStyles = useSelector(selectQuranReaderStyles);
 
   return (
@@ -21,7 +21,7 @@ const VerseText = ({ verse, fontStyle }: VerseTextProps) => {
           <QuranWord
             key={[word.position, word.code, word.lineNum].join('-')}
             word={word}
-            fontStyle={fontStyle}
+            fontStyle={quranReaderStyles.quranFont}
           />
         ))}
       </StyledVerseText>

--- a/src/components/dls/QuranWord/QuranWord.stories.tsx
+++ b/src/components/dls/QuranWord/QuranWord.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { QuranFonts } from 'src/components/QuranReader/types';
+import { QuranFont } from 'src/components/QuranReader/types';
 import QuranWord from './QuranWord';
 import { mockWord } from '../../../../tests/mocks/words';
 
@@ -8,10 +8,8 @@ export default {
   title: 'dls|QuranWord',
 };
 
-export const withUthmaniText = () => <QuranWord word={mockWord()} fontStyle={QuranFonts.Uthmani} />;
+export const withUthmaniText = () => <QuranWord word={mockWord()} fontStyle={QuranFont.Uthmani} />;
 
-export const withIndoParkText = () => (
-  <QuranWord word={mockWord()} fontStyle={QuranFonts.IndoPak} />
-);
+export const withIndoParkText = () => <QuranWord word={mockWord()} fontStyle={QuranFont.IndoPak} />;
 
-export const withMadaniText = () => <QuranWord word={mockWord()} fontStyle={QuranFonts.Madani} />;
+export const withMadaniText = () => <QuranWord word={mockWord()} fontStyle={QuranFont.Madani} />;

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import WordType from 'types/WordType';
-import { QuranFonts } from 'src/components/QuranReader/types';
+import { QuranFont } from 'src/components/QuranReader/types';
 import IndoPakWordText from './IndoPakWordText';
 import MadaniWordText from './MadaniWordText';
 import UthmaniWordText from './UthmaniWordText';
 
 type QuranWordProps = {
   word: WordType;
-  fontStyle?: QuranFonts;
+  fontStyle?: QuranFont;
   highlight?: boolean;
 };
 
@@ -15,9 +15,9 @@ const QuranWord = (props: QuranWordProps) => {
   const { word, fontStyle } = props;
   let WordText;
 
-  if (fontStyle === QuranFonts.Uthmani) {
+  if (fontStyle === QuranFont.Uthmani) {
     WordText = <UthmaniWordText code={word.code} pageNumber={word.pageNumber} />;
-  } else if (fontStyle === QuranFonts.IndoPak) {
+  } else if (fontStyle === QuranFont.IndoPak) {
     WordText = <IndoPakWordText text={word.textMadani} />;
   } else {
     WordText = <MadaniWordText text={word.textMadani} />;

--- a/src/redux/slices/QuranReader/styles.ts
+++ b/src/redux/slices/QuranReader/styles.ts
@@ -1,4 +1,5 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { QuranFont } from 'src/components/QuranReader/types';
 
 const FONT_SCALING_FACTOR = 1.1;
 
@@ -7,6 +8,7 @@ export type QuranReaderStyles = {
   quranTextFontSize: number;
   quranTextLineHeight: number;
   quranTextLetterSpacing: number;
+  quranFont: QuranFont;
 };
 
 const initialState: QuranReaderStyles = {
@@ -15,6 +17,7 @@ const initialState: QuranReaderStyles = {
   quranTextFontSize: 2,
   quranTextLineHeight: 3,
   quranTextLetterSpacing: 0.25,
+  quranFont: QuranFont.Uthmani,
 };
 
 export const quranReaderStylesSlice = createSlice({
@@ -47,6 +50,12 @@ export const quranReaderStylesSlice = createSlice({
         quranTextFontSize: state.quranTextFontSize / FONT_SCALING_FACTOR,
         quranTextLineHeight: state.quranTextLineHeight / FONT_SCALING_FACTOR,
         quranTextLetterSpacing: state.quranTextLetterSpacing / FONT_SCALING_FACTOR,
+      };
+    },
+    setQuranFont: (state: QuranReaderStyles, action: PayloadAction<QuranFont>) => {
+      return {
+        ...state,
+        quranFont: action.payload,
       };
     },
   },


### PR DESCRIPTION
### Summary
Migrated the QuranFont property to redux, it now persists across sessions and is read directly from the `VerseText` component.

Renamed the `QuranFonts` enum to `QuranFont` to follow the recommended enum naming conventions. 

### Test Plan
Changed the initial state after clearing localstorage. Confirmed that the fonts load and persist across sessions