### PR TITLE
Add useSWRInfinite for paginating requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "styled-breakpoints": "^8.1.0",
     "styled-components": "^5.0.1",
     "styled-system": "^5.1.5",
-    "swr": "^0.2.0"
+    "swr": "0.3.0-beta.6"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -1,23 +1,39 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import VerseType from '../../../types/VerseType';
+import ChapterType from 'types/ChapterType';
+import { fetcher } from 'src/api';
+import { useSWRInfinite } from 'swr';
+import { makeUrl } from 'src/utils/api';
+import VerseType from 'types/VerseType';
 import QuranPageView from './QuranPageView';
 import TranslationView from './TranslationView';
 import { selectReadingView } from '../../redux/slices/QuranReader/readingView';
 import { ReadingView } from './types';
 
 type QuranReaderProps = {
-  verses: VerseType[];
+  initialData: { verses: VerseType[] };
+  chapter: ChapterType;
 };
 
-const QuranReader = ({ verses }: QuranReaderProps) => {
+const QuranReader = ({ initialData, chapter }: QuranReaderProps) => {
+  const { data } = useSWRInfinite(
+    (index) => {
+      return makeUrl(`/chapters/${chapter.id}/verses`, { translations: 20, page: index }); // TODO: select the translation using the user preference
+    },
+    fetcher,
+    {
+      initialData: initialData.verses,
+      revalidateOnFocus: false,
+    },
+  );
+
   const readingView = useSelector(selectReadingView);
 
   if (readingView === ReadingView.QuranPage) {
-    return <QuranPageView verses={verses} />;
+    return <QuranPageView verses={data} />;
   }
 
-  return <TranslationView verses={verses} />;
+  return <TranslationView verses={data} />;
 };
 
 export default QuranReader;

--- a/src/pages_/[chapterId].tsx
+++ b/src/pages_/[chapterId].tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import useSWR from 'swr';
 import range from 'lodash/range';
 import { Container, Row } from 'styled-bootstrap-grid';
 import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
+import VerseType from 'types/VerseType';
 import ChapterType from '../../types/ChapterType';
-import { getChapters, getChapter, getChapterVerses, fetcher } from '../api';
-import { makeUrl } from '../utils/api';
-import VerseType from '../../types/VerseType';
+import { getChapters, getChapter, getChapterVerses } from '../api';
 import QuranReader from '../components/QuranReader';
 
 type ChapterProps = {
@@ -16,18 +14,11 @@ type ChapterProps = {
 };
 
 const Chapter: NextPage<ChapterProps> = ({ chapterResponse: { chapter }, versesResponse }) => {
-  const { data } = useSWR(
-    makeUrl(`/chapters/${chapter.id}/verses`, { translations: 20 }), // TODO: select the translation using the user preference
-    fetcher,
-    {
-      initialData: versesResponse,
-      revalidateOnFocus: false,
-    },
-  );
-
   return (
     <Container>
-      <Row>{data.verses && <QuranReader verses={data.verses} />}</Row>
+      <Row>
+        <QuranReader initialData={versesResponse} chapter={chapter} />
+      </Row>
     </Container>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12700,9 +12700,10 @@ svgo@^1.0.0, svgo@^1.2.2, svgo@^1.3.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swr@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-0.2.3.tgz#e0fb260d27f12fafa2388312083368f45127480d"
+swr@0.3.0-beta.6:
+  version "0.3.0-beta.6"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.3.0-beta.6.tgz#76c72427e9ede60083ef9af55214b0d5f9040db6"
+  integrity sha512-R36SAD0sCDnKHJ1IxrN6l5EOlUDjmevaicNggCiq878+68T37NCBGuHN2OsGTwa0vbmchPHSSd8w5eFEYs2d7A==
   dependencies:
     fast-deep-equal "2.0.1"
 


### PR DESCRIPTION
### Summary
This is part 1 of 2 PRs to build infinite scrolling. `useSWR`'s pages feature is going to be deprecated and replaced with useSWRInfinite in `0.3.0`: https://github.com/vercel/swr/pull/435

`useSWRInfinite` allows us to paginate requests and get all the benefits of using `swr`. This feature is currently in beta, I've tested it and will move us back to the stable `swr` once it goes into the stable release (hopefully in a couple of weeks). 

I've refactored the data fetching logic from `[chapterId]` to `QuranReader` as this is where we'll be managing fetching more data as users scroll. 

### Test Plan
The initial data is fetched and rendered as expected. I've created a setTimeout to fetch more pages every 3 seconds, the data is fetched correctly. 



