### PR TITLE
Add word and verse highlighting

### DIFF
--- a/src/components/QuranReader/PageView/Line.tsx
+++ b/src/components/QuranReader/PageView/Line.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { selectQuranReaderStyles, QuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import WordType from 'types/WordType';
-import QuranWord from 'src/components/dls/QuranWord/QuranWord';
+import VerseText from 'src/components/Verse/VerseText';
+import groupVersesByLine from './groupVersesByLine';
 
 type LineProps = {
   words: Array<WordType>;
@@ -11,16 +12,13 @@ type LineProps = {
 
 const Line = ({ words }: LineProps) => {
   const quranReaderStyles = useSelector(selectQuranReaderStyles);
+  const versesOnLine = useMemo(() => groupVersesByLine(words), [words]);
 
   return (
     <StyledLineContainer styles={quranReaderStyles}>
       <StyledLine styles={quranReaderStyles}>
-        {words.map((word) => (
-          <QuranWord
-            key={[word.position, word.code, word.lineNum].join('-')}
-            word={word}
-            fontStyle={quranReaderStyles.quranFont}
-          />
+        {Object.keys(versesOnLine).map((key) => (
+          <VerseText words={versesOnLine[key]} key={key} />
         ))}
       </StyledLine>
     </StyledLineContainer>

--- a/src/components/QuranReader/PageView/groupVersesByLine.ts
+++ b/src/components/QuranReader/PageView/groupVersesByLine.ts
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+import WordType from 'types/WordType';
+
+/**
+ * Splits the words on the line by verse.
+ * output:
+ * {
+ *  06:01 (versekey): [words],
+ *  06:02 (versekey): [words]
+ *  ...
+ * }
+ */
+const groupVersesByLine = (line: WordType[]) => {
+  const verses = _.groupBy(line, (word) => {
+    return word.verseKey;
+  });
+
+  return verses;
+};
+
+export default groupVersesByLine;

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -13,7 +13,7 @@ const TranslationView = ({ verses }: TranslationViewProps) => {
     <StyledTranslationView>
       {verses.map((verse) => (
         <VerseTextContainer highlight={false} key={verse.id}>
-          <VerseText verse={verse} />
+          <VerseText words={verse.words} />
           <StyledText>{verse.translations && verse.translations[0]?.text}</StyledText>
           <hr />
         </VerseTextContainer>

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -12,7 +12,7 @@ const TranslationView = ({ verses }: TranslationViewProps) => {
   return (
     <StyledTranslationView>
       {verses.map((verse) => (
-        <VerseTextContainer key={verse.id}>
+        <VerseTextContainer highlight={false} key={verse.id}>
           <VerseText verse={verse} />
           <StyledText>{verse.translations && verse.translations[0]?.text}</StyledText>
           <hr />
@@ -22,7 +22,9 @@ const TranslationView = ({ verses }: TranslationViewProps) => {
   );
 };
 
-const VerseTextContainer = styled.div``;
+const VerseTextContainer = styled.div<{ highlight: boolean }>`
+  background: ${({ highlight, theme }) => highlight && theme.colors.gray};
+`;
 
 const StyledTranslationView = styled.div`
   max-width: 100%;

--- a/src/components/Verse/VerseText.tsx
+++ b/src/components/Verse/VerseText.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
-import VerseType from '../../../types/VerseType';
+import WordType from 'types/WordType';
 import QuranWord from '../dls/QuranWord/QuranWord';
 import { selectQuranReaderStyles, QuranReaderStyles } from '../../redux/slices/QuranReader/styles';
 
 type VerseTextProps = {
-  verse: VerseType;
+  words: WordType[];
 };
 
-const VerseText = ({ verse }: VerseTextProps) => {
+const VerseText = ({ words }: VerseTextProps) => {
   const quranReaderStyles = useSelector(selectQuranReaderStyles);
 
   return (
     <StyledVerseTextContainer styles={quranReaderStyles}>
       <StyledVerseText styles={quranReaderStyles}>
-        {verse.words?.map((word) => (
+        {words?.map((word) => (
           <QuranWord
             key={[word.position, word.code, word.lineNum].join('-')}
             word={word}
@@ -39,4 +39,4 @@ const StyledVerseTextContainer = styled.div<{ styles: QuranReaderStyles }>`
   letter-spacing: ${(props) => props.styles.quranTextLetterSpacing}rem;
 `;
 
-export default VerseText;
+export default React.memo(VerseText);

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import WordType from 'types/WordType';
 import { QuranFont } from 'src/components/QuranReader/types';
+import styled from 'styled-components';
 import IndoPakWordText from './IndoPakWordText';
 import MadaniWordText from './MadaniWordText';
 import UthmaniWordText from './UthmaniWordText';
@@ -9,9 +10,10 @@ type QuranWordProps = {
   word: WordType;
   fontStyle?: QuranFont;
   highlight?: boolean;
+  highlightBackground?: boolean;
 };
 
-const QuranWord = ({ word, fontStyle }: QuranWordProps) => {
+const QuranWord = ({ word, fontStyle, highlight, highlightBackground }: QuranWordProps) => {
   let WordText;
 
   if (fontStyle === QuranFont.Uthmani) {
@@ -22,7 +24,21 @@ const QuranWord = ({ word, fontStyle }: QuranWordProps) => {
     WordText = <MadaniWordText text={word.textMadani} />;
   }
 
-  return WordText;
+  return (
+    <StyledWordContainer highlight={highlight} highlightBackground={highlightBackground}>
+      {WordText}
+    </StyledWordContainer>
+  );
 };
+
+type StyledWordContainerProps = {
+  highlight: boolean;
+  highlightBackground?: boolean;
+};
+
+const StyledWordContainer = styled.span<StyledWordContainerProps>`
+  color: ${(props) => props.highlight && props.theme.colors.primary};
+  background: ${(props) => props.highlightBackground && props.theme.colors.gray};
+`;
 
 export default QuranWord;

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -10,10 +10,9 @@ type QuranWordProps = {
   word: WordType;
   fontStyle?: QuranFont;
   highlight?: boolean;
-  highlightBackground?: boolean;
 };
 
-const QuranWord = ({ word, fontStyle, highlight, highlightBackground }: QuranWordProps) => {
+const QuranWord = ({ word, fontStyle, highlight }: QuranWordProps) => {
   let WordText;
 
   if (fontStyle === QuranFont.Uthmani) {
@@ -24,21 +23,15 @@ const QuranWord = ({ word, fontStyle, highlight, highlightBackground }: QuranWor
     WordText = <MadaniWordText text={word.textMadani} />;
   }
 
-  return (
-    <StyledWordContainer highlight={highlight} highlightBackground={highlightBackground}>
-      {WordText}
-    </StyledWordContainer>
-  );
+  return <StyledWordContainer highlight={highlight}>{WordText}</StyledWordContainer>;
 };
 
 type StyledWordContainerProps = {
-  highlight: boolean;
-  highlightBackground?: boolean;
+  highlight?: boolean;
 };
 
 const StyledWordContainer = styled.span<StyledWordContainerProps>`
   color: ${(props) => props.highlight && props.theme.colors.primary};
-  background: ${(props) => props.highlightBackground && props.theme.colors.gray};
 `;
 
 export default QuranWord;


### PR DESCRIPTION
### Summary
Added a `highlight` prop to the word component to the `QuranWord` component and the `VerseTextContainer` component. This prop will be used to highlight a word/verse during audio playback, tooltip, etc.

Styles are placeholders.

### Screenshots

| Normal Word | Highlighted Word |
| ------ | ------ |
|![image](https://user-images.githubusercontent.com/11590314/94989115-3e9bc400-056a-11eb-8a9a-540fcd893ae8.png) | ![image](https://user-images.githubusercontent.com/11590314/94989130-507d6700-056a-11eb-860a-fdfe631beda2.png)|

| Normal Translation | Highlighted Translation |
| ------ | ------ |
|![image](https://user-images.githubusercontent.com/11590314/94989103-2a57c700-056a-11eb-8f89-fcc67e0c0720.png)| ![image](https://user-images.githubusercontent.com/11590314/94989099-1dd36e80-056a-11eb-86a4-15550de6adf3.png)|