### PR TITLE
Fixes for eslint property re-assign error, and other warnings

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -37,8 +37,10 @@ overrides:
     rules:
       "@typescript-eslint/no-unused-vars": 2
       "@typescript-eslint/explicit-module-boundary-types": off # allow typescript to automatically determine the return type
-      "no-param-reassign": off # TODO: disable it only for the redux directory, it's used to reassign the state
-
+      "no-param-reassign": [
+          "error",
+          { "props": true, "ignorePropertyModificationsFor": ["draft"] }, # allow object property reassign only for redux toolkit draft object
+        ]
       # these are checked by the TS compiler
       react/forbid-prop-types: 0
       react/jsx-no-undef: 0

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,7 +3,7 @@ import { makeUrl } from './utils/api';
 import ChapterType from '../types/ChapterType';
 import VerseType from '../types/VerseType';
 
-export const fetcher = async function (input: RequestInfo, init?: RequestInit) {
+export const fetcher = async function fetcher(input: RequestInfo, init?: RequestInit) {
   const res = await fetch(input, init);
   return res.json();
 };

--- a/src/pages_/_document.tsx
+++ b/src/pages_/_document.tsx
@@ -38,6 +38,7 @@ export default class MyDocument extends Document {
           {/* Step 5: Output the styles in the head  */}
           {styleTags}
           <style
+            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: `
           ${makeGlobalCss()}

--- a/src/redux/slices/QuranReader/readingView.ts
+++ b/src/redux/slices/QuranReader/readingView.ts
@@ -7,9 +7,7 @@ export const readingViewSlice = createSlice({
   name: 'readingView',
   initialState,
   reducers: {
-    setReadingView: (state: ReadingView, action: PayloadAction<ReadingView>) => {
-      state = action.payload;
-    },
+    setReadingView: (draft, action: PayloadAction) => action.payload,
   },
 });
 

--- a/types/ChapterType.ts
+++ b/types/ChapterType.ts
@@ -9,7 +9,7 @@ interface ChapterType {
   nameSimple: string;
   nameArabic: string;
   chapterNumber: number;
-  translatedName: string;
+  translatedName: Record<'name' | 'languageName', string>;
   languageName: string;
 }
 

--- a/types/ChapterType.ts
+++ b/types/ChapterType.ts
@@ -9,8 +9,8 @@ interface ChapterType {
   nameSimple: string;
   nameArabic: string;
   chapterNumber: number;
-  translatedName: any;
-  languageName: any;
+  translatedName: string;
+  languageName: string;
 }
 
 export default ChapterType;


### PR DESCRIPTION
### Summary
- Redux toolkit uses [immer](https://github.com/immerjs/immer/) to allow mutating the state inside the reducers, that conflicts with the `no-param-reassign` eslint rule, instead of turning it off, I added an ignore rule for the `draft` object that is usually passed to the reducer to mutate its property, which later becomes the new state.
- Fixed a few other minor warnings.

### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
| [image here] | [image here] |