### PR TITLE
Update API url to api.quran.com

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'qs';
 
-export const apiUrl = 'https://quran.com/api/api/v3';
+export const apiUrl = 'https://api.quran.com/api/v3';
 
 /**
  * Generates a url to make an api call to our backend


### PR DESCRIPTION
### Summary
The previous URL got broken after the beta migration. We now use the dedicated API subdomain.