### PR TITLE
Fix no-document-viewport-meta and missing-document-component warnings

### DIFF
--- a/src/pages_/_app.tsx
+++ b/src/pages_/_app.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Head from 'next/head';
 import { DefaultSeo } from 'next-seo';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '../utils/styles';
@@ -8,13 +9,18 @@ import ReduxProvider from '../redux/Provider';
 
 function MyApp({ Component, pageProps }): JSX.Element {
   return (
-    <ReduxProvider>
-      <ThemeProvider theme={theme}>
-        <DefaultSeo {...createSEOConfig({})} />
-        <Component {...pageProps} />
-        <Footer />
-      </ThemeProvider>
-    </ReduxProvider>
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      </Head>
+      <ReduxProvider>
+        <ThemeProvider theme={theme}>
+          <DefaultSeo {...createSEOConfig({})} />
+          <Component {...pageProps} />
+          <Footer />
+        </ThemeProvider>
+      </ReduxProvider>
+    </>
   );
 }
 

--- a/src/pages_/_document.tsx
+++ b/src/pages_/_document.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Head, Main, NextScript, Html } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 import { BaseCSS } from 'styled-bootstrap-grid';
 import { makeGlobalCss } from '../styles/GlobalStyles';
@@ -32,9 +32,8 @@ export default class MyDocument extends Document {
     const { styleTags } = this.props;
 
     return (
-      <html lang="en">
+      <Html lang="en">
         <Head>
-          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
           {/* Step 5: Output the styles in the head  */}
           {styleTags}
           <style
@@ -51,7 +50,7 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
### Summary
Next.js was showing two warnings regarding [no-document-viewport-meta](https://err.sh/next.js/no-document-viewport-meta ) and [missing-document-component](https://github.com/vercel/next.js/blob/master/errors/missing-document-component.md) when starting the dev server.

### Screenshots

| Before | After |
| ------ | ------ |
| <img width="607" alt="Screen Shot 2020-11-01 at 19 17 46" src="https://user-images.githubusercontent.com/15169499/97803721-c2d28b80-1c7d-11eb-8fc7-3039355c6f5b.png"><img width="804" alt="Screen Shot 2020-11-01 at 19 21 47" src="https://user-images.githubusercontent.com/15169499/97803735-d7af1f00-1c7d-11eb-8f0f-99493527dcb6.png">|<img width="788" alt="Screen Shot 2020-11-01 at 20 08 11" src="https://user-images.githubusercontent.com/15169499/97803765-ff9e8280-1c7d-11eb-9315-4d8d3d289fb6.png">|