### PR TITLE
Fix viewport meta tag warning

### DIFF
--- a/src/pages_/_app.tsx
+++ b/src/pages_/_app.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Head from 'next/head';
 import { DefaultSeo } from 'next-seo';
 import { ThemeProvider } from 'styled-components';
 import { theme } from '../utils/styles';
@@ -8,13 +9,18 @@ import ReduxProvider from '../redux/Provider';
 
 function MyApp({ Component, pageProps }): JSX.Element {
   return (
-    <ReduxProvider>
-      <ThemeProvider theme={theme}>
-        <DefaultSeo {...createSEOConfig({})} />
-        <Component {...pageProps} />
-        <Footer />
-      </ThemeProvider>
-    </ReduxProvider>
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      </Head>
+      <ReduxProvider>
+        <ThemeProvider theme={theme}>
+          <DefaultSeo {...createSEOConfig({})} />
+          <Component {...pageProps} />
+          <Footer />
+        </ThemeProvider>
+      </ReduxProvider>
+    </>
   );
 }
 

--- a/src/pages_/_document.tsx
+++ b/src/pages_/_document.tsx
@@ -34,7 +34,6 @@ export default class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
           {/* Step 5: Output the styles in the head  */}
           {styleTags}
           <style


### PR DESCRIPTION
### Summary
See https://github.com/vercel/next.js/blob/master/errors/no-document-viewport-meta.md

### Test Plan
Confirmed that the viewport meta tags are still produced in the document