### PR TITLE
Enabled Incremental Static generation for chapter pages

### DIFF
--- a/src/components/Verse/VerseText.tsx
+++ b/src/components/Verse/VerseText.tsx
@@ -31,9 +31,9 @@ const VerseText = ({ words }: VerseTextProps) => {
         isQuranPage={isQuranPage}
         centerAlignPage={centerAlignPage}
       >
-        {words?.map((word) => (
-          <QuranWord key={word.location} word={word} font={quranReaderStyles.quranFont} />
-        ))}
+        {words?.map((word) => {
+          return <QuranWord key={word.id} word={word} font={quranReaderStyles.quranFont} />;
+        })}
       </StyledVerseText>
     </StyledVerseTextContainer>
   );

--- a/src/pages_/index.tsx
+++ b/src/pages_/index.tsx
@@ -11,6 +11,7 @@ type IndexProps = {
 };
 
 const Index: NextPage<IndexProps> = ({ chaptersResponse: { chapters } }) => {
+  if (!chapters) return null;
   return (
     <div style={{ paddingTop: '4rem' }}>
       <ChaptersList chapters={chapters.slice(0, 38)} />


### PR DESCRIPTION
### Summary
With this PR, the server will render chapter pages for the first requests on the fly, then generate and cache them for subsequent requests, it will also check for page changes every 10 secs and update the generated pages.

### Test Plan
yarn build
yarn start
visit any chapter page e.g. http://localhost:3000/10
you will notice the first load took more time and was generated client-side.
Reload the page and it will load instantly and fully sent from the server.

### Screenshots

| Before | After |
| ------ | ------ |
| [image here] | [image here] |