### PR TITLE
Don't use initialData when the default translations change

### DIFF
--- a/src/components/DeveloperUtility/TranslationsAdjustment.tsx
+++ b/src/components/DeveloperUtility/TranslationsAdjustment.tsx
@@ -1,14 +1,11 @@
 import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { getAvailableTranslations } from 'src/api';
 import AvailableTranslation from 'types/AvailableTranslation';
 import useTranslation from 'next-translate/useTranslation';
-import {
-  selectTranslations,
-  setSelectedTranslations,
-  TranslationsSettings,
-} from 'src/redux/slices/QuranReader/translations';
+import { setSelectedTranslations } from 'src/redux/slices/QuranReader/translations';
+import { useSelectorTyped } from 'src/redux/store';
 
 /**
  * Convert an array of numbers to an array of strings.
@@ -21,7 +18,7 @@ const numbersToStringsArray = (numbersArray: number[]): string[] =>
 
 const TranslationsAdjustment = () => {
   const dispatch = useDispatch();
-  const { selectedTranslations } = useSelector(selectTranslations) as TranslationsSettings;
+  const { selectedTranslations } = useSelectorTyped((state) => state.translations);
   const { lang } = useTranslation();
   const [translations, setTranslations] = useState<AvailableTranslation[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/components/DeveloperUtility/TranslationsAdjustment.tsx
+++ b/src/components/DeveloperUtility/TranslationsAdjustment.tsx
@@ -7,6 +7,7 @@ import useTranslation from 'next-translate/useTranslation';
 import {
   selectTranslations,
   setSelectedTranslations,
+  TranslationsSettings,
 } from 'src/redux/slices/QuranReader/translations';
 
 /**
@@ -20,7 +21,7 @@ const numbersToStringsArray = (numbersArray: number[]): string[] =>
 
 const TranslationsAdjustment = () => {
   const dispatch = useDispatch();
-  const selectedTranslations = useSelector(selectTranslations) as number[];
+  const { selectedTranslations } = useSelector(selectTranslations) as TranslationsSettings;
   const { lang } = useTranslation();
   const [translations, setTranslations] = useState<AvailableTranslation[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/components/DeveloperUtility/TranslationsAdjustment.tsx
+++ b/src/components/DeveloperUtility/TranslationsAdjustment.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { getAvailableTranslations } from 'src/api';
 import AvailableTranslation from 'types/AvailableTranslation';
 import useTranslation from 'next-translate/useTranslation';
-import { setSelectedTranslations } from 'src/redux/slices/QuranReader/translations';
-import { useSelectorTyped } from 'src/redux/store';
+import {
+  selectTranslations,
+  setSelectedTranslations,
+  TranslationsSettings,
+} from 'src/redux/slices/QuranReader/translations';
 
 /**
  * Convert an array of numbers to an array of strings.
@@ -18,7 +21,7 @@ const numbersToStringsArray = (numbersArray: number[]): string[] =>
 
 const TranslationsAdjustment = () => {
   const dispatch = useDispatch();
-  const { selectedTranslations } = useSelectorTyped((state) => state.translations);
+  const { selectedTranslations } = useSelector(selectTranslations) as TranslationsSettings;
   const { lang } = useTranslation();
   const [translations, setTranslations] = useState<AvailableTranslation[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -8,7 +8,10 @@ import Chapter from 'types/Chapter';
 import styled from 'styled-components';
 import { selectNotes } from 'src/redux/slices/QuranReader/notes';
 import { NOTES_SIDE_BAR_DESKTOP_WIDTH } from 'src/styles/constants';
-import { useSelectorTyped } from 'src/redux/store';
+import {
+  selectTranslations,
+  TranslationsSettings,
+} from 'src/redux/slices/QuranReader/translations';
 import { selectReadingView } from '../../redux/slices/QuranReader/readingView';
 import PageView from './PageView';
 
@@ -41,9 +44,9 @@ const QuranReader = ({ initialData, chapter }: QuranReaderProps) => {
   const isVerseView = initialData.verses.length === 1;
   const isSideBarVisible = useSelector(selectNotes).isVisible;
   const quranReaderStyles = useSelector(selectQuranReaderStyles);
-  const { selectedTranslations, isUsingDefaultTranslations } = useSelectorTyped(
-    (state) => state.translations,
-  );
+  const { selectedTranslations, isUsingDefaultTranslations } = useSelector(
+    selectTranslations,
+  ) as TranslationsSettings;
   const { data, size, setSize, isValidating } = useSWRInfinite(
     (index) => {
       // if the response has only 1 verse it means we should set the page to that verse this will be combined with perPage which will be set to only 1.

--- a/src/redux/slices/QuranReader/translations.ts
+++ b/src/redux/slices/QuranReader/translations.ts
@@ -1,14 +1,55 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-const DEFAULT_TRANSLATIONS = [20, 131];
+export const DEFAULT_TRANSLATIONS = [20, 131];
 
-const initialState: number[] = DEFAULT_TRANSLATIONS;
+export type TranslationsSettings = {
+  selectedTranslations: number[];
+  isUsingDefaultTranslations: boolean;
+};
+
+/**
+ * This is to detect whether the user has changed the default translations or not on each translation change.
+ * The user will have changed the default translations in 2 cases:
+ *  1. the length of the array of IDs of the translations the user has selected differs from the length of the array of default IDs.
+ *  2. the length of both arrays are the same but one ID exists in one but not in the other.
+ *
+ * [NOTE]: We could have used the easier JSON.stringify(DEFAULT_TRANSLATIONS) === JSON.stringify(newTranslations)
+ *         comparison but there is a corner case when the user changes the default translations then
+ *         re-selects them which results in the same array as the default one but reversed
+ *         e.g. instead of [20, 131] it becomes [131, 20] and the JSON comparison will fail
+ *         although the BE API's response will have the translations in the same order in both cases
+ *         which is by ID ascendingly (e.g. 20 then 131 even if we set the translations' param as "131, 20").
+ * @param {number[]} newTranslations
+ * @returns {boolean}
+ */
+const isUsingDefaultTranslations = (newTranslations: number[]): boolean => {
+  // if the lengths are different, it means the user has changed the default translations.
+  if (newTranslations.length !== DEFAULT_TRANSLATIONS.length) {
+    return false;
+  }
+  for (let i = 0; i < newTranslations.length; i += 1) {
+    // if the current translation ID is not inside the default IDs' array, it means the user has changed the default translations.
+    if (DEFAULT_TRANSLATIONS.indexOf(newTranslations[i]) === -1) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const initialState: TranslationsSettings = {
+  selectedTranslations: DEFAULT_TRANSLATIONS,
+  isUsingDefaultTranslations: true,
+};
 
 export const translationsSlice = createSlice({
   name: 'translations',
   initialState,
   reducers: {
-    setSelectedTranslations: (state, action: PayloadAction<number[]>) => action.payload,
+    setSelectedTranslations: (state, action: PayloadAction<number[]>) => ({
+      ...state,
+      isUsingDefaultTranslations: isUsingDefaultTranslations(action.payload), // check if the user is using the default translations on each translation change.
+      selectedTranslations: action.payload,
+    }),
   },
 });
 

--- a/src/redux/slices/QuranReader/translations.ts
+++ b/src/redux/slices/QuranReader/translations.ts
@@ -1,39 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import _ from 'lodash';
 
 export const DEFAULT_TRANSLATIONS = [20, 131];
 
 export type TranslationsSettings = {
   selectedTranslations: number[];
   isUsingDefaultTranslations: boolean;
-};
-
-/**
- * This is to detect whether the user has changed the default translations or not on each translation change.
- * The user will have changed the default translations in 2 cases:
- *  1. the length of the array of IDs of the translations the user has selected differs from the length of the array of default IDs.
- *  2. the length of both arrays are the same but one ID exists in one but not in the other.
- *
- * [NOTE]: We could have used the easier JSON.stringify(DEFAULT_TRANSLATIONS) === JSON.stringify(newTranslations)
- *         comparison but there is a corner case when the user changes the default translations then
- *         re-selects them which results in the same array as the default one but reversed
- *         e.g. instead of [20, 131] it becomes [131, 20] and the JSON comparison will fail
- *         although the BE API's response will have the translations in the same order in both cases
- *         which is by ID ascendingly (e.g. 20 then 131 even if we set the translations' param as "131, 20").
- * @param {number[]} newTranslations
- * @returns {boolean}
- */
-const isUsingDefaultTranslations = (newTranslations: number[]): boolean => {
-  // if the lengths are different, it means the user has changed the default translations.
-  if (newTranslations.length !== DEFAULT_TRANSLATIONS.length) {
-    return false;
-  }
-  for (let i = 0; i < newTranslations.length; i += 1) {
-    // if the current translation ID is not inside the default IDs' array, it means the user has changed the default translations.
-    if (DEFAULT_TRANSLATIONS.indexOf(newTranslations[i]) === -1) {
-      return false;
-    }
-  }
-  return true;
 };
 
 const initialState: TranslationsSettings = {
@@ -47,14 +19,13 @@ export const translationsSlice = createSlice({
   reducers: {
     setSelectedTranslations: (state, action: PayloadAction<number[]>) => ({
       ...state,
-      isUsingDefaultTranslations: isUsingDefaultTranslations(action.payload), // check if the user is using the default translations on each translation change.
+      // we need to before we compare because there is a corner case when the user changes the default translations then re-selects them which results in the same array as the default one but reversed e.g. instead of [20, 131] it becomes [131, 20].
+      isUsingDefaultTranslations: _.isEqual(DEFAULT_TRANSLATIONS.sort(), action.payload.sort()), // check if the user is using the default translations on each translation change.
       selectedTranslations: action.payload,
     }),
   },
 });
 
 export const { setSelectedTranslations } = translationsSlice.actions;
-
-export const selectTranslations = (state) => state.translations;
 
 export default translationsSlice.reducer;

--- a/src/redux/slices/QuranReader/translations.ts
+++ b/src/redux/slices/QuranReader/translations.ts
@@ -28,4 +28,6 @@ export const translationsSlice = createSlice({
 
 export const { setSelectedTranslations } = translationsSlice.actions;
 
+export const selectTranslations = (state) => state.translations;
+
 export default translationsSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -8,7 +8,6 @@ import {
   PURGE,
   REGISTER,
 } from 'redux-persist';
-import { useSelector } from 'react-redux';
 import storage from 'redux-persist/lib/storage';
 import { configureStore, getDefaultMiddleware, combineReducers } from '@reduxjs/toolkit';
 import quranReaderStyles from './slices/QuranReader/styles';
@@ -52,10 +51,5 @@ const store = configureStore({
 });
 
 export const persistor = persistStore(store);
-
-// infer the `RootState` type from the store itself.
-type RootState = ReturnType<typeof rootReducer>;
-
-export const useSelectorTyped = <T>(fn: (state: RootState) => T): T => useSelector(fn);
 
 export default store;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -8,6 +8,7 @@ import {
   PURGE,
   REGISTER,
 } from 'redux-persist';
+import { useSelector } from 'react-redux';
 import storage from 'redux-persist/lib/storage';
 import { configureStore, getDefaultMiddleware, combineReducers } from '@reduxjs/toolkit';
 import quranReaderStyles from './slices/QuranReader/styles';
@@ -51,5 +52,10 @@ const store = configureStore({
 });
 
 export const persistor = persistStore(store);
+
+// infer the `RootState` type from the store itself.
+type RootState = ReturnType<typeof rootReducer>;
+
+export const useSelectorTyped = <T>(fn: (state: RootState) => T): T => useSelector(fn);
 
 export default store;

--- a/src/utils/apiPaths.ts
+++ b/src/utils/apiPaths.ts
@@ -1,9 +1,10 @@
 import { decamelizeKeys } from 'humps';
+import { DEFAULT_TRANSLATIONS } from 'src/redux/slices/QuranReader/translations';
 import { ITEMS_PER_PAGE, makeUrl } from './api';
 
 export const DEFAULT_VERSES_PARAMS = {
   words: true,
-  translations: 20,
+  translations: DEFAULT_TRANSLATIONS.join(', '),
   limit: ITEMS_PER_PAGE,
 };
 


### PR DESCRIPTION
### Summary

This PR improves UX by showing a loading indicator instead of falling back to `initialData` which contains the default translations (The Clear Quran and Sahih International) of the `QuranReader` while the user is waiting for the new translations he had selected to show.

### Test Plan

1. Make sure you remove `persist:root` from the local storage first if it has been set.
2. Go to a chapter's page e.g. `{url}/5`.
3. Change the reading view to `translation` from the Developer Utility.
4. Usually the API is pretty quick, so to slow it down, open Google Chrome's Dev Tools, go to `Network` tab then change from `No throttling` to `Slow 3G` for example.
5. Open the Developer Utility again and change the pre-selected translations, maybe select an additional one.
6. A loading indicator should show until the response is received and the QuranReader shouldn't show.
7. Refresh the page, the loading indicator should also show and the QuranReader shouldn't show.

### Screenshots

| Before | After |
| ------ | ------ |
| Old loading Indicator <img width="1440" alt="Old loading" src="https://user-images.githubusercontent.com/15169499/126300824-b1090bad-7c83-4c2e-8a76-280fa82d4c93.png"> | New loading Indicator <img width="1439" alt="New loading" src="https://user-images.githubusercontent.com/15169499/126300811-c762ea19-ee90-47ba-8cc5-93f4310f503b.png"> |