### PR TITLE
Fix Quran reader not wrapping on long verses

### DIFF
--- a/src/components/Verse/VerseText.tsx
+++ b/src/components/Verse/VerseText.tsx
@@ -61,6 +61,7 @@ const StyledVerseText = styled.div<{
   centerAlignPage: boolean;
   isQuranPage: boolean;
 }>`
+  flex-wrap: wrap;
   display: flex;
   ${({ isQuranPage, centerAlignPage }) =>
     isQuranPage &&


### PR DESCRIPTION
### Summary

When there is a long verse e.g. verse 75 of chapter 3, the Quran Reader doesn't wrap the Quranic text so it goes out of the viewport. This PR fixes this by wrapping the text on a new line when it exceeds the width of its container.

### Test Plan

1. Go to `{url}/3/75`.
2. The Quranic text should be wrapped across 2 lines.

### Screenshots

| Before | After |
| ------ | ------ |
| ![Before](https://user-images.githubusercontent.com/15169499/126479350-ad15fa11-251e-41df-b69c-340ac09f34dd.png) |![After](https://user-images.githubusercontent.com/15169499/126479330-951d60a6-3f6f-4fec-90e1-ece7ec87dff3.png)|