### PR TITLE
Add share verse action

### DIFF
--- a/src/components/Verse/VerseActionsMenu.tsx
+++ b/src/components/Verse/VerseActionsMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, SetStateAction, Dispatch } from 'react';
 import clipboardCopy from 'clipboard-copy';
 import { useRouter } from 'next/router';
-import { getOrigin } from 'src/utils/url';
+import { getWindowOrigin } from 'src/utils/url';
 import Verse from '../../../types/Verse';
 import VerseActionsMenuItem from './VerseActionsMenuItem';
 import CopyIcon from '../../../public/icons/copy.svg';
@@ -65,7 +65,7 @@ const VerseActionsMenu: React.FC<Props> = ({ verse, setActiveVerseActionModal })
   };
 
   const onShareClicked = () => {
-    const origin = getOrigin();
+    const origin = getWindowOrigin();
     if (origin) {
       clipboardCopy(`${origin}/${chapterId}/${verse.verseNumber}`).then(() => {
         setIsShared(true);

--- a/src/components/Verse/VerseActionsMenu.tsx
+++ b/src/components/Verse/VerseActionsMenu.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, SetStateAction, Dispatch } from 'react';
 import clipboardCopy from 'clipboard-copy';
 import { useRouter } from 'next/router';
+import { getCurrentPath } from 'src/utils/url';
 import Verse from '../../../types/Verse';
 import VerseActionsMenuItem from './VerseActionsMenuItem';
 import CopyIcon from '../../../public/icons/copy.svg';
 import TafsirIcon from '../../../public/icons/tafsir.svg';
+import ShareIcon from '../../../public/icons/share.svg';
 import AdvancedCopyIcon from '../../../public/icons/advanced_copy.svg';
 import { VerseActionModalType } from './VerseActionModal';
 import styles from './VerseActionsMenu.module.scss';
@@ -14,8 +16,11 @@ interface Props {
   setActiveVerseActionModal: Dispatch<SetStateAction<VerseActionModalType>>;
 }
 
+const RESET_COPY_TEXT_TIMEOUT_MS = 3 * 1000;
+
 const VerseActionsMenu: React.FC<Props> = ({ verse, setActiveVerseActionModal }) => {
   const [isCopied, setIsCopied] = useState(false);
+  const [isShared, setIsShared] = useState(false);
   const router = useRouter();
   const {
     query: { chapterId },
@@ -24,12 +29,23 @@ const VerseActionsMenu: React.FC<Props> = ({ verse, setActiveVerseActionModal })
     let timeoutId: ReturnType<typeof setTimeout>;
     // if the user has just copied the text, we should change the text back to Copy after 3 seconds.
     if (isCopied === true) {
-      timeoutId = setTimeout(() => setIsCopied(false), 3 * 1000);
+      timeoutId = setTimeout(() => setIsCopied(false), RESET_COPY_TEXT_TIMEOUT_MS);
     }
     return () => {
       clearTimeout(timeoutId);
     };
   }, [isCopied]);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    // if the user has just copied the link, we should change the text back after 3 seconds.
+    if (isShared === true) {
+      timeoutId = setTimeout(() => setIsShared(false), RESET_COPY_TEXT_TIMEOUT_MS);
+    }
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [isShared]);
 
   const onCopyClicked = () => {
     clipboardCopy(verse.textUthmani).then(() => {
@@ -48,6 +64,15 @@ const VerseActionsMenu: React.FC<Props> = ({ verse, setActiveVerseActionModal })
     });
   };
 
+  const onShareClicked = () => {
+    const path = getCurrentPath();
+    if (path) {
+      clipboardCopy(path).then(() => {
+        setIsShared(true);
+      });
+    }
+  };
+
   return (
     <>
       <div className={styles.container}>
@@ -62,6 +87,11 @@ const VerseActionsMenu: React.FC<Props> = ({ verse, setActiveVerseActionModal })
           onClick={onAdvancedCopyClicked}
         />
         <VerseActionsMenuItem title="Tafsirs" icon={<TafsirIcon />} onClick={onTafsirsClicked} />
+        <VerseActionsMenuItem
+          title={isShared ? 'Link has been copied to the clipboard!' : 'Share'}
+          icon={<ShareIcon />}
+          onClick={onShareClicked}
+        />
       </div>
     </>
   );

--- a/src/components/Verse/VerseActionsMenu.tsx
+++ b/src/components/Verse/VerseActionsMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, SetStateAction, Dispatch } from 'react';
 import clipboardCopy from 'clipboard-copy';
 import { useRouter } from 'next/router';
-import { getCurrentPath } from 'src/utils/url';
+import { getOrigin } from 'src/utils/url';
 import Verse from '../../../types/Verse';
 import VerseActionsMenuItem from './VerseActionsMenuItem';
 import CopyIcon from '../../../public/icons/copy.svg';
@@ -65,9 +65,9 @@ const VerseActionsMenu: React.FC<Props> = ({ verse, setActiveVerseActionModal })
   };
 
   const onShareClicked = () => {
-    const path = getCurrentPath();
-    if (path) {
-      clipboardCopy(path).then(() => {
+    const origin = getOrigin();
+    if (origin) {
+      clipboardCopy(`${origin}/${chapterId}/${verse.verseNumber}`).then(() => {
         setIsShared(true);
       });
     }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/prefer-default-export */
+export const getCurrentPath = () => {
+  if (typeof window !== 'undefined') {
+    return window.location.href;
+  }
+  return '';
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,13 @@
-/* eslint-disable import/prefer-default-export */
 export const getCurrentPath = () => {
   if (typeof window !== 'undefined') {
     return window.location.href;
+  }
+  return '';
+};
+
+export const getOrigin = () => {
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
   }
   return '';
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -5,7 +5,7 @@ export const getCurrentPath = () => {
   return '';
 };
 
-export const getOrigin = () => {
+export const getWindowOrigin = () => {
   if (typeof window !== 'undefined') {
     return window.location.origin;
   }


### PR DESCRIPTION
### Summary
This PR adds the ability to share the verse's url.

### Test Plan
1. Click on the verse's actions menu.
2. Click on share. The current url should be copied to the clipboard and a message indicating that should appear.
3. The message should return to default after 3 seconds.

### Screenshots

| Before | After |
| ------ | ------ |
| <img width="182" alt="Screen Shot 2021-08-12 at 03 43 34" src="https://user-images.githubusercontent.com/15169499/129100885-c6e12420-b663-47c9-bf79-414e6bfdbd79.png"> | <img width="180" alt="Screen Shot 2021-08-12 at 03 41 55" src="https://user-images.githubusercontent.com/15169499/129100875-b22a963c-45b8-4cea-aa50-369247093db6.png"> |
|  | <img width="184" alt="Screen Shot 2021-08-12 at 03 41 59" src="https://user-images.githubusercontent.com/15169499/129100882-1762174e-5eec-46ea-8973-90802383cc07.png"> |