### PR TITLE
persist AudioPlayer state, except isPlaying

### DIFF
--- a/src/redux/slices/AudioPlayer/persistConfig.ts
+++ b/src/redux/slices/AudioPlayer/persistConfig.ts
@@ -1,0 +1,10 @@
+import storage from 'redux-persist/lib/storage';
+
+const audioPlayerPersistConfig = {
+  key: 'audioPlayerState',
+  storage,
+  version: 1,
+  blacklist: ['isPlaying'],
+};
+
+export default audioPlayerPersistConfig;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -20,6 +20,7 @@ import navbar from './slices/navbar';
 import audioPlayerState from './slices/AudioPlayer/state';
 import audioPlayerStyle from './slices/AudioPlayer/style';
 import theme from './slices/theme';
+import audioPlayerPersistConfig from './slices/AudioPlayer/persistConfig';
 
 const persistConfig = {
   key: 'root',
@@ -29,7 +30,7 @@ const persistConfig = {
 };
 
 const rootReducer = combineReducers({
-  audioPlayerState,
+  audioPlayerState: persistReducer(audioPlayerPersistConfig, audioPlayerState),
   audioPlayerStyle,
   contextMenu,
   navbar,


### PR DESCRIPTION
### Summary
- persist the audio player state, all of it, except `isPlaying`

### Test Plan
- try to play the audio, then reload the browser
- all-state should be preserved. But the audio player is paused
