### PR TITLE
play verse timestamp with new API

### DIFF
--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -169,6 +169,7 @@ const getRequestKey = ({
   if (quranReaderDataType === QuranReaderDataType.Juz) {
     return makeJuzVersesUrl(id, {
       page,
+      reciter,
       translations: selectedTranslations.join(', '),
       ...getDefaultWordFields(quranReaderStyles.quranFont),
     });
@@ -176,6 +177,7 @@ const getRequestKey = ({
   if (quranReaderDataType === QuranReaderDataType.Page) {
     return makePageVersesUrl(id, {
       page,
+      reciter,
       translations: selectedTranslations.join(', '),
       ...getDefaultWordFields(quranReaderStyles.quranFont),
     });

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -12,7 +12,7 @@ import {
 import classNames from 'classnames';
 import { selectTafsirs, TafsirsSettings } from 'src/redux/slices/QuranReader/tafsirs';
 import { getDefaultWordFields } from 'src/utils/api';
-import { selectReciter } from 'src/redux/slices/AudioPlayer/state';
+import { selectIsUsingDefaultReciter, selectReciter } from 'src/redux/slices/AudioPlayer/state';
 import { selectReadingPreference } from '../../redux/slices/QuranReader/readingPreference';
 import PageView from './PageView';
 import TranslationView from './TranslationView';
@@ -57,6 +57,7 @@ const QuranReader = ({
   ) as TranslationsSettings;
   const { selectedTafsirs, isUsingDefaultTafsirs } = useSelector(selectTafsirs) as TafsirsSettings;
   const reciter = useSelector(selectReciter, shallowEqual);
+  const isUsingDefaultReciter = useSelector(selectIsUsingDefaultReciter);
   const { data, size, setSize, isValidating } = useSWRInfinite(
     (index) =>
       getRequestKey({
@@ -73,7 +74,10 @@ const QuranReader = ({
       }),
     verseFetcher,
     {
-      initialData: isUsingDefaultTranslations && isUsingDefaultTafsirs ? initialData.verses : null, // initialData is set to null if the user changes/has changed the default translations/tafsirs so that we can prevent the UI from falling back to the default translations while fetching the verses with the translations/tafsirs the user had selected and we will show a loading indicator instead.
+      initialData:
+        isUsingDefaultTranslations && isUsingDefaultTafsirs && isUsingDefaultReciter
+          ? initialData.verses
+          : null, // initialData is set to null if the user changes/has changed the default translations/tafsirs so that we can prevent the UI from falling back to the default translations while fetching the verses with the translations/tafsirs the user had selected and we will show a loading indicator instead.
       revalidateOnFocus: false, // disable auto revalidation when window gets focused
       revalidateOnMount: true, // enable automatic revalidation when component is mounted. This is needed when the translations inside initialData don't match with the user preferences and would result in inconsistency either when we first load the QuranReader with pre-saved translations from the persistent store or when we change the translations' preferences after initial load.
     },

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -69,7 +69,7 @@ const QuranReader = ({
         isVerseData,
         isTafsirData,
         id,
-        reciter,
+        reciter: reciter.id,
       }),
     verseFetcher,
     {
@@ -162,8 +162,8 @@ const getRequestKey = ({
   quranReaderDataType,
   selectedTranslations,
   selectedTafsirs,
-}: // reciter,
-RequestKeyInput): string => {
+  reciter,
+}: RequestKeyInput): string => {
   // if the response has only 1 verse it means we should set the page to that verse this will be combined with perPage which will be set to only 1.
   const page = isVerseData || isTafsirData ? initialData.verses[0].verseNumber : index + 1;
   if (quranReaderDataType === QuranReaderDataType.Juz) {
@@ -193,7 +193,7 @@ RequestKeyInput): string => {
   }
 
   return makeVersesUrl(id, {
-    reciter: 50,
+    reciter,
     page,
     translations: selectedTranslations.join(', '),
     ...getDefaultWordFields(quranReaderStyles.quranFont),

--- a/src/components/Verse/PlayVerseAudioButton.tsx
+++ b/src/components/Verse/PlayVerseAudioButton.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { playVerse } from 'src/redux/slices/AudioPlayer/state';
+import Verse from 'types/Verse';
 
 import PlayIcon from '../../../public/icons/play-circle-outline.svg';
 import Button from '../dls/Button/Button';
 
 interface Props {
-  verseKey: string;
+  verse: Verse;
 }
 const PlayVerseAudioButton = (props: Props) => {
   const dispatch = useDispatch();
@@ -14,7 +15,7 @@ const PlayVerseAudioButton = (props: Props) => {
     <Button
       icon={<PlayIcon />}
       onClick={() => {
-        dispatch(playVerse(props.verseKey));
+        dispatch(playVerse(props.verse));
       }}
     />
   );

--- a/src/components/Verse/PlayVerseAudioButton.tsx
+++ b/src/components/Verse/PlayVerseAudioButton.tsx
@@ -1,21 +1,28 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { playVerse } from 'src/redux/slices/AudioPlayer/state';
-import Verse from 'types/Verse';
+import { playFrom } from 'src/redux/slices/AudioPlayer/state';
 
 import PlayIcon from '../../../public/icons/play-circle-outline.svg';
 import Button from '../dls/Button/Button';
 
 interface PlayVerseAudioProps {
-  verse: Verse;
+  timestamp: number;
+  chapterId: number;
+  reciterId: number;
 }
-const PlayVerseAudioButton = (props: PlayVerseAudioProps) => {
+const PlayVerseAudioButton = ({ chapterId, reciterId, timestamp }: PlayVerseAudioProps) => {
   const dispatch = useDispatch();
   return (
     <Button
       icon={<PlayIcon />}
       onClick={() => {
-        dispatch(playVerse(props.verse));
+        dispatch(
+          playFrom({
+            chapterId,
+            reciterId,
+            timestamp,
+          }),
+        );
       }}
     />
   );

--- a/src/components/Verse/PlayVerseAudioButton.tsx
+++ b/src/components/Verse/PlayVerseAudioButton.tsx
@@ -6,10 +6,10 @@ import Verse from 'types/Verse';
 import PlayIcon from '../../../public/icons/play-circle-outline.svg';
 import Button from '../dls/Button/Button';
 
-interface Props {
+interface PlayVerseAudioProps {
   verse: Verse;
 }
-const PlayVerseAudioButton = (props: Props) => {
+const PlayVerseAudioButton = (props: PlayVerseAudioProps) => {
   const dispatch = useDispatch();
   return (
     <Button

--- a/src/components/Verse/VerseActions.tsx
+++ b/src/components/Verse/VerseActions.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import Verse from 'types/Verse';
+import { useSelector } from 'react-redux';
+import { selectReciter } from 'src/redux/slices/AudioPlayer/state';
 import Dropdown from '../dls/Dropdown/Dropdown';
 import OverflowMenu from '../../../public/icons/menu_more_horiz.svg';
 import VerseActionsMenu from './VerseActionsMenu';
@@ -13,6 +15,7 @@ interface Props {
 
 const VerseActions: React.FC<Props> = ({ verse }) => {
   const [activeVerseActionModal, setActiveVerseActionModal] = useState<VerseActionModalType>(null);
+  const reciter = useSelector(selectReciter);
 
   return (
     <>
@@ -30,7 +33,11 @@ const VerseActions: React.FC<Props> = ({ verse }) => {
         verse={verse}
         setActiveVerseActionModal={setActiveVerseActionModal}
       />
-      <PlayVerseAudioButton verse={verse} />
+      <PlayVerseAudioButton
+        timestamp={verse.timestamps.timestampFrom}
+        chapterId={Number(verse.chapterId)}
+        reciterId={reciter.id}
+      />
     </>
   );
 };

--- a/src/components/Verse/VerseActions.tsx
+++ b/src/components/Verse/VerseActions.tsx
@@ -30,7 +30,7 @@ const VerseActions: React.FC<Props> = ({ verse }) => {
         verse={verse}
         setActiveVerseActionModal={setActiveVerseActionModal}
       />
-      <PlayVerseAudioButton verseKey={verse.verseKey} />
+      <PlayVerseAudioButton verse={verse} />
     </>
   );
 };

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -1,9 +1,10 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { getAudioFile, getVerseTimestamps } from 'src/api';
+import { getAudioFile } from 'src/api';
 import { triggerPlayAudio, triggerSetCurrentTime } from 'src/components/AudioPlayer/EventTriggers';
 import { getChapterNumberFromKey } from 'src/utils/verse';
 import { AudioFile } from 'types/AudioFile';
 import Reciter from 'types/Reciter';
+import Verse from 'types/Verse';
 
 const DEFAULT_RECITER = {
   id: 5,
@@ -71,21 +72,20 @@ export const loadAndPlayAudioFile = createAsyncThunk<void, number>(
  * @param {number} verseKey example 1:1 -> al-fatihah verse 1
  *
  */
-export const playVerse = createAsyncThunk<void, string>(
+export const playVerse = createAsyncThunk<void, Verse>(
   'audioPlayerState/setAudioTime',
-  async (verseKey, thunkApi) => {
+  async (verse, thunkApi) => {
     const state = thunkApi.getState();
     const reciter = selectReciter(state);
     let audioFile = selectAudioFile(state);
-    const chapter = getChapterNumberFromKey(verseKey);
+    const chapter = getChapterNumberFromKey(verse.verseKey);
     if (!audioFile || audioFile.chapterId !== chapter) {
       thunkApi.dispatch(setAudioStatus(AudioFileStatus.Loading));
       audioFile = await getAudioFile(reciter.id, chapter);
       thunkApi.dispatch(setAudioFile(audioFile));
     }
 
-    const timeStamp = await getVerseTimestamps(reciter?.id, verseKey);
-    const timeStampInSecond = timeStamp.result.timestampFrom / 1000;
+    const timeStampInSecond = verse.timestamps?.timestampFrom / 1000;
     triggerSetCurrentTime(timeStampInSecond);
     thunkApi.dispatch(setCurrentTime(timeStampInSecond));
 

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -39,6 +39,8 @@ const initialState: AudioState = {
 
 export const selectAudioPlayerState = (state) => state.audioPlayerState;
 export const selectReciter = (state) => state.audioPlayerState.reciter as Reciter;
+export const selectIsUsingDefaultReciter = (state) =>
+  state.audioPlayerState.reciter.id === DEFAULT_RECITER.id;
 export const selectAudioFile = (state) => state.audioPlayerState.audioFile as AudioFile;
 export const selectAudioFileStatus = (state) => state.audioPlayerState.audioFileStatus;
 export const selectIsPlaying = (state) => state.audioPlayerState.isPlaying;

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -38,7 +38,7 @@ const initialState: AudioState = {
 };
 
 export const selectAudioPlayerState = (state) => state.audioPlayerState;
-export const selectReciter = (state) => state.audioPlayerState.reciter;
+export const selectReciter = (state) => state.audioPlayerState.reciter as Reciter;
 export const selectAudioFile = (state) => state.audioPlayerState.audioFile as AudioFile;
 export const selectAudioFileStatus = (state) => state.audioPlayerState.audioFileStatus;
 export const selectIsPlaying = (state) => state.audioPlayerState.isPlaying;

--- a/types/Verse.ts
+++ b/types/Verse.ts
@@ -31,6 +31,13 @@ interface Verse {
   translations?: Translation[];
   tafsirs?: Tafsir[];
   audio?: AudioResponse;
+  timestamps?: {
+    verseKey: string;
+    timestampFrom: number;
+    timestampTo: number;
+    duration: number;
+    segments: [number[]];
+  };
 }
 
 export default Verse;


### PR DESCRIPTION
### Summary
- previously we call api to get timestamp api everytime we click "play" verse.
- now we don't call the API anymore

- refactored `getRequestKey` a little bit.

### Test Plan
- click the "play" button on the left side of each verse, in translation reading view. See the network request. there should be no new API call.
