### PR TITLE
Add caching headers config for fonts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,19 @@ const config = {
     runtimeCaching,
     publicExcludes: ['!fonts/v1/**/*', '!fonts/v2/**/*'],
   },
+  async headers() {
+    return [
+      {
+        source: '/fonts/:font*', // match wildcard fonts' path which will match any font file on any level under /fonts.
+        headers: [
+          {
+            key: 'cache-control',
+            value: 'public, max-age=31536000, immutable', // Max-age is 1 year. immutable indicates that the font will not change over the expiry time.
+          },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = withPlugins([withPWA, withFonts, nextTranslate], config);


### PR DESCRIPTION
### Summary
This PR adds caching strategy for fonts using [custom Next.js headers](https://nextjs.org/docs/api-reference/next.config.js/headers#wildcard-path-matching). Caching is needed since Next.js and Vercel sets `max-age` to 0 and `must-revalidate` by default for fonts but since they take some time to be downloaded on every browse while they rarely/never change, adding caching would make the user experience faster, save the data usage for the data used to download the fonts and will reduce the load on the server since the fonts will be served from the local cache once they are cached.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="948" alt="Screen Shot 2021-08-17 at 14 08 47" src="https://user-images.githubusercontent.com/15169499/129681309-b278d336-0026-4a8a-910e-24ca1edf5c0e.png">|<img width="947" alt="Screen Shot 2021-08-17 at 14 08 54" src="https://user-images.githubusercontent.com/15169499/129681321-0503b9ec-82db-4495-8064-805995d23996.png">|