### PR TITLE
Add security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,10 @@ const config = {
   async headers() {
     return [
       {
+        source: '/(.*)', // apply security rules to all routes.
+        headers: securityHeaders,
+      },
+      {
         source: '/fonts/:font*', // match wildcard fonts' path which will match any font file on any level under /fonts.
         headers: [
           {
@@ -30,3 +34,50 @@ const config = {
 };
 
 module.exports = withPlugins([withPWA, withFonts, nextTranslate], config);
+
+/*
+  - default-src: a fallback for all other directives.
+    - 'self': Refers to the origin from which the protected document is being served, including the same URL scheme and port number.
+  - script-src: specifies the valid sources of JS running either inside <script> elements or inline script event handlers (onclick). 
+    - 'unsafe-inline' allows the use of inline resources. 
+    - 'unsafe-eval' is needed otherwise custom JS variables by google analytics will yield to undefined.
+  - img-src: specifies valid sources of images and favicons. We allow all sources. besides inline images using :data.
+    - data: Allows data: URIs to be used as a content source. Currently we use data to embed some images inline e.g. the App Store images in the Side Menu Drawer.
+  - media-src: specifies valid sources for loading media using the <audio> and <video> elements. Currently we only allow audio from quranicaudio.com.
+  - connect-src: restricts the URLs that we can connect to using script interfaces including <a>, XMLHttpRequest, WebSocket. Currently we allow all URLs.
+*/
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://ssl.google-analytics.com;
+  img-src * data:;
+  media-src https://quranicaudio.com;
+  connect-src *;
+`;
+
+const securityHeaders = [
+  // Protects from XSS attacks. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy.replace(/\n/g, ''),
+  },
+  // Controls how much information the browser includes when navigating away from a document. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+  {
+    key: 'Referrer-Policy',
+    value: 'origin-when-cross-origin', // Will Send the origin, path, and query string when performing a same-origin request to the same protocol level e.g. https://www.quran.com/search?page=1&language=en&query=Allah; otherwise, will only send base url e.g. https://www.quran.com.
+  },
+  // Indicate that Content-Type headers should not be changed and be followed. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff', // disallow overriding response Content-Type headers to guess and process the data using an implicit content type.
+  },
+  // Controls DNS pre-fetching, allowing browsers to proactively perform domain name resolution on external links, images, CSS etc which reduces latency when the user clicks a link. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on',
+  },
+  // Controls which features and APIs can be used in the browser. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy and https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(self), geolocation=(self), fullscreen=*', // camera is disabled for all, microphone only for the current origin, geolocation only for the current origin and fullscreen for all including iframes.
+  },
+];


### PR DESCRIPTION
### Summary
After conducting a security headers's [scan](https://securityheaders.com/?q=https%3A%2F%2Fnext.quran.com%2F&followRedirects=on), it turns out we are missing a few essential headers. This PRs adds those headers summarized as following:

- [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
- [`Referrer-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
- [`X-Content-Type-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
- [`X-DNS-Prefetch-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-DNS-Prefetch-Control)
- [`Permissions-Policy`](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md)
