### PR TITLE
Add the recommended Next linting preset 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
         "airbnb",
         "airbnb/hooks",
         "plugin:import/typescript",
-        "prettier"
+        "prettier",
+        "plugin:@next/next/recommended"
     ],
     "parser": "babel-eslint",
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",
+    "@next/eslint-plugin-next": "^11.1.0",
     "@storybook/addon-a11y": "^6.3.7",
     "@storybook/addon-actions": "^6.3.7",
     "@storybook/addon-essentials": "^6.3.7",

--- a/src/components/QuranReader/ReadingView/PageFooter.tsx
+++ b/src/components/QuranReader/ReadingView/PageFooter.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PageFooter: React.FC<Props> = ({ page }) => (
   <div className={styles.pageText}>
-    <Link href={`/page/${page}`}>
+    <Link href={`/page/${page}`} passHref>
       <p className={styles.pageLink}>{`Page ${page}`}</p>
     </Link>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,7 +1957,7 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-11.1.0.tgz#cae83d8e0a65aa9f2af3368f8269ffd9d911746a"
   integrity sha512-zPJkMFRenSf7BLlVee8987G0qQXAhxy7k+Lb/5hLAGkPVHAHm+oFFeL+2ipbI2KTEFlazdmGY0M+AlLQn7pWaw==
 
-"@next/eslint-plugin-next@11.1.0":
+"@next/eslint-plugin-next@11.1.0", "@next/eslint-plugin-next@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-11.1.0.tgz#bee19a333e3d2d81d381b9c2fdf2df713f5774e8"
   integrity sha512-HjLhyshV+ANzTDCFLN1UZMQIyYwZkCdhydfIcOQQVCrqLSd0hCi+AYIGqWfDPhXmP7aeOuKQsmhRmdennQV2qw==


### PR DESCRIPTION
Extended the linting configuration recommended by Next.js: https://nextjs.org/docs/basic-features/eslint.

Got a warning about `passHref` not being passed. Fixed that warning. Confirms that the preset works :) 