### PR TITLE
Make translation mode the default reading preference

### DIFF
--- a/src/redux/slices/QuranReader/readingPreferences.ts
+++ b/src/redux/slices/QuranReader/readingPreferences.ts
@@ -13,7 +13,7 @@ export type ReadingPreferences = {
 };
 
 const initialState: ReadingPreferences = {
-  readingPreference: ReadingPreference.Reading,
+  readingPreference: ReadingPreference.Translation,
   showWordByWordTranslation: false,
   selectedWordByWordTranslation: DEFAULT_TRANSLATION,
   showWordByWordTransliteration: false,


### PR DESCRIPTION
Made translation mode the default reading preference. This is beneficial for SEO + matches the current design