### PR TITLE
Fix Portalling issue

### DIFF
--- a/src/components/dls/Popover/index.tsx
+++ b/src/components/dls/Popover/index.tsx
@@ -46,7 +46,6 @@ const Popover: React.FC<Props> = ({
         {trigger}
       </RadixPopover.Trigger>
       <RadixPopover.Content
-        portalled={false}
         sideOffset={2}
         side={contentSide}
         align={contentAlign}

--- a/src/components/dls/Tooltip/index.tsx
+++ b/src/components/dls/Tooltip/index.tsx
@@ -61,7 +61,6 @@ const Tooltip: React.FC<Props> = ({
       {children}
     </RadixTooltip.Trigger>
     <RadixTooltip.Content
-      portalled={false}
       sideOffset={2}
       side={contentSide}
       align={contentAlign}

--- a/src/styles/ThemeProvider.module.scss
+++ b/src/styles/ThemeProvider.module.scss
@@ -1,4 +1,5 @@
 .container {
   min-height: 100vh;
   background: var(--color-background-default);
+  color: var(--color-text-default);
 }

--- a/src/styles/ThemeProvider.tsx
+++ b/src/styles/ThemeProvider.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { selectTheme } from 'src/redux/slices/theme';
 import styles from './ThemeProvider.module.scss';
 
 const ThemeProvider = ({ children }) => {
   const theme = useSelector(selectTheme);
+  useEffect(() => {
+    if (theme) {
+      document.body.setAttribute('data-theme', theme.type);
+    }
+  }, [theme]);
 
-  return (
-    <div data-theme={theme.type}>
-      <div className={styles.container}>{children}</div>
-    </div>
-  );
+  return <div className={styles.container}>{children}</div>;
 };
 
 export default ThemeProvider;

--- a/src/styles/ThemeProvider.tsx
+++ b/src/styles/ThemeProvider.tsx
@@ -1,15 +1,14 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { selectTheme } from 'src/redux/slices/theme';
 import styles from './ThemeProvider.module.scss';
 
 const ThemeProvider = ({ children }) => {
   const theme = useSelector(selectTheme);
-  useEffect(() => {
-    if (theme) {
-      document.body.setAttribute('data-theme', theme.type);
-    }
-  }, [theme]);
+
+  if (typeof window !== 'undefined' && document.body) {
+    document.body.setAttribute('data-theme', theme.type);
+  }
 
   return <div className={styles.container}>{children}</div>;
 };


### PR DESCRIPTION
### Summary
This PR attempts to solve the portalling issue that happens when using Radix UI's `Tooltip`, `Popover` and `Dialog` components. The issue is that the content of those components gets portalled by default to underneath `document.body` which causes it to exist higher in the DOM tree than the `div` element where we set the current theme inside of Redux storage by adding it to `data-theme` property.