### PR TITLE
Fix advanced copy item styling

### DIFF
--- a/src/components/Verse/VerseActionsMenu.tsx
+++ b/src/components/Verse/VerseActionsMenu.tsx
@@ -89,7 +89,10 @@ const VerseActionsMenu: React.FC<Props> = ({ verse }) => {
         onClick={onCopyClicked}
       />
 
-      <Modal trigger={<VerseActionsMenuItem title="Advanced Copy" icon={<AdvancedCopyIcon />} />}>
+      <Modal
+        triggerClassName={styles.container}
+        trigger={<VerseActionsMenuItem title="Advanced Copy" icon={<AdvancedCopyIcon />} />}
+      >
         <VerseAdvancedCopy verse={verse}>
           {({ ayahSelectionComponent, actionText, onCopy }) => (
             <>

--- a/src/components/dls/ModalNew/Modal.tsx
+++ b/src/components/dls/ModalNew/Modal.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import classNames from 'classnames';
 import styles from './Modal.module.scss';
 
 type ModalProps = {
   children: React.ReactNode;
   trigger?: React.ReactNode;
+  triggerClassName?: string;
   open?: boolean;
   onClickOutside?: () => void;
 };
-const Modal = ({ children, trigger, open, onClickOutside }: ModalProps) => (
+const Modal = ({ children, trigger, open, onClickOutside, triggerClassName }: ModalProps) => (
   <DialogPrimitive.Root open={open}>
     <DialogPrimitive.Overlay className={styles.overlay} />
     {trigger && (
-      <DialogPrimitive.Trigger as="div" className={styles.trigger}>
+      <DialogPrimitive.Trigger
+        as="div"
+        className={classNames(styles.trigger, { [triggerClassName]: triggerClassName })}
+      >
         {trigger}
       </DialogPrimitive.Trigger>
     )}


### PR DESCRIPTION
### Summary
This PR solves a minor UI issue with the verse's advanced copy item. 

### Screenshots

| Before | After |
| ------ | ------ |
| <img width="216" alt="Screen Shot 2021-08-28 at 16 28 43" src="https://user-images.githubusercontent.com/15169499/131213362-e21c6e07-9e6d-4ed1-9f7d-3d32363e3bb0.png"> | <img width="216" alt="Screen Shot 2021-08-28 at 16 28 25" src="https://user-images.githubusercontent.com/15169499/131213360-b182f1e0-75de-4a0e-9a29-a3eb6fe4a6dc.png"> |
|<img width="218" alt="Screen Shot 2021-08-28 at 16 28 20" src="https://user-images.githubusercontent.com/15169499/131213359-90797e72-0977-41ec-95b7-99fe7f661cb1.png">|<img width="216" alt="Screen Shot 2021-08-28 at 16 28 08" src="https://user-images.githubusercontent.com/15169499/131213354-b9b46200-7e8c-4b6f-b771-bf4a5d74a9c7.png">|