### PR TITLE
fix: radio button check is not centered

### DIFF
--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -10,7 +10,7 @@
 
   --spacing-micro: 0.2rem;
   --spacing-xxsmall: 0.4rem;
-  --spacing-xsmall: 0.6rem;
+  --spacing-xsmall: 0.625rem;
   --spacing-small: 0.8rem;
   --spacing-medium: 1rem;
   --spacing-large: 1.2rem;


### PR DESCRIPTION
After
![image](https://user-images.githubusercontent.com/12745166/131319671-333f37ec-7b3b-4ad0-93d2-72efd0c04350.png)

Before
![image](https://user-images.githubusercontent.com/12745166/131319790-700485eb-3866-450c-836d-3fc75f40b184.png)

it was because the width and the height of `spacing-xsmall` is `9.54` in px. This PR makes the spacing-xsmall `10px`