### PR TITLE
Update tokens + Selection highlighting 

### DIFF
--- a/src/components/HomePage/HomePageWelcomeMessage.module.scss
+++ b/src/components/HomePage/HomePageWelcomeMessage.module.scss
@@ -10,7 +10,7 @@
 
   // TODO: migrate this to use our future Link component
   a {
-    color: var(--color-success-medium);
+    color: var(--color-text-link);
     text-decoration: none;
     &:hover {
       text-decoration: underline;

--- a/src/components/dls/Button/Button.module.scss
+++ b/src/components/dls/Button/Button.module.scss
@@ -51,21 +51,13 @@
     background-color: var(--color-text-inverse);
   }
 }
-.alert {
-  background-color: var(--color-alert-medium);
-  color: var(--color-text-inverse);
-  border: 1px solid var(--color-alert-medium);
-  &:hover {
-    color: var(--color-alert-medium);
-    background-color: var(--color-text-inverse);
-  }
-}
+
 .error {
-  background-color: var(--color-alert-medium);
+  background-color: var(--color-error-medium);
   color: var(--color-text-inverse);
   border: 1px solid var(--color-error-medium);
   &:hover {
-    color: var(--color-alert-medium);
+    color: var(--color-error-medium);
     background-color: var(--color-text-inverse);
   }
 }
@@ -135,12 +127,7 @@
     background-color: var(--color-warning-medium);
   }
 }
-.ghost.alert {
-  color: var(--color-alert-medium);
-  &:hover {
-    background-color: var(--color-alert-medium);
-  }
-}
+
 .ghost.success {
   color: var(--color-success-medium);
   &:hover {
@@ -148,9 +135,9 @@
   }
 }
 .ghost.error {
-  color: var(--color-alert-medium);
+  color: var(--color-error-medium);
   &:hover {
-    background-color: var(--color-alert-medium);
+    background-color: var(--color-error-medium);
   }
 }
 

--- a/src/components/dls/Button/Button.tsx
+++ b/src/components/dls/Button/Button.tsx
@@ -21,7 +21,6 @@ export enum ButtonType {
   Success = 'success',
   Error = 'error',
   Warning = 'warning',
-  Alert = 'alert',
 }
 
 export enum ButtonVariant {
@@ -63,7 +62,6 @@ const Button: React.FC<ButtonProps> = ({
     [styles.secondary]: type === ButtonType.Secondary,
     [styles.success]: type === ButtonType.Success,
     [styles.warning]: type === ButtonType.Warning,
-    [styles.alert]: type === ButtonType.Alert,
     [styles.error]: type === ButtonType.Error,
 
     // size

--- a/src/components/dls/Tooltip/Tooltip.module.scss
+++ b/src/components/dls/Tooltip/Tooltip.module.scss
@@ -46,8 +46,8 @@
   }
 }
 .error {
-  background-color: var(--color-alert-medium);
+  background-color: var(--color-error-medium);
   > span {
-    fill: var(--color-alert-medium);
+    fill: var(--color-error-medium);
   }
 }

--- a/src/styles/ThemeProvider.module.scss
+++ b/src/styles/ThemeProvider.module.scss
@@ -2,4 +2,12 @@
   min-height: 100vh;
   background: var(--color-background-default);
   color: var(--color-text-default);
+
+  ::selection {
+    background: var(--color-highlight);
+  }
+
+  ::-moz-selection {
+    background: var(--color-highlight);
+  }
 }

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -8,12 +8,12 @@
   --font-secondary: "Source Sans Pro, sans-serif";
   --font-tertiary: "Times New Roman, sans-serif";
 
-  --spacing-micro: 0.2rem;
-  --spacing-xxsmall: 0.4rem;
+  --spacing-micro: 0.1875rem;
+  --spacing-xxsmall: 0.375rem;
   --spacing-xsmall: 0.625rem;
-  --spacing-small: 0.8rem;
+  --spacing-small: 0.8125rem;
   --spacing-medium: 1rem;
-  --spacing-large: 1.2rem;
+  --spacing-large: 1.1875rem;
   --spacing-mega: 2rem;
 
   --font-size-small: 0.75rem;
@@ -22,10 +22,10 @@
   --font-size-xlarge: 1.5rem;
   --font-size-jumbo: 2rem;
 
-  --line-height-small: 0.8rem;
+  --line-height-small: 0.8125rem;
   --line-height-normal: 1rem;
-  --line-height-large: 1.2rem;
-  --line-height-xlarge: 1.4rem;
+  --line-height-large: 1.1875rem;
+  --line-height-xlarge: 1.375rem;
   --line-height-jumbo: 2.25rem;
 
   --font-weight-normal: 400;

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -4,56 +4,48 @@
   --color-primary-medium: #fff;
   --color-primary-deep: #fff;
 
-  --color-secondary-faded: #fff;
-  --color-secondary-faint: #fff;
-  --color-secondary-medium: rgb(238, 0, 255);
-  --color-secondary-deep: #fff;
+  --color-secondary-faded: #333;
+  --color-secondary-faint: #444;
+  --color-secondary-medium: #888;
+  --color-secondary-deep: #eaeaea;
 
-  --color-success-faded: #fff;
-  --color-success-faint: #fff;
+  --color-success-faded: #d3e5ff;
+  --color-success-faint: #3291ff;
   --color-success-medium: #0070f3;
-  --color-success-deep: #fff;
+  --color-success-deep: #0761d1;
 
-  --color-error-faded: #fff;
-  --color-error-faint: #fff;
-  --color-error-medium: #ee0102;
-  --color-error-deep: #fff;
+  --color-error-faded: #f33;
+  --color-error-faint: #f00;
+  --color-error-medium: #f00;
+  --color-error-deep: #e60000;
 
-  --color-warning-faded: #fff;
-  --color-warning-faint: #fff;
+  --color-warning-faded: #ffefcf;
+  --color-warning-faint: #f7b955;
   --color-warning-medium: #f5a623;
-  --color-warning-deep: #fff;
-
-  --color-alert-faded: #fff;
-  --color-alert-faint: #fff;
-  --color-alert-medium: #ff0080;
-  --color-alert-deep: #fff;
-
-  --color-tertiary-faded: #fff;
-  --color-tertiary-faint: #fff;
-  --color-tertiary-medium: #fff;
-  --color-tertiary-deep: #fff;
+  --color-warning-deep: #ab570a;
 
   --color-text-default: #fff;
   --color-text-faded: #666;
   --color-text-inverse: #000;
-  --color-text-link: #fff;
-  --color-text-warning: #fff;
-  --color-text-error: #fff;
+  --color-text-link: #3291ff;
+  --color-text-warning: #f7b955;
+  --color-text-error: #f33;
 
-  --color-background-default: #141d26;
+  --color-background-default: #000;
   --color-background-alternative: #999;
   --color-background-alternative-deep: #eaeaea;
   --color-background-inverse: #fff;
-  --color-background-backdrop: rgba(0, 0, 0, 0.25);
+  --color-background-backdrop: rgba(255, 255, 255 0.25);
 
   --color-borders-hairline: rgb(235, 238, 240);
 
-  --shadow-small: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  --shadow-normal: 0px 4px 8px rgba(0, 0, 0, 0.12);
-  --shadow-large: 0 5px 10px rgba(0, 0, 0, 0.12);
-  --shadow-xlarge: 0 8px 30px rgba(0, 0, 0, 0.12);
-  --shadow-jumbo: 0 30px 60px rgba(0, 0, 0, 0.12);
-  --shadow-hover: 0 30px 60px rgba(0, 0, 0, 0.12);
-  --shadow-sticky: 0 12px 10px -10px rgba(0, 0, 0, 0.12);
+  --color-highlight: #f81ce5;
+
+  --shadow-small: 0px 2px 4px rgba(255, 255, 255 0.1);
+  --shadow-normal: 0px 4px 8px rgba(255, 255, 255 0.12);
+  --shadow-large: 0 5px 10px rgba(255, 255, 255 0.12);
+  --shadow-xlarge: 0 8px 30px rgba(255, 255, 255 0.12);
+  --shadow-jumbo: 0 30px 60px rgba(255, 255, 255 0.12);
+  --shadow-hover: 0 30px 60px rgba(255, 255, 255 0.12);
+  --shadow-sticky: 0 12px 10px -10px rgba(255, 255, 255 0.12);
 }

--- a/src/styles/themes/_light.scss
+++ b/src/styles/themes/_light.scss
@@ -4,42 +4,32 @@
   --color-primary-medium: #000;
   --color-primary-deep: #fff;
 
-  --color-secondary-faded: #fff;
-  --color-secondary-faint: #fff;
-  --color-secondary-medium: #c8c8c8;
-  --color-secondary-deep: #fff;
+  --color-secondary-faded: #eaeaea;
+  --color-secondary-faint: #999;
+  --color-secondary-medium: #666;
+  --color-secondary-deep: #333;
 
-  --color-success-faded: #fff;
-  --color-success-faint: #fff;
+  --color-success-faded: #d3e5ff;
+  --color-success-faint: #3291ff;
   --color-success-medium: #0070f3;
-  --color-success-deep: #fff;
+  --color-success-deep: #0761d1;
 
-  --color-error-faded: #fff;
-  --color-error-faint: #fff;
+  --color-error-faded: #f7d4d6;
+  --color-error-faint: #ff1a1a;
   --color-error-medium: #ee0102;
-  --color-error-deep: #fff;
+  --color-error-deep: #c50000;
 
   --color-warning-faded: #ffefcf;
   --color-warning-faint: #f7b955;
   --color-warning-medium: #f5a623;
-  --color-warning-deep: #fff;
-
-  --color-alert-faded: #fff;
-  --color-alert-faint: #fff;
-  --color-alert-medium: #ff0080;
-  --color-alert-deep: #fff;
-
-  --color-tertiary-faded: #fff;
-  --color-tertiary-faint: #fff;
-  --color-tertiary-medium: #fff;
-  --color-tertiary-deep: #fff;
+  --color-warning-deep: #ab570a;
 
   --color-text-default: #000;
   --color-text-faded: #666;
   --color-text-inverse: #fff;
-  --color-text-link: #fff;
-  --color-text-warning: #fff;
-  --color-text-error: #fff;
+  --color-text-link: #0070f3;
+  --color-text-warning: #ab570a;
+  --color-text-error: #c50000;
 
   --color-background-default: #fff;
   --color-background-alternative: #eaeaea;
@@ -48,6 +38,8 @@
   --color-background-backdrop: rgba(0, 0, 0, 0.25);
 
   --color-borders-hairline: rgb(235, 238, 240);
+
+  --color-highlight: #79ffe1;
 
   --shadow-small: 0px 2px 4px rgba(0, 0, 0, 0.1);
   --shadow-normal: 0px 4px 8px rgba(0, 0, 0, 0.12);

--- a/src/styles/themes/_sepia.scss
+++ b/src/styles/themes/_sepia.scss
@@ -4,42 +4,32 @@
   --color-primary-medium: #000;
   --color-primary-deep: #fff;
 
-  --color-secondary-faded: #fff;
-  --color-secondary-faint: #fff;
-  --color-secondary-medium: #c8c8c8;
-  --color-secondary-deep: #fff;
+  --color-secondary-faded: #eaeaea;
+  --color-secondary-faint: #999;
+  --color-secondary-medium: #666;
+  --color-secondary-deep: #333;
 
-  --color-success-faded: #fff;
-  --color-success-faint: #fff;
+  --color-success-faded: #d3e5ff;
+  --color-success-faint: #3291ff;
   --color-success-medium: #0070f3;
-  --color-success-deep: #fff;
+  --color-success-deep: #0761d1;
 
-  --color-error-faded: #fff;
-  --color-error-faint: #fff;
+  --color-error-faded: #f7d4d6;
+  --color-error-faint: #ff1a1a;
   --color-error-medium: #ee0102;
-  --color-error-deep: #fff;
+  --color-error-deep: #c50000;
 
-  --color-warning-faded: #fff;
-  --color-warning-faint: #fff;
+  --color-warning-faded: #ffefcf;
+  --color-warning-faint: #f7b955;
   --color-warning-medium: #f5a623;
-  --color-warning-deep: #fff;
-
-  --color-alert-faded: #fff;
-  --color-alert-faint: #fff;
-  --color-alert-medium: #ff0080;
-  --color-alert-deep: #fff;
-
-  --color-tertiary-faded: #fff;
-  --color-tertiary-faint: #fff;
-  --color-tertiary-medium: #fff;
-  --color-tertiary-deep: #fff;
+  --color-warning-deep: #ab570a;
 
   --color-text-default: #000;
   --color-text-faded: #666;
   --color-text-inverse: #fff;
-  --color-text-link: #fff;
-  --color-text-warning: #fff;
-  --color-text-error: #fff;
+  --color-text-link: #0070f3;
+  --color-text-warning: #ab570a;
+  --color-text-error: #c50000;
 
   --color-background-default: #f4ecd8;
   --color-background-alternative: #eaeaea;
@@ -48,6 +38,8 @@
   --color-background-backdrop: rgba(0, 0, 0, 0.25);
 
   --color-borders-hairline: rgb(235, 238, 240);
+
+  --color-highlight: #50e3c2;
 
   --shadow-small: 0px 2px 4px rgba(0, 0, 0, 0.1);
   --shadow-normal: 0px 4px 8px rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
### Summary
* Convert our token rem values to match a full pixel. Thank you @muhajirdev for the bug discovery.
* Add the complete theme token set for the light mode. 
* Apply the tokens to dark and sepia modes (need another follow-up PR) 
* Update the usage of links to the `color-text-link` token
* Remove the alert token 
* Replace the alert color usage with the error color
* Add a selection highlight color

### Screenshots
New selection color: 
![2021-08-31 at 09 08 53](https://user-images.githubusercontent.com/11590314/131458632-13b1e744-8f0c-4bdc-b894-d0ad8ddc56f6.png)
