### PR TITLE
Improve combobox styling

### DIFF
--- a/src/components/Navbar/SettingsDrawer/AudioSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/AudioSection.tsx
@@ -46,14 +46,16 @@ const AudioSection = () => {
       <Section.Title>Audio</Section.Title>
       <Section.Row>
         <Section.Label>Reciter</Section.Label>
-        <Combobox
-          clearable={false}
-          id="audio-reciter"
-          items={items}
-          initialInputValue={selectedReciter.name}
-          value={selectedReciter.id.toString()}
-          onChange={onSelectedReciterChange}
-        />
+        <div>
+          <Combobox
+            clearable={false}
+            id="audio-reciter"
+            items={items}
+            initialInputValue={selectedReciter.name}
+            value={selectedReciter.id.toString()}
+            onChange={onSelectedReciterChange}
+          />
+        </div>
       </Section.Row>
     </Section>
   );

--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
@@ -99,13 +99,15 @@ const QuranFontSection = () => {
       </Section.Row>
       <Section.Row>
         <Section.Label>Style</Section.Label>
-        <Combobox
-          id="quran-font-styles"
-          value={quranFont}
-          initialInputValue={getLabel(quranFont, selectedType)}
-          items={fonts[selectedType]}
-          onChange={(value) => dispatch(setQuranFont(value as QuranFont))}
-        />
+        <div>
+          <Combobox
+            id="quran-font-styles"
+            value={quranFont}
+            initialInputValue={getLabel(quranFont, selectedType)}
+            items={fonts[selectedType]}
+            onChange={(value) => dispatch(setQuranFont(value as QuranFont))}
+          />
+        </div>
       </Section.Row>
       <Section.Row>
         <Section.Label>Font size</Section.Label>

--- a/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
@@ -123,13 +123,15 @@ const ReadingExperienceSection = () => {
       </Section.Row>
       <Section.Row>
         <Section.Label>Word By Word</Section.Label>
-        <Combobox
-          id="wordByWord"
-          items={wordByWordOptions}
-          initialInputValue={getLabel(wordByWordValue)}
-          value={wordByWordValue}
-          onChange={onWordByWordChange}
-        />
+        <div>
+          <Combobox
+            id="wordByWord"
+            items={wordByWordOptions}
+            initialInputValue={getLabel(wordByWordValue)}
+            value={wordByWordValue}
+            onChange={onWordByWordChange}
+          />
+        </div>
       </Section.Row>
     </Section>
   );

--- a/src/components/Navbar/SettingsDrawer/SettingsDrawer.module.scss
+++ b/src/components/Navbar/SettingsDrawer/SettingsDrawer.module.scss
@@ -27,6 +27,7 @@
 }
 
 .header {
+  z-index: inherit;
   width: 100%;
   background-color: var(--color-background-default);
   position: fixed;

--- a/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
@@ -43,15 +43,17 @@ const TafsirSection = () => {
       <Section.Title>Tafsir</Section.Title>
       <Section.Row>
         <Section.Label>Tafsir</Section.Label>
-        <Combobox
-          id="tafsir"
-          isMultiSelect
-          items={items}
-          onChange={(values) =>
-            dispatch(setSelectedTafsirs(stringsToNumbersArray(values as string[])))
-          }
-          value={numbersToStringsArray(selectedTafsirs)}
-        />
+        <div>
+          <Combobox
+            id="tafsir"
+            isMultiSelect
+            items={items}
+            onChange={(values) =>
+              dispatch(setSelectedTafsirs(stringsToNumbersArray(values as string[])))
+            }
+            value={numbersToStringsArray(selectedTafsirs)}
+          />
+        </div>
       </Section.Row>
     </Section>
   );

--- a/src/components/Navbar/SettingsDrawer/ThemeSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/ThemeSection.tsx
@@ -22,13 +22,15 @@ const ThemeSection = () => {
       <Section.Title>Theme</Section.Title>
       <Section.Row>
         <Section.Label>Mode</Section.Label>
-        <Combobox
-          id="theme-section"
-          value={theme.type}
-          initialInputValue={getLabelById(theme.type)}
-          items={themes}
-          onChange={(value) => dispatch({ type: setTheme.type, payload: value })}
-        />
+        <div>
+          <Combobox
+            id="theme-section"
+            value={theme.type}
+            initialInputValue={getLabelById(theme.type)}
+            items={themes}
+            onChange={(value) => dispatch({ type: setTheme.type, payload: value })}
+          />
+        </div>
       </Section.Row>
       <Section.Footer visible={theme.type === 'system'}>
         The system theme automatically adopts to your light/dark mode settings

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -58,16 +58,18 @@ const TranslationSection = () => {
       <Section.Title>Translation</Section.Title>
       <Section.Row>
         <Section.Label>Translation</Section.Label>
-        <Combobox
-          id="translations"
-          items={items || []}
-          isMultiSelect
-          size={ComboboxSize.Medium}
-          value={numbersToStringsArray(selectedTranslations)}
-          onChange={(values) =>
-            dispatch(setSelectedTranslations(stringsToNumbersArray(values as string[])))
-          }
-        />
+        <div>
+          <Combobox
+            id="translations"
+            items={items || []}
+            isMultiSelect
+            size={ComboboxSize.Medium}
+            value={numbersToStringsArray(selectedTranslations)}
+            onChange={(values) =>
+              dispatch(setSelectedTranslations(stringsToNumbersArray(values as string[])))
+            }
+          />
+        </div>
       </Section.Row>
       <Section.Row>
         <Section.Label>Translation</Section.Label>

--- a/src/components/dls/Forms/Combobox/Combobox.module.scss
+++ b/src/components/dls/Forms/Combobox/Combobox.module.scss
@@ -79,6 +79,7 @@
 }
 
 .multiSelectSearchInput {
+  color: var(--color-text-default);
   margin: 0;
   padding: 0;
   background: 0 0;

--- a/src/components/dls/Forms/Combobox/ComboboxItem/ComboboxItem.module.scss
+++ b/src/components/dls/Forms/Combobox/ComboboxItem/ComboboxItem.module.scss
@@ -14,7 +14,8 @@
 .enabledItem {
   cursor: pointer;
   &:hover {
-    background: var(--color-borders-hairline);
+    background: var(--color-background-alternative);
+    font-weight: var(--font-weight-bold);
   }
 }
 .disabledItem {
@@ -23,7 +24,7 @@
 
 .checkedItem {
   font-weight: var(--font-weight-bold);
-  background: var(--color-borders-hairline);
+  background: var(--color-background-alternative);
 }
 
 .prefix {


### PR DESCRIPTION
### Summary
This PR improves styling related to `Combobox` and the Search Drawer.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="369" alt="Screen Shot 2021-09-01 at 12 55 01" src="https://user-images.githubusercontent.com/15169499/131619507-366a680c-e0ff-4d6c-82d8-e0f0ab8b6ea9.png">|<img width="369" alt="Screen Shot 2021-09-01 at 12 55 23" src="https://user-images.githubusercontent.com/15169499/131619514-c8da3af8-d914-4d41-89fb-e7f6f53a6839.png">|
|<img width="369" alt="Screen Shot 2021-09-01 at 12 55 11" src="https://user-images.githubusercontent.com/15169499/131619512-17c2b4dc-c0e8-4dde-9560-76893b7cc918.png">|<img width="369" alt="Screen Shot 2021-09-01 at 12 55 40" src="https://user-images.githubusercontent.com/15169499/131619516-ef6f8f82-b29e-4e1b-b1be-6200282ae84d.png">|
|<img width="365" alt="Screen Shot 2021-09-01 at 12 56 36" src="https://user-images.githubusercontent.com/15169499/131619522-1ee5f8bc-4dc8-4117-b776-2a686eae6a85.png">|<img width="364" alt="Screen Shot 2021-09-01 at 12 56 30" src="https://user-images.githubusercontent.com/15169499/131619518-018bd4ed-0f7e-4f6a-9208-f4a02516b54f.png">|
|<img width="268" alt="Screen Shot 2021-09-01 at 12 56 46" src="https://user-images.githubusercontent.com/15169499/131619523-9dcd7a4e-e51e-4397-875f-583e1869b038.png">|<img width="279" alt="Screen Shot 2021-09-01 at 12 56 52" src="https://user-images.githubusercontent.com/15169499/131619525-91ce5db2-d1ae-49a4-b6a0-a222ca78e99e.png">|