### PR TITLE
Audio player beta polish

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -28,8 +28,7 @@
 }
 
 .containerHidden {
-  height: 0;
-  opacity: 0;
+  display: none;
 }
 
 .containerDefault {
@@ -53,6 +52,10 @@
   }
 }
 
+.innerContainerExpanded {
+  margin-top: var(--spacing-micro);
+}
+
 .actionButtonsContainer {
   margin-top: var(--spacing-micro);
   display: flex;
@@ -63,7 +66,7 @@
   }
 }
 .actionButtonsContainerHidden {
-  opacity: 0;
+  display: none;
 }
 
 .seekBackwardsContainer {

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -13,6 +13,7 @@ import {
   selectVisibility,
   setVisibility,
   Visibility,
+  selectReciter,
 } from '../../redux/slices/AudioPlayer/state';
 import MinusTenIcon from '../../../public/icons/minus-ten.svg';
 import UnfoldLessIcon from '../../../public/icons/unfold_less.svg';
@@ -35,7 +36,7 @@ const AudioPlayer = () => {
   const visibility = useSelector(selectVisibility);
   const isHidden = audioFileStatus === AudioFileStatus.NoFile;
   const isLoading = audioFileStatus === AudioFileStatus.Loading;
-
+  const reciterName = useSelector(selectReciter).name;
   const durationInSeconds = audioFile?.duration / 1000 || 0;
 
   const toggleVisibility = () => {
@@ -110,7 +111,11 @@ const AudioPlayer = () => {
         [styles.containerExpanded]: visibility === Visibility.Expanded,
       })}
     >
-      <div className={styles.innerContainer}>
+      <div
+        className={classNames(styles.innerContainer, {
+          [styles.innerContainerExpanded]: visibility === Visibility.Expanded,
+        })}
+      >
         {/* We have to create an inline audio player and hide it due to limitations of how safari requires a play action to trigger: https://stackoverflow.com/questions/31776548/why-cant-javascript-play-audio-files-on-iphone-safari */}
         <audio
           src={audioFile?.audioUrl}
@@ -156,6 +161,7 @@ const AudioPlayer = () => {
             currentTime={currentTime}
             audioDuration={durationInSeconds}
             setTime={triggerSetCurrentTime}
+            reciterName={reciterName}
           />
         </div>
         {/* The div below serves as placeholder for a right section, as well as for centering the slider */}

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -1,6 +1,8 @@
 @use "src/styles/breakpoints";
 @use "src/styles/constants";
 
+$split-height: 2px;
+
 .container {
   text-align: left;
   margin-top: var(--spacing-xxsmall);
@@ -32,7 +34,7 @@
   left: 15%;
   margin: 0 auto;
   width: 65%;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-medium);
   margin-left: var(--spacing-medium);
   margin-right: var(--spacing-medium);
   position: inherit;
@@ -43,7 +45,7 @@
 }
 
 .split {
-  height: 2px;
+  height: $split-height;
   cursor: pointer;
   display: inline-block;
   margin-bottom: calc(1.5 * var(--spacing-micro));

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -18,13 +18,27 @@
   margin: 0;
   width: 100%;
   height: calc(1.25 * var(--spacing-xxsmall));
-
+  transition: var(--transition-regular);
   @include breakpoints.tablet {
     width: 70%;
     position: inherit;
     bottom: inherit;
     margin-left: var(--spacing-medium);
     margin-right: var(--spacing-medium);
+  }
+}
+
+.splitsContainerExpanded {
+  left: 15%;
+  margin: 0 auto;
+  width: 65%;
+  margin-bottom: 1rem;
+  margin-left: var(--spacing-medium);
+  margin-right: var(--spacing-medium);
+  position: inherit;
+
+  @include breakpoints.tablet {
+    width: 70%;
   }
 }
 
@@ -41,18 +55,21 @@
 }
 
 .reciterNameContainer {
+  transition: var(--transition-regular);
   @include breakpoints.tablet {
     display: none;
   }
 }
 
-.currentTime {
+.reciterNameContainerExpanded {
   display: none;
 }
 
-.currentTimeExpanded {
+.currentTime {
   display: none;
-  @include breakpoints.desktop {
-    display: inline-block;
-  }
+  transition: var(--transition-regular);
+}
+
+.currentTimeExpanded {
+  display: inline-block;
 }

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -3,7 +3,6 @@ import { secondsFormatter } from 'src/utils/datetime';
 import _ from 'lodash';
 import classNames from 'classnames';
 import { Visibility } from 'src/redux/slices/AudioPlayer/state';
-import Reciter from 'types/Reciter';
 import styles from './Slider.module.scss';
 
 const NUMBER_OF_SPLITS = 100;
@@ -13,7 +12,7 @@ type SliderProps = {
   audioDuration: number;
   setTime: (number) => void;
   visibility: Visibility;
-  reciterName: Reciter['name'];
+  reciterName: string;
 };
 
 const Split = ({ isComplete, startTime, onClick }: SplitProps) => (

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -3,6 +3,7 @@ import { secondsFormatter } from 'src/utils/datetime';
 import _ from 'lodash';
 import classNames from 'classnames';
 import { Visibility } from 'src/redux/slices/AudioPlayer/state';
+import Reciter from 'types/Reciter';
 import styles from './Slider.module.scss';
 
 const NUMBER_OF_SPLITS = 100;
@@ -12,6 +13,7 @@ type SliderProps = {
   audioDuration: number;
   setTime: (number) => void;
   visibility: Visibility;
+  reciterName: Reciter['name'];
 };
 
 const Split = ({ isComplete, startTime, onClick }: SplitProps) => (
@@ -28,10 +30,11 @@ const Split = ({ isComplete, startTime, onClick }: SplitProps) => (
  * The slider is divided into {NUMBER_OF_SPLITS} splits. These splits represent
  * the audio playback completion and are used for seeking audio at a particular time.
  */
-const Slider = ({ currentTime, audioDuration, setTime, visibility }: SliderProps) => {
+const Slider = ({ currentTime, audioDuration, setTime, visibility, reciterName }: SliderProps) => {
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;
   const isAudioLoaded = audioDuration !== 0; // placeholder check until we're able to retrieve the value from redux
+  const isExpanded = visibility === Visibility.Expanded;
 
   const splits = _.range(0, NUMBER_OF_SPLITS).map((index) => {
     const splitStartTime = splitDuration * index;
@@ -50,14 +53,24 @@ const Slider = ({ currentTime, audioDuration, setTime, visibility }: SliderProps
     <div className={styles.container}>
       <span
         className={classNames(styles.currentTime, {
-          [styles.currentTimeExpanded]: visibility === Visibility.Expanded,
+          [styles.currentTimeExpanded]: isExpanded,
         })}
       >
         {secondsFormatter(currentTime)}
       </span>
-      <div className={classNames(styles.splitsContainer)}>{splits}</div>
-      <div className={styles.reciterNameContainer}>
-        Mishary Al - Affasy <br />
+      <div
+        className={classNames(styles.splitsContainer, {
+          [styles.splitsContainerExpanded]: isExpanded,
+        })}
+      >
+        {splits}
+      </div>
+      <div
+        className={classNames(styles.reciterNameContainer, {
+          [styles.reciterNameContainerExpanded]: isExpanded,
+        })}
+      >
+        {reciterName} <br />
       </div>
       <span className={styles.remainingTime}>{secondsFormatter(remainingTime)}</span>
     </div>


### PR DESCRIPTION
### Summary
* Replace opacity: 0 and visibility: hidden with display: none. This prevents the items from being interactive and from taking height/width in the container.
* Increase the spacing under the expanded audio player controls
* Pull the reciter name instead of using a placeholder value
* Improve the audio player expanded design on mobile. The transition is broken, needs a follow-up.

### Screenshots Mobile

| Before | After |
| ------ | ------ |
| <img width="347" alt="2021-09-01 at 13 41 13@2x" src="https://user-images.githubusercontent.com/11590314/131665351-7b6b3fec-1815-4dc4-87d4-785cf38e2b0e.png"> | <img width="337" alt="2021-09-01 at 13 41 34@2x" src="https://user-images.githubusercontent.com/11590314/131665397-c07d83bd-be84-4246-b1d8-b8cd66a1d572.png">|

### Screenshots Desktop

| Before | After |
| ------ | ------ |
| <img width="867" alt="2021-09-01 at 13 42 26@2x" src="https://user-images.githubusercontent.com/11590314/131665510-15ed70ac-351c-4bf7-ada9-e09f5d35cefa.png">| <img width="873" alt="2021-09-01 at 13 42 06@2x" src="https://user-images.githubusercontent.com/11590314/131665465-de4bfd3f-7cf5-4536-9c97-de9bbc749a88.png"> |
