### PR TITLE
add mobile support for Tooltip

### DIFF
--- a/src/components/dls/Tooltip/Tooltip.stories.tsx
+++ b/src/components/dls/Tooltip/Tooltip.stories.tsx
@@ -71,16 +71,6 @@ export default {
         category: 'Optional',
       },
     },
-    open: {
-      defaultValue: undefined,
-      options: [true, false],
-      control: { type: 'radio' },
-      table: {
-        category: 'Optional',
-      },
-      description:
-        'This is to control the visibility of the overlay programmatically. onOpenChange will be ignored in that case.',
-    },
     tip: {
       defaultValue: true,
       options: [true, false],
@@ -178,13 +168,6 @@ TooltipWithoutTip.args = {
   children: DefaultTrigger,
   text: Text,
   tip: false,
-};
-
-export const ControlledTooltip = Template.bind({});
-ControlledTooltip.args = {
-  children: <p>Hovering away will not close the tooltip</p>,
-  text: Text,
-  open: true,
 };
 
 export const TooltipCollidesWithWindowEdges = Template.bind({});

--- a/src/components/dls/Tooltip/index.tsx
+++ b/src/components/dls/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState, useCallback, useEffect } from 'react';
 import * as RadixTooltip from '@radix-ui/react-tooltip';
 import classNames from 'classnames';
 import styles from './Tooltip.module.scss';
@@ -27,7 +27,6 @@ interface Props {
   text: ReactNode;
   children: ReactNode | ReactNode[];
   onOpenChange?: (open: boolean) => void;
-  open?: boolean;
   contentSide?: ContentSide;
   contentAlign?: ContentAlign;
   avoidCollisions?: boolean;
@@ -42,7 +41,6 @@ const Tooltip: React.FC<Props> = ({
   text,
   children,
   onOpenChange,
-  open,
   type,
   contentSide = ContentSide.BOTTOM,
   contentAlign = ContentAlign.CENTER,
@@ -51,33 +49,54 @@ const Tooltip: React.FC<Props> = ({
   tip = true,
   invertColors = true,
   centerText = true,
-}) => (
-  <RadixTooltip.Root
-    delayDuration={delay}
-    {...(typeof open !== 'undefined' && { open })}
-    {...(onOpenChange && { onOpenChange })}
-  >
-    <RadixTooltip.Trigger aria-label="Open tooltip" className={styles.trigger}>
-      {children}
-    </RadixTooltip.Trigger>
-    <RadixTooltip.Content
-      sideOffset={2}
-      side={contentSide}
-      align={contentAlign}
-      avoidCollisions={avoidCollisions}
-      className={classNames(styles.content, {
-        [styles.noInverse]: invertColors === false,
-        [styles.noCenter]: centerText === false,
-        [styles.success]: type === TooltipType.SUCCESS,
-        [styles.warning]: type === TooltipType.WARNING,
-        [styles.error]: type === TooltipType.ERROR,
-        [styles.secondary]: type === TooltipType.SECONDARY,
-      })}
+}) => {
+  // we need this to handle on trigger click to support mobile devices since the library doesn't support it out of the box.
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleIsOpen = useCallback(() => {
+    setIsOpen((prevIsOpen) => !prevIsOpen);
+  }, []);
+
+  // listen to any changes in isOpen and trigger the onChange callback if it exists.
+  useEffect(() => {
+    if (onOpenChange) {
+      onOpenChange(isOpen);
+    }
+  }, [isOpen, onOpenChange]);
+
+  return (
+    <RadixTooltip.Root
+      delayDuration={delay}
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+      }}
     >
-      {text}
-      {tip && <RadixTooltip.Arrow />}
-    </RadixTooltip.Content>
-  </RadixTooltip.Root>
-);
+      <RadixTooltip.Trigger
+        aria-label="Open tooltip"
+        className={styles.trigger}
+        onClick={toggleIsOpen}
+      >
+        {children}
+      </RadixTooltip.Trigger>
+      <RadixTooltip.Content
+        sideOffset={2}
+        side={contentSide}
+        align={contentAlign}
+        avoidCollisions={avoidCollisions}
+        className={classNames(styles.content, {
+          [styles.noInverse]: invertColors === false,
+          [styles.noCenter]: centerText === false,
+          [styles.success]: type === TooltipType.SUCCESS,
+          [styles.warning]: type === TooltipType.WARNING,
+          [styles.error]: type === TooltipType.ERROR,
+          [styles.secondary]: type === TooltipType.SECONDARY,
+        })}
+      >
+        {text}
+        {tip && <RadixTooltip.Arrow />}
+      </RadixTooltip.Content>
+    </RadixTooltip.Root>
+  );
+};
 
 export default Tooltip;


### PR DESCRIPTION
### Summary
This PR adds mobile support for `Tooltip` component since [Radix UI's `Tooltip`](https://www.radix-ui.com/docs/primitives/components/tooltip) doesn't support that out of the box since they consider that there is no hovering on mobile so no need to do anything. To add it, we needed to make the component always controlled to listen to `onClick` event on the Tooltip's `Trigger`.

### Screenshots

| Before | After |
| ------ | ------ |
||![Image](https://user-images.githubusercontent.com/15169499/131671108-88cc90b0-d12e-47c6-9c1d-de7b43fab391.jpg)|


