### PR TITLE
Add minimum required items and fix infinite loop when clearing tags

### DIFF
--- a/src/components/Navbar/SettingsDrawer/AudioSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/AudioSection.tsx
@@ -48,8 +48,8 @@ const AudioSection = () => {
         <Section.Label>Reciter</Section.Label>
         <div>
           <Combobox
-            clearable={false}
             id="audio-reciter"
+            minimumRequiredItems={1}
             items={items}
             initialInputValue={selectedReciter.name}
             value={selectedReciter.id.toString()}

--- a/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, useSelector } from 'react-redux';
 import { getTafsirs } from 'src/api';
@@ -27,6 +28,11 @@ const TafsirSection = () => {
   const { selectedTafsirs } = useSelector(selectTafsirs) as TafsirsSettings;
   const { lang } = useTranslation();
 
+  const onTafsirsChange = useCallback(
+    (values) => dispatch(setSelectedTafsirs(stringsToNumbersArray(values as string[]))),
+    [dispatch],
+  );
+
   const { data: tafsirs, error } = useSWR(`/tafsirs/${lang}`, () =>
     getTafsirs(lang).then((res) => {
       throwIfError(res);
@@ -48,9 +54,7 @@ const TafsirSection = () => {
             id="tafsir"
             isMultiSelect
             items={items}
-            onChange={(values) =>
-              dispatch(setSelectedTafsirs(stringsToNumbersArray(values as string[])))
-            }
+            onChange={onTafsirsChange}
             value={numbersToStringsArray(selectedTafsirs)}
           />
         </div>

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { getAvailableTranslations } from 'src/api';
@@ -40,6 +41,11 @@ const TranslationSection = () => {
   const { translationFontScale } = quranReaderStyles;
   const { lang } = useTranslation();
 
+  const onTranslationsChange = useCallback(
+    (values) => dispatch(setSelectedTranslations(stringsToNumbersArray(values as string[]))),
+    [dispatch],
+  );
+
   const { data: translations, error } = useSWR(`/translations/${lang}`, () =>
     getAvailableTranslations(lang).then((res) => {
       throwIfError(res);
@@ -65,9 +71,7 @@ const TranslationSection = () => {
             isMultiSelect
             size={ComboboxSize.Medium}
             value={numbersToStringsArray(selectedTranslations)}
-            onChange={(values) =>
-              dispatch(setSelectedTranslations(stringsToNumbersArray(values as string[])))
-            }
+            onChange={onTranslationsChange}
           />
         </div>
       </Section.Row>

--- a/src/components/dls/Forms/Combobox/MultiSelect.stories.tsx
+++ b/src/components/dls/Forms/Combobox/MultiSelect.stories.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-
+import React, { useState, useEffect, useCallback } from 'react';
 import Combobox from './index';
 import SettingIcon from '../../../../../public/icons/settings.svg';
 import SearchIcon from '../../../../../public/icons/search.svg';
@@ -28,7 +27,7 @@ export default {
         category: 'Optional',
       },
       description:
-        'A function that will be called when an item is selected. The function will pass the name of the item selected along with id of the combobox.',
+        'A function that will be called when an item is selected. The function will pass the name of the item selected along with id of the combobox. This should be used with useCallback.',
     },
     initialInputValue: {
       table: {
@@ -96,6 +95,15 @@ export default {
       },
       description: 'Whether the combobox has an error or not.',
     },
+    minimumRequiredItems: {
+      defaultValue: 0,
+      control: { type: 'number' },
+      table: {
+        category: 'Optional',
+      },
+      description:
+        'If above 0 will indicate the minimum number of items that should be present at any give time. This will be useful when controlling the component.',
+    },
     emptyMessage: {
       defaultValue: 'No results',
       control: { type: 'text' },
@@ -134,9 +142,9 @@ const ControlledRemoteTemplate = (args) => {
       setIsLoading(false);
     }, 1000);
   }, []);
-  const onChange = (newSelectedValues: string[]) => {
+  const onChange = useCallback((newSelectedValues: string[]) => {
     setValue(newSelectedValues);
-  };
+  }, []);
   return (
     <Combobox
       {...args}
@@ -151,9 +159,10 @@ const ControlledRemoteTemplate = (args) => {
 // this template will be controlled where the value is a local value and not fetched from a remote datastore.
 const ControlledLocalTemplate = (args) => {
   const [value, setValue] = useState(['Item1', 'Item2', 'Item3', 'Item4']);
-  const onChange = (newSelectedValues: string[]) => {
+
+  const onChange = useCallback((newSelectedValues: string[]) => {
     setValue(newSelectedValues);
-  };
+  }, []);
   return <Combobox {...args} value={value} isMultiSelect onChange={onChange} />;
 };
 
@@ -184,6 +193,13 @@ export const ControlledCombobox = ControlledLocalTemplate.bind({});
 ControlledCombobox.args = {
   id: 'controlled-local-multi-select',
   items: generateItems(),
+};
+
+export const ControlledComboboxWithARequiredValue = ControlledLocalTemplate.bind({});
+ControlledComboboxWithARequiredValue.args = {
+  id: 'controlled-local-multi-select-with-required-value',
+  items: generateItems(),
+  minimumRequiredItems: 4,
 };
 
 export const RemoteControlledCombobox = ControlledRemoteTemplate.bind({});

--- a/src/components/dls/Forms/Combobox/SingleSelect.stories.tsx
+++ b/src/components/dls/Forms/Combobox/SingleSelect.stories.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-
+import React, { useState, useEffect, useCallback } from 'react';
 import Combobox from './index';
 import SettingIcon from '../../../../../public/icons/settings.svg';
 import SearchIcon from '../../../../../public/icons/search.svg';
@@ -28,7 +27,7 @@ export default {
         category: 'Optional',
       },
       description:
-        'A function that will be called when an item is selected. The function will pass the name of the item selected along with id of the combobox.',
+        'A function that will be called when an item is selected. The function will pass the name of the item selected along with id of the combobox. This should be used with useCallback.',
     },
     initialInputValue: {
       table: {
@@ -96,6 +95,15 @@ export default {
       },
       description: 'Whether the combobox has an error or not.',
     },
+    minimumRequiredItems: {
+      defaultValue: 0,
+      control: { type: 'number' },
+      table: {
+        category: 'Optional',
+      },
+      description:
+        'If above 0 will indicate the minimum number of items that should be present at any give time. This will be useful when controlling the component.',
+    },
     emptyMessage: {
       defaultValue: 'No results',
       control: { type: 'text' },
@@ -135,9 +143,9 @@ const ControlledRemoteTemplate = (args) => {
     }, 1000);
   }, []);
 
-  const onChange = (newSelectedValue: string) => {
+  const onChange = useCallback((newSelectedValue: string) => {
     setValue(newSelectedValue);
-  };
+  }, []);
   return (
     <Combobox
       {...args}
@@ -151,9 +159,9 @@ const ControlledRemoteTemplate = (args) => {
 // this template will be controlled where the value is a local value and not fetched from a remote datastore.
 const ControlledLocalTemplate = (args) => {
   const [value, setValue] = useState('Item1');
-  const onChange = (newSelectedValue: string) => {
+  const onChange = useCallback((newSelectedValue: string) => {
     setValue(newSelectedValue);
-  };
+  }, []);
   return <Combobox {...args} value={value} initialInputValue={value} onChange={onChange} />;
 };
 
@@ -184,6 +192,13 @@ export const DefaultControlledCombobox = ControlledLocalTemplate.bind({});
 DefaultControlledCombobox.args = {
   id: 'controlled-local-single-select',
   items: generateItems(),
+};
+
+export const ControlledComboboxWithARequiredValue = ControlledLocalTemplate.bind({});
+ControlledComboboxWithARequiredValue.args = {
+  id: 'controlled-local-single-select-with-required-value',
+  items: generateItems(),
+  minimumRequiredItems: 1,
 };
 
 export const RemoteControlledCombobox = ControlledRemoteTemplate.bind({});


### PR DESCRIPTION
### Summary

This PR:
1. Adds the ability to specify the minimum number of items required which once reached we shouldn't allow un-selecting the item(s). This can work in single and multi select mode. when it's single select, specifying the number to be `1` should be the way to set it. 
2. Fixes the issue of infinite rendering once the Tafsirs/Translations are cleared using backspace key inside the Settings Drawer.
3. Applies the feature added in 1 to the `Reciters` section inside the Settings Drawer which ensures at any given time at least 1 reciter should be selected. 