### PR TITLE
Only show tooltip for words

### DIFF
--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -36,11 +36,15 @@ const QuranWord = ({ word, font, highlight, allowWordByWord = true }: QuranWordP
     wordText = <TextWord font={font} text={word.text} charType={word.charTypeName} />;
   }
 
-  // only show tooltip when it's not the verse number,
-  // when it's allowed to have wbw and when the settings
-  // is set to either translation or transliteration or both.
+  /*
+    Only show the tooltip when the following conditions are met:
+
+    1. When the current character is of type Word.
+    2. When it's allowed to have word by word (won't be allowed for search results as of now).
+    3. When the tooltip settings are set to either translation or transliteration or both.
+  */
   const showTooltip =
-    word.charTypeName !== CharType.End && allowWordByWord && !!showTooltipFor.length;
+    word.charTypeName === CharType.Word && allowWordByWord && !!showTooltipFor.length;
   // will be highlighted either if it's explicitly set to be so or when the tooltip is open.
   const shouldBeHighLighted = highlight || isTooltipOpened;
   return (

--- a/types/Word.ts
+++ b/types/Word.ts
@@ -6,6 +6,7 @@ export enum CharType {
   End = 'end',
   Pause = 'pause',
   Sajdah = 'sajdah',
+  RubElHizb = 'rub-el-hizb',
 }
 
 interface Word {


### PR DESCRIPTION
### Summary
This PR adds the ability to only show the Tooltip when the character is of type `Word` since we have the following types:

|Type|Description|
| ------ | ------ |
|word| The Quranic Word |
|end| The Ayah marker that indicates the number|
|pause| A pause|
|sajdah| A Sajdah|
|rub-el-hizb|To Indicate The start of a Rub of a Hizb|

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="538" alt="Screen Shot 2021-09-04 at 19 22 13" src="https://user-images.githubusercontent.com/15169499/132094268-32da4b67-83b6-4441-a43f-9de3428eb7ba.png">||