### PR TITLE
Improve combobox styling

### DIFF
--- a/src/components/dls/Forms/Combobox/Combobox.module.scss
+++ b/src/components/dls/Forms/Combobox/Combobox.module.scss
@@ -106,13 +106,13 @@
 }
 
 .tagContainer {
-  max-width: 90%;
+  max-width: calc(100% - var(--spacing-xxsmall));
 }
 
 .search {
   position: relative;
   max-width: 100%;
-  width: var(--spacing-medium);
+  width: var(--spacing-xxsmall);
 }
 
 .fullWidth {

--- a/src/components/dls/Forms/Combobox/Combobox.module.scss
+++ b/src/components/dls/Forms/Combobox/Combobox.module.scss
@@ -105,6 +105,10 @@
   max-width: 100%;
 }
 
+.tagContainer {
+  max-width: 90%;
+}
+
 .search {
   position: relative;
   max-width: 100%;

--- a/src/components/dls/Forms/Combobox/Tag/Tag.module.scss
+++ b/src/components/dls/Forms/Combobox/Tag/Tag.module.scss
@@ -2,16 +2,17 @@
   position: relative;
   display: flex;
   flex: none;
+  justify-content: center;
+  align-items: center;
   box-sizing: border-box;
   max-width: 100%;
-  height: var(--spacing-large);
   margin: var(--spacing-micro) 0;
   background: var(--color-background-alternative);
   border-radius: var(--border-radius-default);
   user-select: none;
   margin-inline-end: var(--spacing-xxsmall);
-  padding-inline-end: var(--spacing-xxsmall);
-  padding-inline-start: var(--spacing-xxsmall);
+  padding-inline-end: var(--spacing-xsmall);
+  padding-inline-start: var(--spacing-xsmall);
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -28,6 +29,7 @@
   overflow: hidden;
   white-space: pre;
   text-overflow: ellipsis;
+  padding: var(--spacing-xxsmall);
 }
 
 .itemRemove {

--- a/src/components/dls/Forms/Combobox/index.tsx
+++ b/src/components/dls/Forms/Combobox/index.tsx
@@ -335,7 +335,7 @@ const Combobox: React.FC<Props> = ({
             >
               {isMultiSelect &&
                 tags.map((tag) => (
-                  <div key={tag} className={styles.overflowItem}>
+                  <div key={tag} className={classNames(styles.overflowItem, styles.tagContainer)}>
                     <Tag tag={tag} onRemoveTagClicked={onRemoveTagClicked} size={size} />
                   </div>
                 ))}


### PR DESCRIPTION
### Summary
This PR improves the combobox styling by adding more padding to each tag and also keeps the input in the same line if the input is empty and there are long tags present.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="270" alt="Screen Shot 2021-09-04 at 19 49 46" src="https://user-images.githubusercontent.com/15169499/132094985-72d4b48e-a2d9-4aa8-bd86-f8f355104ef8.png">|<img width="275" alt="Screen Shot 2021-09-04 at 19 49 40" src="https://user-images.githubusercontent.com/15169499/132094984-fcfcd2d9-4bd1-4eeb-9fa5-1892e1b905c9.png">