### PR TITLE
fix box shadow on dark mode

### DIFF
--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -41,11 +41,11 @@
 
   --color-highlight: #f81ce5;
 
-  --shadow-small: 0px 2px 4px rgba(255, 255, 255 0.1);
-  --shadow-normal: 0px 4px 8px rgba(255, 255, 255 0.12);
-  --shadow-large: 0 5px 10px rgba(255, 255, 255 0.12);
-  --shadow-xlarge: 0 8px 30px rgba(255, 255, 255 0.12);
-  --shadow-jumbo: 0 30px 60px rgba(255, 255, 255 0.12);
-  --shadow-hover: 0 30px 60px rgba(255, 255, 255 0.12);
-  --shadow-sticky: 0 12px 10px -10px rgba(255, 255, 255 0.12);
+  --shadow-small: 0px 2px 4px rgba(255, 255, 255, 0.1);
+  --shadow-normal: 0px 4px 8px rgba(255, 255, 255, 0.12);
+  --shadow-large: 0 5px 10px rgba(255, 255, 255, 0.12);
+  --shadow-xlarge: 0 8px 30px rgba(255, 255, 255, 0.12);
+  --shadow-jumbo: 0 30px 60px rgba(255, 255, 255, 0.12);
+  --shadow-hover: 0 30px 60px rgba(255, 255, 255, 0.12);
+  --shadow-sticky: 0 12px 10px -10px rgba(255, 255, 255, 0.12);
 }


### PR DESCRIPTION
TSIA

After 
![image](https://user-images.githubusercontent.com/12745166/132114464-c180343b-b059-4c73-bc60-ec8af090cb8b.png)



But we can improve this
- we probably should illuminate the surface of the popover, instead of using box-shadow 
![image](https://user-images.githubusercontent.com/12745166/132114386-e0eee523-43f0-4033-bb9d-af96a25917c2.png)

![image](https://user-images.githubusercontent.com/12745166/132114397-29446c05-668f-44f7-a3e1-f5d13978164e.png)



## References: 
- https://uxplanet.org/8-tips-for-dark-theme-design-8dfc2f8f7ab6

## Open for discussion:
- shall we introduce token `foreground`, `background`. I think vercel is using this.?
- 
![image](https://user-images.githubusercontent.com/12745166/132114787-cbef3921-3317-4ed9-b067-1a1d2e22be65.png)


## Additional note
- Vercel : Popover is white, on dark theme
![image](https://user-images.githubusercontent.com/12745166/132114836-f616dc56-40fb-4145-9224-3037f071c88d.png)


- Modal have a white-ish border on dark theme, with dark surface.
![image](https://user-images.githubusercontent.com/12745166/132114809-f93df0f4-7783-41e0-a438-51693fcb34f2.png)