### PR TITLE
Disable indexing pages for Beta

### DIFF
--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -28,6 +28,8 @@ export function createSEOConfig({
     title: seoTitle,
     description: setDescription,
     titleTemplate: '%s - Quran.com',
+    dangerouslySetAllPagesToNoFollow: true, // @see https://github.com/garmeeh/next-seo#dangerouslySetAllPagesToNoFollow
+    dangerouslySetAllPagesToNoIndex: true, // @see https://github.com/garmeeh/next-seo#dangerouslySetAllPagesToNoIndex
     openGraph: {
       type: 'website',
       locale: 'en_US', // TODO: (@abdellatif): adjust this based on the next-translate locale

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -16,11 +16,16 @@ type SeoConfigType = {
   canonicalUrl?: string;
 };
 
+interface SEOProps extends NextSeoProps {
+  dangerouslySetAllPagesToNoFollow?: boolean;
+  dangerouslySetAllPagesToNoIndex?: boolean;
+}
+
 export function createSEOConfig({
   title,
   description,
   canonicalUrl,
-}: SeoConfigType = {}): NextSeoProps {
+}: SeoConfigType = {}): SEOProps {
   const seoTitle = title || config.defaultPageTitle;
   const setDescription = description ?? config.siteDescription;
 

--- a/src/vercel.json
+++ b/src/vercel.json
@@ -1,0 +1,8 @@
+{
+    "headers": [
+        {
+            "key": "x-robots-tag",
+            "value": "noindex"
+        }
+    ]
+}


### PR DESCRIPTION
### Summary
This PR disables indexing pages by telling search engine crawlers not to follow or index any page through:

1. Setting the value of `robots` and `googlebot` meta tags to `noindex,nofollow` as per [Google's recommendation](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag) through using `next-seo` [configs](https://github.com/garmeeh/next-seo#dangerouslySetAllPagesToNoFollow).
2. Also by `noindex` as the value of `x-robots-tag` header to Vercel's config file as per Vercel's [recommendation](https://vercel.com/docs/edge-network/headers#x-robots-tag). 

### Screenshots

| Before | After |
| ------ | ------ |
| <img width="457" alt="Screen Shot 2021-09-06 at 13 23 41" src="https://user-images.githubusercontent.com/15169499/132171895-c7b66864-bbf1-4e28-8642-c228e509aff9.png"> | <img width="457" alt="Screen Shot 2021-09-06 at 13 24 06" src="https://user-images.githubusercontent.com/15169499/132171896-b70e7f12-d6b5-413b-aef0-7a3b8114263c.png"> |