### PR TITLE
POC: fix copying text no "space"

### DIFF
--- a/src/components/dls/QuranWord/QuranWord.module.scss
+++ b/src/components/dls/QuranWord/QuranWord.module.scss
@@ -1,5 +1,5 @@
 .container {
-  display: inline-block;
+  display: contents;
 }
 
 .wbwContainer {

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -48,7 +48,7 @@ const QuranWord = ({ word, font, highlight, allowWordByWord = true }: QuranWordP
   // will be highlighted either if it's explicitly set to be so or when the tooltip is open.
   const shouldBeHighLighted = highlight || isTooltipOpened;
   return (
-    <div
+    <span
       className={classNames(styles.container, {
         [styles.highlighted]: shouldBeHighLighted,
         [styles.wbwContainer]: isWordByWordLayout,
@@ -77,7 +77,7 @@ const QuranWord = ({ word, font, highlight, allowWordByWord = true }: QuranWordP
           {showWordByWordTranslation && <p className={styles.wbwText}>{word.translation?.text}</p>}
         </>
       )}
-    </div>
+    </span>
   );
 };
 

--- a/src/components/dls/QuranWord/TextWord.module.scss
+++ b/src/components/dls/QuranWord/TextWord.module.scss
@@ -1,6 +1,7 @@
 .word {
   unicode-bidi: bidi-override;
   line-height: normal;
+  display: contents;
 }
 
 .UthmanicHafs1Ver17 {

--- a/src/components/dls/QuranWord/TextWord.tsx
+++ b/src/components/dls/QuranWord/TextWord.tsx
@@ -31,7 +31,7 @@ const TextWord: React.FC<MadaniWordTextProps> = ({ text, font, charType }) => (
       [styles[INDO_PAK]]: charType !== CharType.End && UTHMANI_HAFS_FONTS[font] === INDO_PAK,
     })}
   >
-    {text}
+    {` ${text} `}
   </span>
 );
 


### PR DESCRIPTION
### Summary

Issue: When copying the, with direction selection. We lost the "space" between words. For example bismillah becomes "بِسۡمِٱللَّهِٱلرَّحۡمَٰنِٱلرَّحِيمِ"

The issue is reproducible with normal alphabet here https://codesandbox.io/s/clever-hoover-5zn28?file=/index.html:0-625

This happens because the children is "blockified". There are multiple things that's causing this
- display: flex -> automatically turns the children into `block`
- and we also use `inline-block` in the children.

This can be solved by using `display: contents` in `flex`'s children

### Side Effects

The effects is there will be some whitespace between quran word

Here's some side by side comparison, before and after this PR

![image](https://user-images.githubusercontent.com/12745166/132218522-7b786dc3-1d75-4b99-884d-547453d27fac.png)

![image](https://user-images.githubusercontent.com/12745166/132218600-b7a477f1-eeb2-449e-8184-647dda7417af.png)


### References
- https://stackoverflow.com/questions/27970957/flexbox-adding-newline-to-clipboard
- https://caniuse.com/css-display-contents#:~:text=display%3A%20contents%20causes%20an%20element's,grid%20or%20similar%20layout%20techniques.

