### PR TITLE
fix: audio player expand transition on mobile

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -84,6 +84,7 @@
     align-items: center;
     justify-content: center;
     margin-top: var(--space-small);
+    margin-left: var(--spacing-medium);
   }
 }
 

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -165,7 +165,6 @@ const AudioPlayer = () => {
             reciterName={reciterName}
           />
         </div>
-        {/* The div below serves as placeholder for a right section, as well as for centering the slider */}
         <div className={styles.rightSection}>
           {visibility === Visibility.Expanded && (
             <Button tooltip="Minimize" shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -17,6 +17,10 @@ $split-height: 2px;
 .containerExpanded {
   flex-direction: row;
   justify-content: space-between;
+  padding-bottom: var(--spacing-xxsmall);
+  @include breakpoints.tablet {
+    padding-bottom: 0;
+  }
 }
 
 .splitsContainer {

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -6,10 +6,18 @@ $split-height: 2px;
 .container {
   text-align: left;
   margin-top: var(--spacing-xxsmall);
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+
   @include breakpoints.tablet {
     text-align: inherit;
-    margin-top: var(--spacing-medium);
+    margin-top: var(--spacing-large);
+    flex-direction: row;
   }
+}
+.containerExpanded {
+  flex-direction: row;
 }
 
 .splitsContainer {
@@ -17,12 +25,13 @@ $split-height: 2px;
   position: fixed;
   bottom: constants.$audio-player-default-height;
   left: 0;
+  right: 0;
   margin: 0;
-  width: 100%;
   height: calc(1.25 * var(--spacing-xxsmall));
   transition: var(--transition-regular);
+  box-sizing: border-box;
   @include breakpoints.tablet {
-    width: 70%;
+    width: 100%;
     position: inherit;
     bottom: inherit;
     margin-left: var(--spacing-medium);
@@ -31,16 +40,17 @@ $split-height: 2px;
 }
 
 .splitsContainerExpanded {
-  left: 15%;
   margin: 0 auto;
-  width: 65%;
-  margin-bottom: var(--spacing-medium);
-  margin-left: var(--spacing-medium);
-  margin-right: var(--spacing-medium);
-  position: inherit;
+  left: 0;
+  right: 0;
+  padding-right: 20%;
+  padding-left: 20%;
+  margin-bottom: var(--spacing-mega);
+  bottom: constants.$audio-player-default-height;
 
   @include breakpoints.tablet {
-    width: 70%;
+    padding-right: 5%;
+    padding-left: 5%;
   }
 }
 

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -2,38 +2,37 @@
 @use "src/styles/constants";
 
 $split-height: 2px;
-$mobile-split-padding: 20%;
-$tablet-split-padding: 5%;
 
 .container {
   text-align: left;
   margin-top: var(--spacing-xxsmall);
   display: flex;
-  justify-content: space-between;
   flex-direction: column;
-
   @include breakpoints.tablet {
+    display: inherit;
     text-align: inherit;
-    margin-top: var(--spacing-large);
-    flex-direction: row;
+    margin-top: var(--spacing-medium);
   }
 }
 .containerExpanded {
   flex-direction: row;
+  justify-content: space-between;
 }
 
 .splitsContainer {
   display: inline-block;
   position: fixed;
   bottom: constants.$audio-player-default-height;
-  left: 0;
-  right: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
   margin: 0;
+  width: 100%;
   height: calc(1.25 * var(--spacing-xxsmall));
   transition: var(--transition-regular);
-  box-sizing: border-box;
   @include breakpoints.tablet {
-    width: 100%;
+    left: 0;
+    transform: none;
+    width: 70%;
     position: inherit;
     bottom: inherit;
     margin-left: var(--spacing-medium);
@@ -42,17 +41,21 @@ $tablet-split-padding: 5%;
 }
 
 .splitsContainerExpanded {
+  left: 50%;
   margin: 0 auto;
-  left: 0;
-  right: 0;
-  padding-right: $mobile-split-padding;
-  padding-left: $mobile-split-padding;
-  margin-bottom: var(--spacing-mega);
-  bottom: constants.$audio-player-default-height;
+  width: 60%;
+  transform: translate(-50%, 0);
+  margin-bottom: var(--spacing-medium);
+  position: fixed;
+  bottom: inherit;
 
   @include breakpoints.tablet {
-    padding-right: $tablet-split-padding;
-    padding-left: $tablet-split-padding;
+    margin-left: var(--spacing-medium);
+    margin-right: var(--spacing-medium);
+    transform: translate(0, 0);
+    position: inherit;
+    width: 70%;
+    position: inherit;
   }
 }
 

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -2,6 +2,8 @@
 @use "src/styles/constants";
 
 $split-height: 2px;
+$mobile-split-padding: 20%;
+$tablet-split-padding: 5%;
 
 .container {
   text-align: left;
@@ -43,14 +45,14 @@ $split-height: 2px;
   margin: 0 auto;
   left: 0;
   right: 0;
-  padding-right: 20%;
-  padding-left: 20%;
+  padding-right: $mobile-split-padding;
+  padding-left: $mobile-split-padding;
   margin-bottom: var(--spacing-mega);
   bottom: constants.$audio-player-default-height;
 
   @include breakpoints.tablet {
-    padding-right: 5%;
-    padding-left: 5%;
+    padding-right: $tablet-split-padding;
+    padding-left: $tablet-split-padding;
   }
 }
 

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -49,7 +49,11 @@ const Slider = ({ currentTime, audioDuration, setTime, visibility, reciterName }
   });
 
   return (
-    <div className={styles.container}>
+    <div
+      className={classNames(styles.container, {
+        [styles.containerExpanded]: isExpanded,
+      })}
+    >
       <span
         className={classNames(styles.currentTime, {
           [styles.currentTimeExpanded]: isExpanded,


### PR DESCRIPTION
### Summary

On mobile, expanding the audio player was a bit clunky.
This PR fixed the issue


On desktop there's still some layout shift, similar to current next.quran.com, created a trello card about it. Will do in another PR