### PR TITLE
add spacing in searchContainer search page

### DIFF
--- a/src/pages/search.module.scss
+++ b/src/pages/search.module.scss
@@ -29,7 +29,7 @@
 .searchInputContainer {
   border: 1px solid var(--color-borders-hairline);
   border-radius: var(--border-radius-pill);
-  padding: var(--spacing-xxsmall);
+  padding: var(--spacing-xxsmall) var(--spacing-xsmall);
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
### Summary

Adding some spacing, need some room to breathe.

Before
![image](https://user-images.githubusercontent.com/12745166/132270283-2f1dbe94-3657-484a-925a-f3af66bb0fd9.png)


After
![image](https://user-images.githubusercontent.com/12745166/132270261-9248c3f8-ae76-4ea9-aa7b-ce3e4f1f8df6.png)


We probably should have an `Input` DLS. Added a trello card about that.
