### PR TITLE
Beta week 1 misc fixes and improvements

### DIFF
--- a/src/components/Navbar/LanguageSelector.tsx
+++ b/src/components/Navbar/LanguageSelector.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import styles from './LanguageSelector.module.scss';
+// import styles from './LanguageSelector.module.scss';
 
-const LanuageSelector = () => <div className={styles.container}>English</div>;
+// <div className={styles.container}>English</div>;
+// placeholder until we support localization.
+const LanuageSelector = () => <></>;
 
 export default LanuageSelector;

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerItem.module.scss
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerItem.module.scss
@@ -31,7 +31,7 @@
   color: inherit;
   cursor: pointer;
   &:hover {
-    color: var(--color-primary-medium);
+    color: var(--color-text-default);
 
     path {
       fill: var(--color-primary-medium);

--- a/src/components/QuranReader/QuranReader.module.scss
+++ b/src/components/QuranReader/QuranReader.module.scss
@@ -39,7 +39,7 @@
     border: none;
     padding: 0;
     font-size: var(--font-size-small);
-    color: var(--color-primary-medium);
+    color: var(--color-text-default);
     cursor: pointer;
   }
 }

--- a/src/components/QuranReader/ReadingView/PageFooter.module.scss
+++ b/src/components/QuranReader/ReadingView/PageFooter.module.scss
@@ -2,7 +2,7 @@
   text-align: center;
   padding: var(--spacing-xxsmall) 0;
   font-size: var(--font-size-small);
-  color: var(--color-primary-medium);
+  color: var(--color-text-default);
   width: fit-content;
   margin: 0 auto;
 }

--- a/src/components/QuranReader/TafsirView/TafsirView.module.scss
+++ b/src/components/QuranReader/TafsirView/TafsirView.module.scss
@@ -11,7 +11,7 @@
   padding-bottom: var(--spacing-xxsmall);
   margin: var(--spacing-xxsmall) 0;
   border-bottom: 1px solid var(--color-primary-medium);
-  color: var(--color-primary-medium);
+  color: var(--color-text-default);
 }
 
 .tafsirContainer {

--- a/src/components/QuranReader/TranslationView/TranslationView.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationView.module.scss
@@ -18,7 +18,7 @@
 }
 
 .translationName {
-  color: var(--color-text-default);
+  color: var(--color-text-faded);
   font-size: var(--font-size-small);
 }
 

--- a/src/components/chapters/ChapterBlock.module.scss
+++ b/src/components/chapters/ChapterBlock.module.scss
@@ -38,7 +38,7 @@
 .number {
   min-width: calc(2 * var(--spacing-large));
   margin: 0;
-  color: var(--color-primary-medium);
+  color: var(--color-text-default);
 }
 
 .detailsContainer {
@@ -49,16 +49,17 @@
 
 .nameArabic {
   font-size: var(--font-size-large);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-default);
 }
 
 .nameTranslated {
   font-size: var(--font-size-small);
-  color: var(--color-primary-medium);
+  color: var(--color-text-faded);
 }
 
 .numberOfVerses {
   text-align: right;
   font-size: var(--font-size-small);
-  color: var(--color-primary-medium);
+  color: var(--color-text-faded);
 }

--- a/src/components/dls/Button/Button.module.scss
+++ b/src/components/dls/Button/Button.module.scss
@@ -17,7 +17,7 @@
   color: var(--color-text-inverse);
   border: 1px solid var(--color-primary-medium);
   &:hover {
-    color: var(--color-primary-medium);
+    color: var(--color-text-default);
     background-color: var(--color-text-inverse);
   }
 }
@@ -110,7 +110,7 @@
   }
 }
 .ghost.primary {
-  color: var(--color-primary-medium);
+  color: var(--color-text-default);
   &:hover {
     background-color: var(--color-primary-medium);
   }

--- a/src/components/dls/Link/Link.module.scss
+++ b/src/components/dls/Link/Link.module.scss
@@ -10,7 +10,7 @@
   }
 }
 .primary {
-  color: var(--color-primary-medium);
+  color: var(--color-text-default);
   &:hover {
     text-decoration: underline;
   }
@@ -18,7 +18,7 @@
 .secondary {
   color: var(--color-text-faded);
   &:hover {
-    color: var(--color-primary-medium);
+    color: var(--color-text-default);
   }
 }
 .blend {

--- a/src/redux/slices/AudioPlayer/persistConfig.ts
+++ b/src/redux/slices/AudioPlayer/persistConfig.ts
@@ -4,7 +4,7 @@ const audioPlayerPersistConfig = {
   key: 'audioPlayerState',
   storage,
   version: 1,
-  blacklist: ['isPlaying'],
+  blacklist: ['isPlaying', 'visibility'],
 };
 
 export default audioPlayerPersistConfig;

--- a/src/styles/themes/_light.scss
+++ b/src/styles/themes/_light.scss
@@ -24,7 +24,7 @@
   --color-warning-medium: #f5a623;
   --color-warning-deep: #ab570a;
 
-  --color-text-default: #000;
+  --color-text-default: #272727;
   --color-text-faded: #666;
   --color-text-inverse: #fff;
   --color-text-link: #0070f3;


### PR DESCRIPTION
### Summary
* Hide the language selector until we have support for localization. Was confusing users why we have the word "English" in the navbar.
* Replace all usage of `color: var(--color-primary-medium);` with `color: var(--color-text-default);`. both initially had a value of `#000` but the later is the one intended for text colors (see the next point).
* Reduce the text color and background contrast. Changed `#000` with `#272727`
* Add hierarchy to the home page surah cards by introducing boldness and fading secondary titles.
* Make the translation name text-faded as the information is intended to be secondary. 
* Blacklist the audio player visibility state in redux persist. It was a non-optimal experience when a user opens the site and the audio player is expanded
