### PR TITLE
Hide Navbar and minize audio player on scroll

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -39,10 +39,16 @@
   height: constants.$audio-player-expanded-height;
 }
 
-.containerMinimized {
-  height: var(--spacing-mega);
+.containerMinimized.containerExpanded {
+  height: constants.$audio-player-minimized-height;
   @include breakpoints.tablet {
     height: constants.$audio-player-expanded-height;
+  }
+}
+.containerMinimized.containerDefault {
+  height: constants.$audio-player-minimized-height;
+  @include breakpoints.tablet {
+    height: constants.$audio-player-default-height;
   }
 }
 
@@ -70,6 +76,13 @@
 
   @include breakpoints.tablet {
     flex-direction: inherit;
+  }
+
+  &.defaultAndMinimized {
+    display: none;
+    @include breakpoints.tablet {
+      display: flex;
+    }
   }
 }
 .actionButtonsContainerHidden {

--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -39,6 +39,13 @@
   height: constants.$audio-player-expanded-height;
 }
 
+.containerMinimized {
+  height: var(--spacing-mega);
+  @include breakpoints.tablet {
+    height: constants.$audio-player-expanded-height;
+  }
+}
+
 .innerContainer {
   @include utility.center-horizontally;
   display: flex;

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { withStopPropagation } from 'src/utils/event';
+import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
 import {
   setIsPlaying,
   selectAudioPlayerState,
@@ -39,6 +40,19 @@ const AudioPlayer = () => {
   const isLoading = audioFileStatus === AudioFileStatus.Loading;
   const reciterName = useSelector(selectReciter).name;
   const durationInSeconds = audioFile?.duration / 1000 || 0;
+  const isExpanded = visibility === Visibility.Expanded || visibility === Visibility.Minimized;
+
+  const onDirectionChange = useCallback(
+    (direction: ScrollDirection) => {
+      if (direction === ScrollDirection.Down && visibility === Visibility.Expanded) {
+        dispatch({ type: setVisibility.type, payload: Visibility.Minimized });
+      } else if (direction === ScrollDirection.Up && visibility !== Visibility.Default) {
+        dispatch({ type: setVisibility.type, payload: Visibility.Default });
+      }
+    },
+    [dispatch, visibility],
+  );
+  useScrollDirection(onDirectionChange);
 
   const toggleVisibility = () => {
     const nextValue = visibility === Visibility.Default ? Visibility.Expanded : Visibility.Default;
@@ -110,6 +124,7 @@ const AudioPlayer = () => {
         [styles.containerHidden]: isHidden,
         [styles.containerDefault]: visibility === Visibility.Default,
         [styles.containerExpanded]: visibility === Visibility.Expanded,
+        [styles.containerMinimized]: visibility === Visibility.Minimized,
       })}
     >
       <div
@@ -140,7 +155,7 @@ const AudioPlayer = () => {
         />
         <div
           className={classNames(styles.actionButtonsContainer, {
-            [styles.actionButtonsContainerHidden]: visibility === Visibility.Expanded,
+            [styles.actionButtonsContainerHidden]: isExpanded,
           })}
         >
           <div className={styles.mobileCloseButtonContainer}>
@@ -170,7 +185,7 @@ const AudioPlayer = () => {
           />
         </div>
         <div className={styles.desktopRightActions}>
-          {visibility === Visibility.Expanded && (
+          {isExpanded && (
             <Button tooltip="Minimize" shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>
               <UnfoldLessIcon />
             </Button>
@@ -183,7 +198,7 @@ const AudioPlayer = () => {
           <CloseButton />
         </div>
       </div>
-      {visibility === Visibility.Expanded && <PlaybackControls />}
+      {isExpanded && <PlaybackControls />}
     </div>
   );
 };

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -11,12 +11,11 @@ import {
   selectAudioFileStatus,
   setAudioStatus,
   AudioFileStatus,
-  setVisibility,
-  Visibility,
   selectReciter,
-  setIsMinimized,
-  selectVisibility,
-  selectIsMinimized,
+  setIsMobileMinimizedForScrolling,
+  setIsExpanded,
+  selectIsExpanded,
+  selectIsMobileMinimizedForScrolling,
 } from 'src/redux/slices/AudioPlayer/state';
 import MinusTenIcon from '../../../public/icons/minus-ten.svg';
 import UnfoldLessIcon from '../../../public/icons/unfold_less.svg';
@@ -41,26 +40,22 @@ const AudioPlayer = () => {
   const isLoading = audioFileStatus === AudioFileStatus.Loading;
   const reciterName = useSelector(selectReciter).name;
   const durationInSeconds = audioFile?.duration / 1000 || 0;
-  const visibility = useSelector(selectVisibility);
-  const isMinimized = useSelector(selectIsMinimized);
-  const isExpanded = visibility === Visibility.Expanded;
-  const isDefault = visibility === Visibility.Default;
-  const isDefaultAndMinimized = isMinimized && isDefault;
+  const isExpanded = useSelector(selectIsExpanded);
+  const isMobileMinimizedForScrolling = useSelector(selectIsMobileMinimizedForScrolling);
   const onDirectionChange = useCallback(
     (direction: ScrollDirection) => {
-      if (direction === ScrollDirection.Down && !isMinimized) {
-        dispatch({ type: setIsMinimized.type, payload: true });
-      } else if (direction === ScrollDirection.Up && isMinimized) {
-        dispatch({ type: setIsMinimized.type, payload: false });
+      if (direction === ScrollDirection.Down && !isMobileMinimizedForScrolling) {
+        dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: true });
+      } else if (direction === ScrollDirection.Up && isMobileMinimizedForScrolling) {
+        dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: false });
       }
     },
-    [dispatch, isMinimized],
+    [dispatch, isMobileMinimizedForScrolling],
   );
   useScrollDirection(onDirectionChange);
 
-  const toggleVisibility = () => {
-    const nextValue = visibility === Visibility.Default ? Visibility.Expanded : Visibility.Default;
-    dispatch({ type: setVisibility.type, payload: nextValue });
+  const toggleIsExpanded = () => {
+    dispatch({ type: setIsExpanded.type, payload: !isExpanded });
   };
 
   const onAudioPlay = useCallback(() => {
@@ -122,13 +117,13 @@ const AudioPlayer = () => {
     <div
       role="button"
       tabIndex={0}
-      onClick={toggleVisibility}
-      onKeyPress={toggleVisibility}
+      onClick={toggleIsExpanded}
+      onKeyPress={toggleIsExpanded}
       className={classNames(styles.container, {
         [styles.containerHidden]: isHidden,
-        [styles.containerDefault]: visibility === Visibility.Default,
-        [styles.containerExpanded]: visibility === Visibility.Expanded,
-        [styles.containerMinimized]: isMinimized,
+        [styles.containerDefault]: !isExpanded,
+        [styles.containerExpanded]: isExpanded,
+        [styles.containerMinimized]: isMobileMinimizedForScrolling,
       })}
     >
       <div
@@ -160,7 +155,7 @@ const AudioPlayer = () => {
         <div
           className={classNames(styles.actionButtonsContainer, {
             [styles.actionButtonsContainerHidden]: isExpanded,
-            [styles.defaultAndMinimized]: isDefaultAndMinimized,
+            [styles.defaultAndMinimized]: isMobileMinimizedForScrolling && !isExpanded,
           })}
         >
           <div className={styles.mobileCloseButtonContainer}>
@@ -182,8 +177,8 @@ const AudioPlayer = () => {
         </div>
         <div className={styles.sliderContainer}>
           <Slider
-            isMinimized={isMinimized}
-            visibility={visibility}
+            isMobileMinimizedForScrolling={isMobileMinimizedForScrolling}
+            isExpanded={isExpanded}
             currentTime={currentTime}
             audioDuration={durationInSeconds}
             setTime={triggerSetCurrentTime}
@@ -191,12 +186,11 @@ const AudioPlayer = () => {
           />
         </div>
         <div className={styles.desktopRightActions}>
-          {isExpanded && (
+          {isExpanded ? (
             <Button tooltip="Minimize" shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>
               <UnfoldLessIcon />
             </Button>
-          )}
-          {visibility === Visibility.Default && (
+          ) : (
             <Button tooltip="Expand" variant={ButtonVariant.Ghost} shape={ButtonShape.Circle}>
               <UnfoldMoreIcon />
             </Button>

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -23,6 +23,15 @@ $split-height: 2px;
   }
 }
 
+.containerMinimized {
+  flex-direction: row;
+  justify-content: space-between;
+  padding-bottom: var(--spacing-xxsmall);
+  @include breakpoints.tablet {
+    padding-bottom: 0;
+  }
+}
+
 .splitsContainer {
   display: inline-block;
   position: fixed;
@@ -41,6 +50,24 @@ $split-height: 2px;
     bottom: inherit;
     margin-left: var(--spacing-medium);
     margin-right: var(--spacing-medium);
+  }
+}
+
+.splitsContainerMinimized {
+  left: 50%;
+  margin: 0 auto;
+  width: 100%;
+  transform: translate(-50%, 0);
+  position: fixed;
+  bottom: constants.$audio-player-minimized-height;
+  @include breakpoints.tablet {
+    bottom: inherit;
+    margin-left: var(--spacing-medium);
+    margin-right: var(--spacing-medium);
+    transform: translate(0, 0);
+    position: inherit;
+    width: 70%;
+    position: inherit;
   }
 }
 
@@ -83,6 +110,10 @@ $split-height: 2px;
 }
 
 .reciterNameContainerExpanded {
+  display: none;
+}
+
+.reciterNameContainerMinimized {
   display: none;
 }
 

--- a/src/components/AudioPlayer/Slider.module.scss
+++ b/src/components/AudioPlayer/Slider.module.scss
@@ -91,6 +91,13 @@ $split-height: 2px;
   transition: var(--transition-regular);
 }
 
+.defaultAndMinimized {
+  display: inline-block;
+  @include breakpoints.tablet {
+    display: none;
+  }
+}
+
 .currentTimeExpanded {
   display: inline-block;
 }

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -33,7 +33,7 @@ const Slider = ({ currentTime, audioDuration, setTime, visibility, reciterName }
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;
   const isAudioLoaded = audioDuration !== 0; // placeholder check until we're able to retrieve the value from redux
-  const isExpanded = visibility === Visibility.Expanded;
+  const isExpanded = visibility === Visibility.Expanded || visibility === Visibility.Minimized;
 
   const splits = _.range(0, NUMBER_OF_SPLITS).map((index) => {
     const splitStartTime = splitDuration * index;

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -13,6 +13,7 @@ type SliderProps = {
   setTime: (number) => void;
   visibility: Visibility;
   reciterName: string;
+  isMinimized: boolean;
 };
 
 const Split = ({ isComplete, startTime, onClick }: SplitProps) => (
@@ -29,11 +30,19 @@ const Split = ({ isComplete, startTime, onClick }: SplitProps) => (
  * The slider is divided into {NUMBER_OF_SPLITS} splits. These splits represent
  * the audio playback completion and are used for seeking audio at a particular time.
  */
-const Slider = ({ currentTime, audioDuration, setTime, visibility, reciterName }: SliderProps) => {
+const Slider = ({
+  currentTime,
+  audioDuration,
+  setTime,
+  visibility,
+  reciterName,
+  isMinimized,
+}: SliderProps) => {
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;
   const isAudioLoaded = audioDuration !== 0; // placeholder check until we're able to retrieve the value from redux
-  const isExpanded = visibility === Visibility.Expanded || visibility === Visibility.Minimized;
+  const isExpanded = visibility === Visibility.Expanded || isMinimized;
+  const isDefaultAndMinimized = isMinimized && visibility === Visibility.Default;
 
   const splits = _.range(0, NUMBER_OF_SPLITS).map((index) => {
     const splitStartTime = splitDuration * index;
@@ -56,7 +65,8 @@ const Slider = ({ currentTime, audioDuration, setTime, visibility, reciterName }
     >
       <span
         className={classNames(styles.currentTime, {
-          [styles.currentTimeExpanded]: isExpanded,
+          [styles.currentTimeExpanded]: visibility === Visibility.Expanded,
+          [styles.defaultAndMinimized]: isDefaultAndMinimized,
         })}
       >
         {secondsFormatter(currentTime)}

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { secondsFormatter } from 'src/utils/datetime';
 import _ from 'lodash';
 import classNames from 'classnames';
-import { Visibility } from 'src/redux/slices/AudioPlayer/state';
 import styles from './Slider.module.scss';
 
 const NUMBER_OF_SPLITS = 100;
@@ -11,9 +10,9 @@ type SliderProps = {
   currentTime: number;
   audioDuration: number;
   setTime: (number) => void;
-  visibility: Visibility;
+  isExpanded: boolean;
   reciterName: string;
-  isMinimized: boolean;
+  isMobileMinimizedForScrolling: boolean;
 };
 
 const Split = ({ isComplete, startTime, onClick }: SplitProps) => (
@@ -34,15 +33,13 @@ const Slider = ({
   currentTime,
   audioDuration,
   setTime,
-  visibility,
+  isExpanded,
   reciterName,
-  isMinimized,
+  isMobileMinimizedForScrolling,
 }: SliderProps) => {
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;
   const isAudioLoaded = audioDuration !== 0; // placeholder check until we're able to retrieve the value from redux
-  const isExpanded = visibility === Visibility.Expanded || isMinimized;
-  const isDefaultAndMinimized = isMinimized && visibility === Visibility.Default;
 
   const splits = _.range(0, NUMBER_OF_SPLITS).map((index) => {
     const splitStartTime = splitDuration * index;
@@ -61,12 +58,13 @@ const Slider = ({
     <div
       className={classNames(styles.container, {
         [styles.containerExpanded]: isExpanded,
+        [styles.containerMinimized]: isMobileMinimizedForScrolling,
       })}
     >
       <span
         className={classNames(styles.currentTime, {
-          [styles.currentTimeExpanded]: visibility === Visibility.Expanded,
-          [styles.defaultAndMinimized]: isDefaultAndMinimized,
+          [styles.currentTimeExpanded]: isExpanded,
+          [styles.defaultAndMinimized]: isMobileMinimizedForScrolling && !isExpanded,
         })}
       >
         {secondsFormatter(currentTime)}
@@ -74,6 +72,7 @@ const Slider = ({
       <div
         className={classNames(styles.splitsContainer, {
           [styles.splitsContainerExpanded]: isExpanded,
+          [styles.splitsContainerMinimized]: isMobileMinimizedForScrolling,
         })}
       >
         {splits}
@@ -81,6 +80,7 @@ const Slider = ({
       <div
         className={classNames(styles.reciterNameContainer, {
           [styles.reciterNameContainerExpanded]: isExpanded,
+          [styles.reciterNameContainerMinimized]: isMobileMinimizedForScrolling,
         })}
       >
         {reciterName} <br />

--- a/src/components/DeveloperUtility/AudioPlayerAdjustment.tsx
+++ b/src/components/DeveloperUtility/AudioPlayerAdjustment.tsx
@@ -1,27 +1,21 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { selectVisibility, setVisibility, Visibility } from 'src/redux/slices/AudioPlayer/state';
+import { selectIsExpanded, setIsExpanded } from 'src/redux/slices/AudioPlayer/state';
 
-const options = [Visibility.Default, Visibility.Expanded];
 const AudioPlayerAdjustment = () => {
   const dispatch = useDispatch();
-  const visibility = useSelector(selectVisibility);
+  const isExpanded = useSelector(selectIsExpanded);
 
   return (
-    <label htmlFor="audio-player-is-minimized">
-      Audio player visibility
-      <select
-        name="audio-player-is-minimized"
-        onChange={(event) => dispatch({ type: setVisibility.type, payload: event.target.value })}
-        value={visibility}
+    <div>
+      Audio player{' '}
+      <button
+        type="button"
+        onClick={() => dispatch({ type: setIsExpanded.type, payload: !isExpanded })}
       >
-        {options.map((value) => (
-          <option key={value} value={value}>
-            {value}
-          </option>
-        ))}
-      </select>
-    </label>
+        Toggle Expansion
+      </button>
+    </div>
   );
 };
 

--- a/src/components/DeveloperUtility/AudioPlayerAdjustment.tsx
+++ b/src/components/DeveloperUtility/AudioPlayerAdjustment.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectVisibility, setVisibility, Visibility } from 'src/redux/slices/AudioPlayer/state';
 
+const options = [Visibility.Default, Visibility.Expanded];
 const AudioPlayerAdjustment = () => {
   const dispatch = useDispatch();
-  const isMinimized = useSelector(selectVisibility);
-  const options = [Visibility.Default, Visibility.Expanded, Visibility.Minimized];
+  const visibility = useSelector(selectVisibility);
 
   return (
     <label htmlFor="audio-player-is-minimized">
-      Audio player isMinimized
+      Audio player visibility
       <select
         name="audio-player-is-minimized"
         onChange={(event) => dispatch({ type: setVisibility.type, payload: event.target.value })}
-        value={isMinimized}
+        value={visibility}
       >
         {options.map((value) => (
           <option key={value} value={value}>

--- a/src/components/FeedbackWidget/FeedbackWidget.module.scss
+++ b/src/components/FeedbackWidget/FeedbackWidget.module.scss
@@ -11,6 +11,20 @@
     display: inherit;
     right: calc(var(--spacing-mega) + var(--spacing-medium));
   }
+  &.isMinimized {
+    margin-bottom: constants.$audio-player-minimized-height;
+    bottom: var(--spacing-medium);
+  }
+  &.isMinimized.audioPlayerOpen {
+    @include breakpoints.tablet {
+      margin-bottom: constants.$audio-player-default-height;
+    }
+  }
+  &.isMinimized.audioPlayerExpanded {
+    @include breakpoints.tablet {
+      margin-bottom: constants.$audio-player-expanded-height;
+    }
+  }
 }
 
 .audioPlayerOpen {

--- a/src/components/FeedbackWidget/FeedbackWidget.module.scss
+++ b/src/components/FeedbackWidget/FeedbackWidget.module.scss
@@ -11,16 +11,16 @@
     display: inherit;
     right: calc(var(--spacing-mega) + var(--spacing-medium));
   }
-  &.isMinimized {
+  &.isMobileMinimizedForScrolling {
     margin-bottom: constants.$audio-player-minimized-height;
     bottom: var(--spacing-medium);
   }
-  &.isMinimized.audioPlayerOpen {
+  &.isMobileMinimizedForScrolling.audioPlayerOpen {
     @include breakpoints.tablet {
       margin-bottom: constants.$audio-player-default-height;
     }
   }
-  &.isMinimized.audioPlayerExpanded {
+  &.isMobileMinimizedForScrolling.audioPlayerExpanded {
     @include breakpoints.tablet {
       margin-bottom: constants.$audio-player-expanded-height;
     }

--- a/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -4,26 +4,25 @@ import { useSelector } from 'react-redux';
 import {
   AudioFileStatus,
   selectAudioFileStatus,
-  selectIsMinimized,
-  selectVisibility,
-  Visibility,
+  selectIsMobileMinimizedForScrolling,
+  selectIsExpanded,
 } from 'src/redux/slices/AudioPlayer/state';
 import Button from '../dls/Button/Button';
 import Link from '../dls/Link/Link';
 import styles from './FeedbackWidget.module.scss';
 
 const FeedbackWidget = () => {
-  const audioPlayerVisibility = useSelector(selectVisibility);
+  const audioPlayerIsExpanded = useSelector(selectIsExpanded);
   const audioFileStatus = useSelector(selectAudioFileStatus);
-  const isMinimized = useSelector(selectIsMinimized);
+  const isMobileMinimizedForScrolling = useSelector(selectIsMobileMinimizedForScrolling);
   const isHidden = audioFileStatus === AudioFileStatus.NoFile;
-  const isAudioPlayerOpen = !isHidden && audioPlayerVisibility === Visibility.Default;
-  const isAudioPlayerExpanded = !isHidden && audioPlayerVisibility === Visibility.Expanded;
+  const isAudioPlayerOpen = !isHidden && !audioPlayerIsExpanded;
+  const isAudioPlayerExpanded = !isHidden && audioPlayerIsExpanded;
 
   return (
     <div
       className={classNames(styles.container, {
-        [styles.isMinimized]: isMinimized,
+        [styles.isMobileMinimizedForScrolling]: isMobileMinimizedForScrolling,
         [styles.audioPlayerOpen]: isAudioPlayerOpen,
         [styles.audioPlayerExpanded]: isAudioPlayerExpanded,
       })}

--- a/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import {
   AudioFileStatus,
   selectAudioFileStatus,
+  selectIsMinimized,
   selectVisibility,
   Visibility,
 } from 'src/redux/slices/AudioPlayer/state';
@@ -14,14 +15,15 @@ import styles from './FeedbackWidget.module.scss';
 const FeedbackWidget = () => {
   const audioPlayerVisibility = useSelector(selectVisibility);
   const audioFileStatus = useSelector(selectAudioFileStatus);
+  const isMinimized = useSelector(selectIsMinimized);
   const isHidden = audioFileStatus === AudioFileStatus.NoFile;
-
   const isAudioPlayerOpen = !isHidden && audioPlayerVisibility === Visibility.Default;
   const isAudioPlayerExpanded = !isHidden && audioPlayerVisibility === Visibility.Expanded;
 
   return (
     <div
       className={classNames(styles.container, {
+        [styles.isMinimized]: isMinimized,
         [styles.audioPlayerOpen]: isAudioPlayerOpen,
         [styles.audioPlayerExpanded]: isAudioPlayerExpanded,
       })}

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -14,6 +14,9 @@
 
 .styledNavHidden {
   transform: translateY(0 - constants.$navbar-height);
+  @include breakpoints.tablet {
+    transform: none;
+  }
 }
 
 .itemsContainer {

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   selectNavbar,
   setIsSearchDrawerOpen,
   setIsNavigationDrawerOpen,
   setIsSettingsDrawerOpen,
+  setIsVisible,
 } from 'src/redux/slices/navbar';
 import Link from 'next/link';
 import classNames from 'classnames';
+import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
 import Button, { ButtonShape, ButtonVariant } from '../dls/Button/Button';
 import LanguageSelector from './LanguageSelector';
 import IconSettings from '../../../public/icons/settings.svg';
@@ -21,8 +23,19 @@ import SettingsDrawer from './SettingsDrawer/SettingsDrawer';
 
 const Navbar = () => {
   const { isVisible } = useSelector(selectNavbar);
-
   const dispatch = useDispatch();
+
+  const onDirectionChange = useCallback(
+    (direction: ScrollDirection) => {
+      if (direction === ScrollDirection.Up && !isVisible) {
+        dispatch({ type: setIsVisible.type, payload: true });
+      } else if (direction === ScrollDirection.Down && isVisible) {
+        dispatch({ type: setIsVisible.type, payload: false });
+      }
+    },
+    [dispatch, isVisible],
+  );
+  useScrollDirection(onDirectionChange);
 
   const openNavigationDrawer = () => {
     dispatch({ type: setIsNavigationDrawerOpen.type, payload: true });
@@ -38,59 +51,57 @@ const Navbar = () => {
 
   return (
     <nav className={classNames(styles.styledNav, { [styles.styledNavHidden]: !isVisible })}>
-      {isVisible && (
-        <div className={styles.itemsContainer}>
-          <div className={styles.centerVertically}>
-            <div className={styles.leftCTA}>
-              <>
-                <Button
-                  tooltip="Menu"
-                  variant={ButtonVariant.Ghost}
-                  shape={ButtonShape.Circle}
-                  onClick={openNavigationDrawer}
-                >
-                  <IconMenu />
+      <div className={styles.itemsContainer}>
+        <div className={styles.centerVertically}>
+          <div className={styles.leftCTA}>
+            <>
+              <Button
+                tooltip="Menu"
+                variant={ButtonVariant.Ghost}
+                shape={ButtonShape.Circle}
+                onClick={openNavigationDrawer}
+              >
+                <IconMenu />
+              </Button>
+              <NavigationDrawer />
+            </>
+            <Link href="/">
+              <a>
+                <Button shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>
+                  <IconQ />
                 </Button>
-                <NavigationDrawer />
-              </>
-              <Link href="/">
-                <a>
-                  <Button shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>
-                    <IconQ />
-                  </Button>
-                </a>
-              </Link>
-              <LanguageSelector />
-            </div>
-          </div>
-          <div className={styles.centerVertically}>
-            <div className={styles.rightCTA}>
-              <>
-                <Button
-                  tooltip="Settings"
-                  shape={ButtonShape.Circle}
-                  variant={ButtonVariant.Ghost}
-                  onClick={openSettingsDrawer}
-                >
-                  <IconSettings />
-                </Button>
-                <SettingsDrawer />
-              </>
-              <>
-                <Button
-                  tooltip="Search"
-                  variant={ButtonVariant.Ghost}
-                  onClick={openSearchDrawer}
-                  shape={ButtonShape.Circle}
-                >
-                  <IconSearch />
-                </Button>
-                <SearchDrawer />
-              </>
-            </div>
+              </a>
+            </Link>
+            <LanguageSelector />
           </div>
         </div>
-      )}
+        <div className={styles.centerVertically}>
+          <div className={styles.rightCTA}>
+            <>
+              <Button
+                tooltip="Settings"
+                shape={ButtonShape.Circle}
+                variant={ButtonVariant.Ghost}
+                onClick={openSettingsDrawer}
+              >
+                <IconSettings />
+              </Button>
+              <SettingsDrawer />
+            </>
+            <>
+              <Button
+                tooltip="Search"
+                variant={ButtonVariant.Ghost}
+                onClick={openSearchDrawer}
+                shape={ButtonShape.Circle}
+              >
+                <IconSearch />
+              </Button>
+              <SearchDrawer />
+            </>
+          </div>
+        </div>
+      </div>
     </nav>
   );
 };

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -11,6 +11,7 @@
   top: 0;
   height: var(--spacing-medium);
   @include breakpoints.tablet {
+    top: constants.$navbar-height;
     transition: var(--transition-regular);
     margin-right: 0;
   }

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1,9 +1,11 @@
 export default {
-  2: (state) => ({
+  3: (state) => ({
     ...state,
     audioPlayerState: {
       ...state.audioPlayerState,
-      isMinimized: false,
+      visibility: undefined,
+      isExpanded: false,
+      isMobileMinimizedForScrolling: false,
     },
   }),
 };

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1,16 +1,9 @@
 export default {
-  1: (state) => ({
-    ...state,
-    audioPlayerState: {
-      ...state.audioPlayerState,
-      isMinimized: false,
-    },
-  }),
   2: (state) => ({
     ...state,
     audioPlayerState: {
       ...state.audioPlayerState,
-      isMinimized: state.audioPlayerState.isMinimized,
+      isMinimized: false,
     },
   }),
 };

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1,0 +1,16 @@
+export default {
+  1: (state) => ({
+    ...state,
+    audioPlayerState: {
+      ...state.audioPlayerState,
+      isMinimized: false,
+    },
+  }),
+  2: (state) => ({
+    ...state,
+    audioPlayerState: {
+      ...state.audioPlayerState,
+      isMinimized: state.audioPlayerState.isMinimized,
+    },
+  }),
+};

--- a/src/redux/slices/AudioPlayer/persistConfig.ts
+++ b/src/redux/slices/AudioPlayer/persistConfig.ts
@@ -3,8 +3,8 @@ import storage from 'redux-persist/lib/storage';
 const audioPlayerPersistConfig = {
   key: 'audioPlayerState',
   storage,
-  version: 1,
-  blacklist: ['isPlaying', 'visibility'],
+  version: 2,
+  blacklist: ['isPlaying', 'visibility', 'isMinimized'],
 };
 
 export default audioPlayerPersistConfig;

--- a/src/redux/slices/AudioPlayer/persistConfig.ts
+++ b/src/redux/slices/AudioPlayer/persistConfig.ts
@@ -3,8 +3,8 @@ import storage from 'redux-persist/lib/storage';
 const audioPlayerPersistConfig = {
   key: 'audioPlayerState',
   storage,
-  version: 2,
-  blacklist: ['isPlaying', 'visibility', 'isMinimized'],
+  version: 3,
+  blacklist: ['isPlaying', 'isExpanded', 'isMobileMinimizedForScrolling'],
 };
 
 export default audioPlayerPersistConfig;

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -12,19 +12,14 @@ export enum AudioFileStatus {
   NoFile = 'NoFile',
 }
 
-export enum Visibility {
-  Default = 'Default',
-  Expanded = 'Expanded',
-}
-
 export type AudioState = {
   isPlaying: boolean;
   currentTime: number;
   reciter: Reciter;
   audioFile: AudioFile;
   audioFileStatus: AudioFileStatus;
-  visibility: Visibility;
-  isMinimized: boolean;
+  isExpanded: boolean;
+  isMobileMinimizedForScrolling: boolean;
 };
 
 const initialState: AudioState = {
@@ -33,8 +28,8 @@ const initialState: AudioState = {
   audioFile: null,
   reciter: DEFAULT_RECITER,
   audioFileStatus: AudioFileStatus.NoFile,
-  visibility: Visibility.Default,
-  isMinimized: false,
+  isExpanded: false,
+  isMobileMinimizedForScrolling: false,
 };
 
 export const selectAudioPlayerState = (state) => state.audioPlayerState as AudioState;
@@ -44,8 +39,9 @@ export const selectIsUsingDefaultReciter = (state) =>
 export const selectAudioFile = (state) => state.audioPlayerState.audioFile as AudioFile;
 export const selectAudioFileStatus = (state) => state.audioPlayerState.audioFileStatus;
 export const selectIsPlaying = (state) => state.audioPlayerState.isPlaying;
-export const selectVisibility = (state) => state.audioPlayerState.visibility as Visibility;
-export const selectIsMinimized = (state) => state.audioPlayerState.isMinimized as boolean;
+export const selectIsExpanded = (state) => state.audioPlayerState.isExpanded as boolean;
+export const selectIsMobileMinimizedForScrolling = (state) =>
+  state.audioPlayerState.isMobileMinimizedForScrolling as boolean;
 
 /**
  * get the audio file for the current reciter
@@ -115,9 +111,9 @@ export const audioPlayerStateSlice = createSlice({
       ...state,
       isPlaying: action.payload,
     }),
-    setIsMinimized: (state, action: PayloadAction<boolean>) => ({
+    setIsMobileMinimizedForScrolling: (state, action: PayloadAction<boolean>) => ({
       ...state,
-      isMinimized: action.payload,
+      isMobileMinimizedForScrolling: action.payload,
     }),
     setReciter: (state, action: PayloadAction<Reciter>) => ({
       ...state,
@@ -135,9 +131,9 @@ export const audioPlayerStateSlice = createSlice({
       ...state,
       audioFileStatus: action.payload,
     }),
-    setVisibility: (state, action: PayloadAction<Visibility>) => ({
+    setIsExpanded: (state, action: PayloadAction<boolean>) => ({
       ...state,
-      visibility: action.payload,
+      isExpanded: action.payload,
     }),
     resetAudioFile: (state) => ({
       ...state,
@@ -161,9 +157,9 @@ export const {
   setReciter,
   setAudioFile,
   setAudioStatus,
-  setVisibility,
+  setIsExpanded,
   resetAudioFile,
-  setIsMinimized,
+  setIsMobileMinimizedForScrolling,
 } = audioPlayerStateSlice.actions;
 
 export default audioPlayerStateSlice.reducer;

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -13,7 +13,6 @@ export enum AudioFileStatus {
 }
 
 export enum Visibility {
-  Minimized = 'Minimized',
   Default = 'Default',
   Expanded = 'Expanded',
 }
@@ -25,6 +24,7 @@ export type AudioState = {
   audioFile: AudioFile;
   audioFileStatus: AudioFileStatus;
   visibility: Visibility;
+  isMinimized: boolean;
 };
 
 const initialState: AudioState = {
@@ -34,16 +34,18 @@ const initialState: AudioState = {
   reciter: DEFAULT_RECITER,
   audioFileStatus: AudioFileStatus.NoFile,
   visibility: Visibility.Default,
+  isMinimized: false,
 };
 
-export const selectAudioPlayerState = (state) => state.audioPlayerState;
+export const selectAudioPlayerState = (state) => state.audioPlayerState as AudioState;
 export const selectReciter = (state) => state.audioPlayerState.reciter as Reciter;
 export const selectIsUsingDefaultReciter = (state) =>
   state.audioPlayerState.reciter.id === DEFAULT_RECITER.id;
 export const selectAudioFile = (state) => state.audioPlayerState.audioFile as AudioFile;
 export const selectAudioFileStatus = (state) => state.audioPlayerState.audioFileStatus;
 export const selectIsPlaying = (state) => state.audioPlayerState.isPlaying;
-export const selectVisibility = (state) => state.audioPlayerState.visibility;
+export const selectVisibility = (state) => state.audioPlayerState.visibility as Visibility;
+export const selectIsMinimized = (state) => state.audioPlayerState.isMinimized as boolean;
 
 /**
  * get the audio file for the current reciter
@@ -113,6 +115,10 @@ export const audioPlayerStateSlice = createSlice({
       ...state,
       isPlaying: action.payload,
     }),
+    setIsMinimized: (state, action: PayloadAction<boolean>) => ({
+      ...state,
+      isMinimized: action.payload,
+    }),
     setReciter: (state, action: PayloadAction<Reciter>) => ({
       ...state,
       reciter: action.payload,
@@ -157,6 +163,7 @@ export const {
   setAudioStatus,
   setVisibility,
   resetAudioFile,
+  setIsMinimized,
 } = audioPlayerStateSlice.actions;
 
 export default audioPlayerStateSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -7,6 +7,7 @@ import {
   PERSIST,
   PURGE,
   REGISTER,
+  createMigrate,
 } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import { configureStore, getDefaultMiddleware, combineReducers } from '@reduxjs/toolkit';
@@ -21,11 +22,15 @@ import navbar from './slices/navbar';
 import audioPlayerState from './slices/AudioPlayer/state';
 import theme from './slices/theme';
 import audioPlayerPersistConfig from './slices/AudioPlayer/persistConfig';
+import migrations from './migrations';
 
 const persistConfig = {
   key: 'root',
-  version: 1,
+  version: 2,
   storage,
+  migrate: createMigrate(migrations, {
+    debug: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development',
+  }),
   whitelist: [
     'quranReaderStyles',
     'readingPreferences',

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -26,7 +26,7 @@ import migrations from './migrations';
 
 const persistConfig = {
   key: 'root',
-  version: 2,
+  version: 3,
   storage,
   migrate: createMigrate(migrations, {
     debug: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development',

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -5,6 +5,7 @@ $side-menu-desktop-width: 24rem;
 $notes-side-bar-desktop-width: 26rem;
 
 $audio-player-expanded-height: 6rem;
+$audio-player-minimized-height: 2rem;
 
 $audio-player-default-height: 3rem;
 

--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,5 +1,5 @@
 // Need to stopPropagation() to prevent the event from bubbling up to the parent container
-// which cause dispatch `setIsMinimized` to be called
+// which cause dispatch `setIsMobileMinimizedForScrolling` to be called
 // eslint-disable-next-line import/prefer-default-export
 export const withStopPropagation = (cb: () => void) => (e) => {
   e.stopPropagation();


### PR DESCRIPTION
### Summary
This PR changes the behavior while browsing on mobile of `NavBar` to hide on scroll down and `AudioPlayer` to minimize when expanded on scrolling down.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="275" alt="Screen Shot 2021-09-09 at 10 19 55" src="https://user-images.githubusercontent.com/15169499/132616930-1657abcd-2991-4392-a1fe-9f16f84f1a2d.png">|<img width="275" alt="Screen Shot 2021-09-09 at 10 15 25" src="https://user-images.githubusercontent.com/15169499/132616886-8def21bf-01e6-47dd-b0fd-e32f0e19e9a4.png">|
|<img width="274" alt="Screen Shot 2021-09-09 at 10 21 14" src="https://user-images.githubusercontent.com/15169499/132617190-9b14e91b-ff5d-4e53-a654-3fae72d7a7f8.png">|<img width="274" alt="Screen Shot 2021-09-09 at 10 22 36" src="https://user-images.githubusercontent.com/15169499/132617196-a8c2142b-3b4f-4e7a-b4e2-af46b8295ebb.png">|