### PR TITLE
remove vendor util that is already covered by autoprefixer in nextjs

### DIFF
--- a/src/components/dls/Modal/Modal.module.scss
+++ b/src/components/dls/Modal/Modal.module.scss
@@ -7,7 +7,7 @@ $desktopWidth: 90vw;
 $desktopMaxWidth: calc(28.125 * var(--spacing-medium));
 $mobileWidth: 100vw;
 
-@include utility.keyframes(fadeIn) {
+@keyframes fadeIn {
   from {
     opacity: 0;
   }
@@ -16,7 +16,7 @@ $mobileWidth: 100vw;
   }
 }
 
-@include utility.keyframes(fadeOut) {
+@keyframes fadeOut {
   from {
     opacity: 1;
   }
@@ -25,7 +25,7 @@ $mobileWidth: 100vw;
   }
 }
 
-@include utility.keyframes(desktopContentIn) {
+@keyframes desktopContentIn {
   0% {
     opacity: 0;
     transform: translate(-50%, -70%);
@@ -36,7 +36,7 @@ $mobileWidth: 100vw;
   }
 }
 
-@include utility.keyframes(desktopContentOut) {
+@keyframes desktopContentOut {
   0% {
     transform: translate(-50%, -50%);
   }
@@ -45,7 +45,7 @@ $mobileWidth: 100vw;
   }
 }
 
-@include utility.keyframes(mobileContentIn) {
+@keyframes mobileContentIn {
   0% {
     transform: translate(0%, 100%);
   }
@@ -54,7 +54,7 @@ $mobileWidth: 100vw;
   }
 }
 
-@include utility.keyframes(mobileContentOut) {
+@keyframes mobileContentOut {
   0% {
     transform: translate(0%, 0%);
   }

--- a/src/styles/_utility.scss
+++ b/src/styles/_utility.scss
@@ -13,32 +13,6 @@
   justify-content: center;
 }
 
-@mixin keyframes($animation-name) {
-  @-webkit-keyframes #{$animation-name} {
-    @content;
-  }
-  @-moz-keyframes #{$animation-name} {
-    @content;
-  }
-  @-ms-keyframes #{$animation-name} {
-    @content;
-  }
-  @-o-keyframes #{$animation-name} {
-    @content;
-  }
-  @keyframes #{$animation-name} {
-    @content;
-  }
-}
-
-@mixin animation($str) {
-  -webkit-animation: #{$str};
-  -moz-animation: #{$str};
-  -ms-animation: #{$str};
-  -o-animation: #{$str};
-  animation: #{$str};
-}
-
 $scales-map: (
   default: (
     desktop: (


### PR DESCRIPTION
### Summary

Autoprefixer can handle css vendoring for us. And nextjs supports autoprefixer out of the box.
So we can safely remove our css vendoring utility

Reference:
- https://nextjs.org/docs/advanced-features/customizing-postcss-config#default-behavior
