### PR TITLE
get chapterData directly from the JSON file instead of from API

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -8,8 +8,6 @@ import {
   AudioFilesResponse,
   AudioTimestampsResponse,
   TafsirsResponse,
-  ChapterResponse,
-  ChaptersResponse,
   VersesResponse,
   BaseResponse,
   ChapterInfoResponse,
@@ -17,7 +15,6 @@ import {
 } from 'types/APIResponses';
 import { SearchRequest, AdvancedCopyRequest } from 'types/APIRequests';
 import { AudioFile } from 'types/AudioFile';
-import { makeUrl } from './utils/api';
 import {
   makeAdvancedCopyUrl,
   makeTafsirsUrl,
@@ -41,21 +38,6 @@ export const fetcher = async function fetcher(
 ): Promise<BaseResponse> {
   const res = await fetch(input, init);
   return res.json();
-};
-
-export const getChapters = async (): Promise<ChaptersResponse> => {
-  const payload = await fetcher(makeUrl(`/chapters`));
-
-  return camelizeKeys(payload);
-};
-
-export const getChapter = async (
-  id: string | number,
-  language: string,
-): Promise<ChapterResponse> => {
-  const payload = await fetcher(makeUrl(`/chapters/${id}`, { language }));
-
-  return camelizeKeys(payload);
 };
 
 export const getChapterVerses = async (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,9 +5,9 @@ import { ChaptersResponse } from 'types/APIResponses';
 import BookmarkedVersesList from 'src/components/Verses/BookmarkedVersesList';
 import homepageImage from 'public/images/homepage.png';
 import HomePageWelcomeMessage from 'src/components/HomePage/HomePageWelcomeMessage';
+import { getAllChaptersData } from 'src/utils/chapter';
 import ChaptersList from '../components/chapters/ChaptersList';
 import QuickLinks from '../components/HomePage/QuickLinks';
-import { getChapters } from '../api';
 import styles from './index.module.scss';
 
 type IndexProps = {
@@ -33,10 +33,14 @@ const Index: NextPage<IndexProps> = ({ chaptersResponse: { chapters } }) => (
 );
 
 export const getStaticProps: GetStaticProps = async () => {
-  const chaptersResponse = await getChapters();
+  const allChaptersData = getAllChaptersData();
 
   return {
-    props: { chaptersResponse },
+    props: {
+      chaptersResponse: {
+        chapters: Object.values(allChaptersData),
+      },
+    },
   };
 };
 


### PR DESCRIPTION
### Summary
- remove `getChapter` api call in `getStaticProps`
- replace with `getChapterData` utility which get the data directly from the json in `/public/data/chapter/en.json` (depends on the language)


### Test result
Example:
- the chapter data is being in `<NextSEOHead` as `title`. Functionality still works
![image](https://user-images.githubusercontent.com/12745166/133195527-fbe647c7-bbf3-4fb2-a405-4f41f6957d95.png)



### Notes
- the `getChapter`function inside `api.ts` is not removed yet. In case we need it in the future. But we can also remove it to avoid confusion so there's only 1 way to do nothing.