### PR TITLE
upgrade SWR

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-infinite-scroller": "^1.2.4",
     "react-redux": "^7.2.4",
     "redux-persist": "^6.0.0",
-    "swr": "^0.5.6"
+    "swr": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.15.4",

--- a/src/components/DeveloperUtility/ReciterAdjustment.tsx
+++ b/src/components/DeveloperUtility/ReciterAdjustment.tsx
@@ -3,13 +3,13 @@ import { useDispatch, shallowEqual, useSelector } from 'react-redux';
 import { getAvailableReciters } from 'src/api';
 import { selectReciter, setReciter } from 'src/redux/slices/AudioPlayer/state';
 import { makeRecitersUrl } from 'src/utils/apiPaths';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import Reciter from 'types/Reciter';
 import styles from './ReciterAdjustment.module.scss';
 
 const ReciterAdjustment: React.FC = () => {
   const dispatch = useDispatch();
-  const { data, error } = useSWR(makeRecitersUrl(), () =>
+  const { data, error } = useSWRImmutable(makeRecitersUrl(), () =>
     getAvailableReciters().then((res) =>
       res.status === 500 ? Promise.reject(error) : Promise.resolve(res.reciters),
     ),

--- a/src/components/Navbar/SettingsDrawer/AudioSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/AudioSection.tsx
@@ -3,7 +3,7 @@ import { getAvailableReciters } from 'src/api';
 import Combobox from 'src/components/dls/Forms/Combobox';
 import { selectReciter, setReciter } from 'src/redux/slices/AudioPlayer/state';
 import { makeRecitersUrl } from 'src/utils/apiPaths';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import Reciter from 'types/Reciter';
 import Section from './Section';
 
@@ -19,13 +19,10 @@ const recitersToComboboxItems = (reciters) =>
 
 const AudioSection = () => {
   const dispatch = useDispatch();
-  const { data, error } = useSWR(
-    makeRecitersUrl(),
-    () =>
-      getAvailableReciters().then((res) =>
-        res.status === 500 ? Promise.reject(error) : Promise.resolve(res.reciters),
-      ),
-    { revalidateOnFocus: false, revalidateOnReconnect: true },
+  const { data, error } = useSWRImmutable(makeRecitersUrl(), () =>
+    getAvailableReciters().then((res) =>
+      res.status === 500 ? Promise.reject(error) : Promise.resolve(res.reciters),
+    ),
   );
   const selectedReciter = useSelector(selectReciter, shallowEqual);
   const reciters = data || [];

--- a/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
@@ -5,7 +5,7 @@ import { getTafsirs } from 'src/api';
 import Combobox from 'src/components/dls/Forms/Combobox';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import { throwIfError } from 'src/utils/error';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import { areArraysEqual, numbersToStringsArray, stringsToNumbersArray } from 'src/utils/array';
 import {
   MAXIMUM_FONT_STEP,
@@ -46,7 +46,7 @@ const TafsirSection = () => {
     [dispatch],
   );
 
-  const { data: tafsirs, error } = useSWR(`/tafsirs/${lang}`, () =>
+  const { data: tafsirs, error } = useSWRImmutable(`/tafsirs/${lang}`, () =>
     getTafsirs(lang).then((res) => {
       throwIfError(res);
       return res.tafsirs;

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -19,7 +19,7 @@ import {
 } from 'src/redux/slices/QuranReader/translations';
 import { areArraysEqual, numbersToStringsArray, stringsToNumbersArray } from 'src/utils/array';
 import { throwIfError } from 'src/utils/error';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import { makeTranslationsUrl } from 'src/utils/apiPaths';
 import { getTranslatedLabelWithLanguage } from 'src/utils/input';
 import { DropdownItem } from 'src/components/dls/Forms/Combobox/ComboboxItem';
@@ -51,7 +51,7 @@ const TranslationSection = () => {
     [dispatch],
   );
 
-  const { data: translations, error } = useSWR(makeTranslationsUrl(lang), () =>
+  const { data: translations, error } = useSWRImmutable(makeTranslationsUrl(lang), () =>
     getAvailableTranslations(lang).then((res) => {
       throwIfError(res);
       return res.translations;

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallowEqual, useSelector } from 'react-redux';
 import InfiniteScroll from 'react-infinite-scroller';
-import { useSWRInfinite } from 'swr';
+import useSWRInfinite from 'swr/infinite';
 import { VersesResponse } from 'types/APIResponses';
 import { selectNotes } from 'src/redux/slices/QuranReader/notes';
 import {
@@ -68,7 +68,7 @@ const QuranReader = ({
       }),
     verseFetcher,
     {
-      initialData:
+      fallbackData:
         isUsingDefaultTranslations && isUsingDefaultTafsirs && isUsingDefaultReciter
           ? initialData.verses
           : null, // initialData is set to null if the user changes/has changed the default translations/tafsirs so that we can prevent the UI from falling back to the default translations while fetching the verses with the translations/tafsirs the user had selected and we will show a loading indicator instead.

--- a/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.tsx
+++ b/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.tsx
@@ -8,7 +8,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { getVerseNumberFromKey, generateChapterVersesKeys } from 'src/utils/verse';
 import { getAdvancedCopyRawResult, getAvailableTranslations } from 'src/api';
 import { QuranFont } from 'src/components/QuranReader/types';
-import useSWR from 'swr';
+import useSWRImmutable from 'swr/immutable';
 import { makeTranslationsUrl } from 'src/utils/apiPaths';
 import { throwIfError } from 'src/utils/error';
 import Link, { LinkVariant } from 'src/components/dls/Link/Link';
@@ -104,16 +104,11 @@ const VerseAdvancedCopy: React.FC<Props> = ({ verse, children }) => {
   // because we already have call the API in settings menu. useSWR will save it to cache.
   // in this component, we will get the data from the cache.
   // so, no rerender, no layout shift.
-  const { data: availableTranslations } = useSWR(
-    makeTranslationsUrl(lang),
-    () =>
-      getAvailableTranslations(lang).then((res) => {
-        throwIfError(res);
-        return res.translations;
-      }),
-    {
-      revalidateOnFocus: false,
-    },
+  const { data: availableTranslations } = useSWRImmutable(makeTranslationsUrl(lang), () =>
+    getAvailableTranslations(lang).then((res) => {
+      throwIfError(res);
+      return res.translations;
+    }),
   );
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14553,10 +14553,10 @@ svgo@^0.7.2:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-swr@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-0.5.6.tgz#70bfe9bc9d7ac49a064be4a0f4acf57982e55a31"
-  integrity sha512-Bmx3L4geMZjYT5S2Z6EE6/5Cx6v1Ka0LhqZKq8d6WL2eu9y6gHWz3dUzfIK/ymZVHVfwT/EweFXiYGgfifei3w==
+swr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.1.tgz#15f62846b87ee000e52fa07812bb65eb62d79483"
+  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
   dependencies:
     dequal "2.0.2"
 


### PR DESCRIPTION
### Summary
This PR upgrades `SWR` version from [0.5.6](https://github.com/vercel/swr/releases/tag/0.5.6) to [1.0.1](https://github.com/vercel/swr/releases/tag/1.0.1) which introduced some breaking changes. The changes that were applied:

- Replace `swr` with `swr/immutable` which would stop revalidating on focus or reconnecting.
- Use `swr/infinite` instead of importing it from `swr` package.
- Use `fallbackData` instead of `initialData`.

Resources:

- https://swr.vercel.app/blog/swr-v1#migration-guide