### PR TITLE
remove unnecassary `as unknown` type casting

### DIFF
--- a/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
@@ -67,9 +67,7 @@ const ReadingExperienceSection = () => {
       <Section.Row>
         <Section.Label>View</Section.Label>
         <RadioGroup
-          onChange={(value) =>
-            dispatch(setReadingPreference(value as unknown as ReadingPreference))
-          }
+          onChange={(value) => dispatch(setReadingPreference(value as ReadingPreference))}
           value={readingPreference}
           label="view"
           items={preferences}


### PR DESCRIPTION
### Summary

see the code, previously, this was an issue. But it's no longer an issue now. Not sure why, maybe the package is updated or something.