### PR TITLE
Select multiple languages/translations on search page

### DIFF
--- a/src/components/Search/LanguagesFilter.tsx
+++ b/src/components/Search/LanguagesFilter.tsx
@@ -4,16 +4,21 @@ import Combobox from '../dls/Forms/Combobox';
 import styles from './Filter.module.scss';
 
 interface Props {
-  onLanguageChange: (languageIsoCode: string) => void;
-  selectedLanguage: string;
+  onLanguageChange: (languageIsoCode: string[]) => void;
+  selectedLanguages: string;
   languages: AvailableLanguage[];
 }
 
 const LanguagesFilter: React.FC<Props> = memo(
-  ({ languages, selectedLanguage, onLanguageChange }) => {
-    // we need to match the selectedLanguage because if it comes from the URL's query param and the user had entered an invalid languageCode in the url, we should set a different text
-    const matchedLanguage = languages.find((language) => language.isoCode === selectedLanguage);
-    const initialInputValue = matchedLanguage ? matchedLanguage.translatedName.name : '';
+  ({ languages, selectedLanguages, onLanguageChange }) => {
+    /*
+      We need to only pick the languages that exist in the list of available languages
+      to avoid selecting non-existent items since the languages can come from the URL path
+      which the user can edit to enter invalid values.
+    */
+    const matchedLanguages = languages
+      .filter((language) => selectedLanguages.split(',').includes(language.isoCode))
+      .map((language) => language.isoCode);
 
     const languagesItems = useMemo(
       () =>
@@ -28,12 +33,12 @@ const LanguagesFilter: React.FC<Props> = memo(
 
     return (
       <Combobox
+        isMultiSelect
         id="languagesFilter"
-        value={selectedLanguage}
+        value={matchedLanguages}
         minimumRequiredItems={1}
         items={languagesItems}
         onChange={onLanguageChange}
-        initialInputValue={initialInputValue}
         placeholder="Select a language"
         label={<div className={styles.dropdownLabel}>Language</div>}
       />

--- a/src/components/Search/TranslationsFilter.tsx
+++ b/src/components/Search/TranslationsFilter.tsx
@@ -5,18 +5,25 @@ import Combobox from '../dls/Forms/Combobox';
 import styles from './Filter.module.scss';
 
 interface Props {
-  onTranslationChange: (translationId: string) => void;
-  selectedTranslation: string;
+  onTranslationChange: (translationId: string[]) => void;
+  selectedTranslations: string;
   translations: AvailableTranslation[];
 }
 
 const TranslationsFilter: React.FC<Props> = memo(
-  ({ translations, selectedTranslation, onTranslationChange }) => {
-    // we need to match the selectedTranslation because if it comes from the URL's query param and the user had entered an invalid languageCode in the url or if he didn't select a translation at all, we should set a different text
-    const matchedTranslation = translations.find(
-      (translation) => translation.id.toString() === selectedTranslation,
-    );
-    const initialInputValue = matchedTranslation ? matchedTranslation.translatedName.name : '';
+  ({ translations, selectedTranslations, onTranslationChange }) => {
+    /*
+      We need to only pick the translations that exist in the list of available translations
+      to avoid selecting non-existent items since the translations can come from the URL path
+      which the user can edit to enter invalid values.
+    */
+    const matchedTranslations = selectedTranslations
+      ? translations
+          .filter((translation) =>
+            selectedTranslations.split(',').includes(translation.id.toString()),
+          )
+          .map((translation) => translation.id.toString())
+      : [];
 
     const translationsItems = useMemo(
       () =>
@@ -34,11 +41,11 @@ const TranslationsFilter: React.FC<Props> = memo(
 
     return (
       <Combobox
+        isMultiSelect
         id="translationsFilter"
-        value={selectedTranslation || ''}
+        value={matchedTranslations}
         items={translationsItems}
         onChange={onTranslationChange}
-        initialInputValue={initialInputValue}
         placeholder="Select a translation"
         label={<div className={styles.dropdownLabel}>Translation</div>}
       />

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -32,8 +32,8 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
   const { lang } = useTranslation();
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [selectedLanguage, setSelectedLanguage] = useState<string>(lang);
-  const [selectedTranslation, setSelectedTranslation] = useState<string>(null);
+  const [selectedLanguages, setSelectedLanguages] = useState<string>(lang);
+  const [selectedTranslations, setSelectedTranslations] = useState<string>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [searchResult, setSearchResult] = useState<SearchResponse>(null);
@@ -45,11 +45,11 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
   const queryParams = useMemo(
     () => ({
       page: currentPage,
-      language: selectedLanguage,
+      languages: selectedLanguages,
       query: debouncedSearchQuery,
-      translations: selectedTranslation,
+      translations: selectedTranslations,
     }),
-    [currentPage, debouncedSearchQuery, selectedLanguage, selectedTranslation],
+    [currentPage, debouncedSearchQuery, selectedLanguages, selectedTranslations],
   );
   useAddQueryParamsToUrl('/search', queryParams);
 
@@ -65,11 +65,11 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
       if (router.query.page) {
         setCurrentPage(Number(router.query.page));
       }
-      if (router.query.language) {
-        setSelectedLanguage(router.query.language as string);
+      if (router.query.languages) {
+        setSelectedLanguages(router.query.languages as string);
       }
-      if (router.query.translation) {
-        setSelectedTranslation(router.query.translation as string);
+      if (router.query.translations) {
+        setSelectedTranslations(router.query.translations as string);
       }
     }
   }, [router]);
@@ -132,9 +132,9 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
   useEffect(() => {
     // only when the search query has a value we call the API.
     if (debouncedSearchQuery) {
-      getResults(debouncedSearchQuery, currentPage, selectedTranslation, selectedLanguage);
+      getResults(debouncedSearchQuery, currentPage, selectedTranslations, selectedLanguages);
     }
-  }, [currentPage, debouncedSearchQuery, getResults, selectedLanguage, selectedTranslation]);
+  }, [currentPage, debouncedSearchQuery, getResults, selectedLanguages, selectedTranslations]);
 
   const onPageChange = (page: number) => {
     setCurrentPage(page);
@@ -145,12 +145,14 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
    *
    * @param {string} languageIsoCode
    */
-  const onLanguageChange = useCallback((languageIsoCode: string) => {
-    setSelectedLanguage(languageIsoCode);
+  const onLanguageChange = useCallback((languageIsoCodes: string[]) => {
+    // convert the array into a string
+    setSelectedLanguages(languageIsoCodes.join(','));
   }, []);
 
-  const onTranslationChange = useCallback((translationId: string) => {
-    setSelectedTranslation(translationId);
+  const onTranslationChange = useCallback((translationIds: string[]) => {
+    // convert the array into a string
+    setSelectedTranslations(translationIds.join(','));
     // reset the current page since most probable the results will change.
     setCurrentPage(1);
   }, []);
@@ -196,12 +198,12 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
             <p className={styles.boldHeader}>Filters</p>
             <LanguagesFilter
               languages={languages}
-              selectedLanguage={selectedLanguage}
+              selectedLanguages={selectedLanguages}
               onLanguageChange={onLanguageChange}
             />
             <TranslationsFilter
               translations={translations}
-              selectedTranslation={selectedTranslation}
+              selectedTranslations={selectedTranslations}
               onTranslationChange={onTranslationChange}
             />
           </div>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -15,6 +15,9 @@ import AvailableTranslation from 'types/AvailableTranslation';
 import AvailableLanguage from 'types/AvailableLanguage';
 import NextSeoHead from 'src/components/NextSeoHead';
 import SearchResults from 'src/components/Search/SearchResults';
+import { selectSelectedTranslations } from 'src/redux/slices/QuranReader/translations';
+import { areArraysEqual } from 'src/utils/array';
+import { useSelector } from 'react-redux';
 import IconClose from '../../public/icons/close.svg';
 import styles from './search.module.scss';
 
@@ -30,10 +33,13 @@ const Search: NextPage<SearchProps> = ({ languages, translations }) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const { lang } = useTranslation();
+  const userTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [selectedLanguages, setSelectedLanguages] = useState<string>(lang);
-  const [selectedTranslations, setSelectedTranslations] = useState<string>(null);
+  const [selectedTranslations, setSelectedTranslations] = useState<string>(() =>
+    userTranslations.join(','),
+  );
   const [isSearching, setIsSearching] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [searchResult, setSearchResult] = useState<SearchResponse>(null);


### PR DESCRIPTION
### Summary
This PR makes it possible to select multiple languages/translations when searching for a keyword on the search page.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="319" alt="Screen Shot 2021-09-15 at 18 45 47" src="https://user-images.githubusercontent.com/15169499/133428068-7899de95-8a69-4dde-a2cf-bedcb8cd1c8d.png">|<img width="318" alt="Screen Shot 2021-09-15 at 18 45 55" src="https://user-images.githubusercontent.com/15169499/133428077-2a058904-6ce6-49df-bf2a-1c4081b3661d.png">|