### PR TITLE
Fix storybook deployment + add  storybook deploy preview url in PR's comment

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -62,7 +62,7 @@ jobs:
           body-includes: "Storybook preview:"
       - name: Save comment id
         id: comment-id
-        run: echo "::set-output name=comment-id::446"
+        run: echo "::set-output name=comment-id::${{ steps.find-comment.outputs.comment-id }}"
       - name: Create comment
         if: steps.find-comment.outputs.comment-id == '' # only create new comment, if no previous storybook comment found
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -74,9 +74,8 @@ jobs:
 
   post-storybook-url:
     runs-on: ubuntu-latest
-    needs: create-storybook-comment
+    needs: [create-storybook-comment, deploy-storybook]
     steps:
-      - run: echo ${{ needs.create-storybook-comment.outputs.comment-id }}
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Storybook preview
+          body-includes: "Storybook preview:"
       - name: Create comment
         if: steps.find-comment.outputs.comment-id == '' # only create new comment, if no previous storybook comment found
         uses: peter-evans/create-or-update-comment@v1
@@ -77,7 +77,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Storybook preview
+          body-includes: "Storybook preview:"
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -61,9 +61,9 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: "Storybook preview:"
       - name: Save comment id
-        id: comment-id
         run: echo "::set-output name=comment-id::${{ steps.find-comment.outputs.comment-id }}"
       - name: Create comment
+        id: create-comment
         if: steps.find-comment.outputs.comment-id == '' # only create new comment, if no previous storybook comment found
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -71,6 +71,10 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Storybook preview: *In-Progress*
+      - name: Save comment id
+        if: steps.find-comment.outputs.comment-id != ''
+        run: echo "::set-output name=comment-id::${{ steps.create-comment.outputs.comment-id }}"
+
 
   post-storybook-url:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -79,7 +79,6 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Storybook preview
       - name: Update comment
-        if: needs.create-storybook-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -1,6 +1,6 @@
 name: Build Storybook
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build-storybook:
@@ -47,3 +47,38 @@ jobs:
           GIT_AUTHOR_NAME: ${{ github.actor }}
           GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ github.actor }}
+
+  create-storybook-comment:
+    runs-on: ubuntu-latest
+    outputs:
+      comment-id: ${{ steps.fc.outputs.comment-id }}
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Storybook preview
+      - name: Create comment
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Storybook preview: *In-Progress*
+
+  post-storybook-url:
+    runs-on: ubuntu-latest
+    needs: [create-storybook-comment]
+    steps:
+      - name: Update comment
+        if: needs.create-storybook-comment.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ needs.create-storybook-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Storybook preview: https://quran.github.io/quran.com-frontend-next/storybook/${{ github.head_ref }}/
+          edit-mode: replace 

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -50,6 +50,8 @@ jobs:
 
   create-storybook-comment:
     runs-on: ubuntu-latest
+    outputs:
+      comment-id: ${{ steps.step1.outputs.test }}
     steps:
       - name: Find Comment
         uses: peter-evans/find-comment@v1
@@ -58,6 +60,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: "Storybook preview:"
+      - name: Save comment id
+        id: comment-id
+        run: echo "::set-output name=comment-id::446"
       - name: Create comment
         if: steps.find-comment.outputs.comment-id == '' # only create new comment, if no previous storybook comment found
         uses: peter-evans/create-or-update-comment@v1
@@ -69,19 +74,12 @@ jobs:
 
   post-storybook-url:
     runs-on: ubuntu-latest
-    needs: deploy-storybook
+    needs: create-storybook-comment
     steps:
-      - name: Find Comment
-        uses: peter-evans/find-comment@v1
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: "Storybook preview:"
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          comment-id: ${{ needs.create-storybook-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Storybook preview: https://quran.github.io/quran.com-frontend-next/storybook/${{ github.head_ref }}/

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -51,7 +51,7 @@ jobs:
   create-storybook-comment:
     runs-on: ubuntu-latest
     outputs:
-      comment-id: ${{ steps.step1.outputs.test }}
+      comment-id: ${{ steps.comment-id.outputs.comment-id }}
     steps:
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -50,34 +50,39 @@ jobs:
 
   create-storybook-comment:
     runs-on: ubuntu-latest
-    outputs:
-      comment-id: ${{ steps.fc.outputs.comment-id }}
     steps:
       - name: Find Comment
         uses: peter-evans/find-comment@v1
-        id: fc
+        id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Storybook preview
       - name: Create comment
-        if: steps.fc.outputs.comment-id == ''
+        if: steps.find-comment.outputs.comment-id == '' # only create new comment, if no previous storybook comment found
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Storybook preview: *In-Progress*
 
   post-storybook-url:
     runs-on: ubuntu-latest
-    needs: [create-storybook-comment]
+    needs: deploy-storybook
     steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Storybook preview
       - name: Update comment
         if: needs.create-storybook-comment.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ needs.create-storybook-comment.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Storybook preview: https://quran.github.io/quran.com-frontend-next/storybook/${{ github.head_ref }}/

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -76,6 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-storybook-comment
     steps:
+      - run: echo ${{ needs.create-storybook-comment.outputs.comment-id }}
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -60,30 +60,30 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: "Storybook preview:"
-      - name: Save comment id
-        run: echo "::set-output name=comment-id::${{ steps.find-comment.outputs.comment-id }}"
       - name: Create comment
         id: create-comment
-        if: steps.find-comment.outputs.comment-id == '' # only create new comment, if no previous storybook comment found
+        if: steps.find-comment.outputs.comment-id == '' # prev comment id does not exist, create new comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Storybook preview: *In-Progress*
-      - name: Save comment id
-        if: steps.find-comment.outputs.comment-id != ''
-        run: echo "::set-output name=comment-id::${{ steps.create-comment.outputs.comment-id }}"
-
-
+            
   post-storybook-url:
     runs-on: ubuntu-latest
     needs: [create-storybook-comment, deploy-storybook]
     steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "Storybook preview:"
       - name: Update comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          comment-id: ${{ needs.create-storybook-comment.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Storybook preview: https://quran.github.io/quran.com-frontend-next/storybook/${{ github.head_ref }}/


### PR DESCRIPTION
# Summary

### Fix storybook deployment fail

  - We deploy storybook by pushing the storybook build artifact into `gh-pages` branch in this repository
  - Previously the storybook deployment failed because, we run github action twice `on: [push, pull request]`.
  - So sometime there's a race condition, between the 2 actions. Where both is trying to execute `Commit updates`, both action tried to commit and push to same branch at the same time. (see `build-storybook.yml` for the details
  - So github rejected one the `push`
    
```
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
```
 
 - now, we only run the action once `on: [pull request]`


### Adding storybook URL for the PR

- Create a PR comment `Storybook preview : *In-Progress`, when PR is created
- Then update the comment into `Storybook preview: [storybook-url]` when the storybook deployment is finished


PR test : #452 

### Known issues
- There's some code duplication (`find-comment`). 
I decided to do just duplicate code, after a few iterations few with "without duplication" alternative (by using github actions' output and yaml `merge` feature.  The other approaches is less familiar and adding complexity to the code.  

The amount of duplication is still manageable, and they sit close to each other. I think this is okay.