### PR TITLE
misc changes: dark mode mismatch modal & loading state

### DIFF
--- a/src/components/AudioPlayer/PlayPauseButton.tsx
+++ b/src/components/AudioPlayer/PlayPauseButton.tsx
@@ -56,8 +56,7 @@ const PlayPauseButton = () => {
         <Spinner size={SpinnerSize.Large} />
       </Button>
     );
-
-  if (isPlaying) {
+  else if (isPlaying)
     button = (
       <Button
         tooltip="Pause"
@@ -69,8 +68,7 @@ const PlayPauseButton = () => {
         <PauseIcon />
       </Button>
     );
-  }
-  if (!isPlaying)
+  else if (!isPlaying)
     button = (
       <Button
         tooltip="Play"

--- a/src/components/AudioPlayer/SurahAudioMismatchModal.module.scss
+++ b/src/components/AudioPlayer/SurahAudioMismatchModal.module.scss
@@ -1,3 +1,4 @@
 .bodyText {
+  color: var(--color-text-default);
   text-align: center;
 }


### PR DESCRIPTION
### Summary
- fix: loading state unreachable on audioplayer after clicking 
- dark mode UI issue with modal, (mistmacth modal)


### dark mode UI issue

Before
![image](https://user-images.githubusercontent.com/12745166/133638521-d2a1db7c-2151-4835-9424-2e76ce393c97.png)

After
![image](https://user-images.githubusercontent.com/12745166/133638574-5426112f-be8c-4819-a80a-9ac9ce3ef97f.png)