### PR TITLE
Disable arrow-body-style linting rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -92,6 +92,7 @@
         "jsdoc/require-param-name": 2,
         "jsdoc/require-returns": 2,
         "jsdoc/require-returns-type": 2,
+        "arrow-body-style": 0,
         "prettier/prettier": [
             2,
             {


### PR DESCRIPTION
### Summary
This PR disables [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style) linting rule which comes by default with [eslint-config-airbnb](https://github.com/airbnb/javascript) package