### PR TITLE
Solve combobox backspace issue

### DIFF
--- a/src/components/dls/Forms/Combobox/index.tsx
+++ b/src/components/dls/Forms/Combobox/index.tsx
@@ -154,7 +154,7 @@ const Combobox: React.FC<Props> = ({
    */
   const shouldDeleteLastTag = useKeyPressedDetector(
     'Backspace',
-    isMultiSelect && !inputValue && !!tags.length && !preventUnselectingItems,
+    isOpened && isMultiSelect && !inputValue && !!tags.length && !preventUnselectingItems,
   );
 
   const invokeOnChangeCallback = useCallback(


### PR DESCRIPTION
### Summary
This PR resolves the issue with `Combobox` clearing tags on backspace press even when the combobx is not opened.