### PR TITLE
perf: remove currentTime from redux

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -35,7 +35,7 @@ import { withStopPropagation } from 'src/utils/event';
 
 const AudioPlayer = () => {
   const dispatch = useDispatch();
-  const audioPlayerEl = useRef<HTMLAudioElement>(null);
+  const audioPlayerElRef = useRef<HTMLAudioElement>(null);
   const audioFile = useSelector(selectAudioFile, shallowEqual);
   const audioFileStatus = useSelector(selectAudioFileStatus);
   const isHidden = audioFileStatus === AudioFileStatus.NoFile;
@@ -76,15 +76,15 @@ const AudioPlayer = () => {
   // Sync the global audio player element reference with the AudioPlayer component.
   useEffect(() => {
     if (process.browser && window) {
-      window.audioPlayerEl = audioPlayerEl.current;
+      window.audioPlayerEl = audioPlayerElRef.current;
     }
-  }, [audioPlayerEl]);
+  }, [audioPlayerElRef]);
 
   // eventListeners useEffect
   useEffect(() => {
     let currentRef = null;
-    if (audioPlayerEl && audioPlayerEl.current) {
-      currentRef = audioPlayerEl.current;
+    if (audioPlayerElRef && audioPlayerElRef.current) {
+      currentRef = audioPlayerElRef.current;
       currentRef.addEventListener('play', onAudioPlay);
       currentRef.addEventListener('pause', onAudioPause);
       currentRef.addEventListener('ended', onAudioEnded);
@@ -99,7 +99,7 @@ const AudioPlayer = () => {
         currentRef.removeEventListener('canplaythrough', onAudioLoaded);
       }
     };
-  }, [audioPlayerEl, onAudioPlay, onAudioPause, onAudioEnded, onAudioLoaded]);
+  }, [audioPlayerElRef, onAudioPlay, onAudioPause, onAudioEnded, onAudioLoaded]);
 
   return (
     <div
@@ -124,7 +124,7 @@ const AudioPlayer = () => {
           src={audioFile?.audioUrl}
           style={{ display: 'none' }}
           id="audio-player"
-          ref={audioPlayerEl}
+          ref={audioPlayerElRef}
         />
         {/* <AudioKeyBoardListeners
           seek={(seekDuration) => seek(seekDuration)}
@@ -164,7 +164,7 @@ const AudioPlayer = () => {
         </div>
         <div className={styles.sliderContainer}>
           <Slider
-            audioPlayerEl={audioPlayerEl}
+            audioPlayerElRef={audioPlayerElRef}
             isMobileMinimizedForScrolling={isMobileMinimizedForScrolling}
             isExpanded={isExpanded}
             audioDuration={durationInSeconds}

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -35,7 +35,7 @@ import { withStopPropagation } from 'src/utils/event';
 
 const AudioPlayer = () => {
   const dispatch = useDispatch();
-  const audioPlayerEl = useRef(null);
+  const audioPlayerEl = useRef<HTMLAudioElement>(null);
   const audioFile = useSelector(selectAudioFile, shallowEqual);
   const audioFileStatus = useSelector(selectAudioFileStatus);
   const isHidden = audioFileStatus === AudioFileStatus.NoFile;
@@ -164,6 +164,7 @@ const AudioPlayer = () => {
         </div>
         <div className={styles.sliderContainer}>
           <Slider
+            audioPlayerEl={audioPlayerEl}
             isMobileMinimizedForScrolling={isMobileMinimizedForScrolling}
             isExpanded={isExpanded}
             audioDuration={durationInSeconds}

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -21,8 +21,6 @@ import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/d
 import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
 import {
   setIsPlaying,
-  selectAudioPlayerState,
-  setCurrentTime,
   selectAudioFile,
   selectAudioFileStatus,
   setAudioStatus,
@@ -37,7 +35,6 @@ import { withStopPropagation } from 'src/utils/event';
 
 const AudioPlayer = () => {
   const dispatch = useDispatch();
-  const { currentTime } = useSelector(selectAudioPlayerState, shallowEqual);
   const audioPlayerEl = useRef(null);
   const audioFile = useSelector(selectAudioFile, shallowEqual);
   const audioFileStatus = useSelector(selectAudioFileStatus);
@@ -47,6 +44,7 @@ const AudioPlayer = () => {
   const durationInSeconds = audioFile?.duration / 1000 || 0;
   const isExpanded = useSelector(selectIsExpanded);
   const isMobileMinimizedForScrolling = useSelector(selectIsMobileMinimizedForScrolling);
+  const [currentTime, setCurrentTime] = useState(0); // TODO: get current time from last session
   const onDirectionChange = useCallback(
     (direction: ScrollDirection) => {
       if (direction === ScrollDirection.Down && !isMobileMinimizedForScrolling) {
@@ -106,17 +104,8 @@ const AudioPlayer = () => {
 
   // No need to debounce. The frequency is funciton is set by the browser based on the system it's running on
   const onTimeUpdate = () => {
-    // update the current audio time in redux
-    dispatch({
-      type: setCurrentTime.type,
-      payload: audioPlayerEl.current.currentTime,
-    });
+    setCurrentTime(audioPlayerEl.current.currentTime);
   };
-
-  useEffect(() => {
-    triggerSetCurrentTime(currentTime);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import classNames from 'classnames';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -10,7 +10,7 @@ import UnfoldMoreIcon from '../../../public/icons/unfold_more.svg';
 
 import styles from './AudioPlayer.module.scss';
 import CloseButton from './CloseButton';
-import { triggerPauseAudio, triggerSeek, triggerSetCurrentTime } from './EventTriggers';
+import { triggerPauseAudio, triggerSeek } from './EventTriggers';
 import MediaSessionApiListeners from './MediaSessionApiListeners';
 // import AudioKeyBoardListeners from './AudioKeyboardListeners';
 import PlaybackControls from './PlaybackControls';
@@ -44,7 +44,6 @@ const AudioPlayer = () => {
   const durationInSeconds = audioFile?.duration / 1000 || 0;
   const isExpanded = useSelector(selectIsExpanded);
   const isMobileMinimizedForScrolling = useSelector(selectIsMobileMinimizedForScrolling);
-  const [currentTime, setCurrentTime] = useState(0); // TODO: get current time from last session
   const onDirectionChange = useCallback(
     (direction: ScrollDirection) => {
       if (direction === ScrollDirection.Down && !isMobileMinimizedForScrolling) {
@@ -102,11 +101,6 @@ const AudioPlayer = () => {
     };
   }, [audioPlayerEl, onAudioPlay, onAudioPause, onAudioEnded, onAudioLoaded]);
 
-  // No need to debounce. The frequency is funciton is set by the browser based on the system it's running on
-  const onTimeUpdate = () => {
-    setCurrentTime(audioPlayerEl.current.currentTime);
-  };
-
   return (
     <div
       role="button"
@@ -131,7 +125,6 @@ const AudioPlayer = () => {
           style={{ display: 'none' }}
           id="audio-player"
           ref={audioPlayerEl}
-          onTimeUpdate={onTimeUpdate}
         />
         {/* <AudioKeyBoardListeners
           seek={(seekDuration) => seek(seekDuration)}
@@ -173,9 +166,7 @@ const AudioPlayer = () => {
           <Slider
             isMobileMinimizedForScrolling={isMobileMinimizedForScrolling}
             isExpanded={isExpanded}
-            currentTime={currentTime}
             audioDuration={durationInSeconds}
-            setTime={triggerSetCurrentTime}
             reciterName={reciterName}
           />
         </div>

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -14,6 +14,7 @@ type SliderProps = {
   isExpanded: boolean;
   reciterName: string;
   isMobileMinimizedForScrolling: boolean;
+  audioPlayerEl: React.MutableRefObject<HTMLAudioElement>;
 };
 
 /**
@@ -28,17 +29,21 @@ const Slider = ({
   isExpanded,
   reciterName,
   isMobileMinimizedForScrolling,
+  audioPlayerEl,
 }: SliderProps): JSX.Element => {
   const [currentTime, setCurrentTime] = useState(0); // TODO: get current time from last session
 
   useEffect(() => {
+    if (!audioPlayerEl.current) return null;
+
+    const audioPlayer = audioPlayerEl.current;
     const updateCurrentTime = () => {
-      setCurrentTime(window.audioPlayerEl.currentTime);
+      setCurrentTime(audioPlayer.currentTime);
     };
 
-    window.audioPlayerEl.addEventListener('timeupdate', updateCurrentTime);
-    return () => window.audioPlayerEl.removeEventListener('timeupdate', updateCurrentTime);
-  }, []);
+    audioPlayerEl.current.addEventListener('timeupdate', updateCurrentTime);
+    return () => audioPlayer.removeEventListener('timeupdate', updateCurrentTime);
+  }, [audioPlayerEl]);
 
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -14,7 +14,7 @@ type SliderProps = {
   isExpanded: boolean;
   reciterName: string;
   isMobileMinimizedForScrolling: boolean;
-  audioPlayerEl: React.MutableRefObject<HTMLAudioElement>;
+  audioPlayerElRef: React.MutableRefObject<HTMLAudioElement>;
 };
 
 /**
@@ -29,21 +29,21 @@ const Slider = ({
   isExpanded,
   reciterName,
   isMobileMinimizedForScrolling,
-  audioPlayerEl,
+  audioPlayerElRef,
 }: SliderProps): JSX.Element => {
   const [currentTime, setCurrentTime] = useState(0); // TODO: get current time from last session
 
   useEffect(() => {
-    if (!audioPlayerEl.current) return null;
+    const audioPlayerEl = audioPlayerElRef.current;
+    if (!audioPlayerEl) return null;
 
-    const audioPlayer = audioPlayerEl.current;
     const updateCurrentTime = () => {
-      setCurrentTime(audioPlayer.currentTime);
+      setCurrentTime(audioPlayerEl.currentTime);
     };
 
-    audioPlayerEl.current.addEventListener('timeupdate', updateCurrentTime);
-    return () => audioPlayer.removeEventListener('timeupdate', updateCurrentTime);
-  }, [audioPlayerEl]);
+    audioPlayerEl.addEventListener('timeupdate', updateCurrentTime);
+    return () => audioPlayerEl.removeEventListener('timeupdate', updateCurrentTime);
+  }, [audioPlayerElRef]);
 
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;

--- a/src/components/AudioPlayer/Slider.tsx
+++ b/src/components/AudioPlayer/Slider.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import classNames from 'classnames';
 import range from 'lodash/range';
 
+import { triggerSetCurrentTime } from './EventTriggers';
 import styles from './Slider.module.scss';
 import Split, { NUMBER_OF_SPLITS } from './SliderSplit';
 
 import { secondsFormatter } from 'src/utils/datetime';
 
 type SliderProps = {
-  currentTime: number;
   audioDuration: number;
-  setTime: (number: number) => void;
   isExpanded: boolean;
   reciterName: string;
   isMobileMinimizedForScrolling: boolean;
@@ -25,13 +24,22 @@ type SliderProps = {
  * @returns {JSX.Element}
  */
 const Slider = ({
-  currentTime,
   audioDuration,
-  setTime,
   isExpanded,
   reciterName,
   isMobileMinimizedForScrolling,
 }: SliderProps): JSX.Element => {
+  const [currentTime, setCurrentTime] = useState(0); // TODO: get current time from last session
+
+  useEffect(() => {
+    const updateCurrentTime = () => {
+      setCurrentTime(window.audioPlayerEl.currentTime);
+    };
+
+    window.audioPlayerEl.addEventListener('timeupdate', updateCurrentTime);
+    return () => window.audioPlayerEl.removeEventListener('timeupdate', updateCurrentTime);
+  }, []);
+
   const splitDuration = audioDuration / NUMBER_OF_SPLITS;
   const remainingTime = audioDuration - currentTime;
   const isAudioLoaded = audioDuration !== 0; // placeholder check until we're able to retrieve the value from redux
@@ -44,7 +52,7 @@ const Slider = ({
         isComplete={isComplete}
         key={index}
         startTime={splitStartTime}
-        onClick={() => setTime(splitStartTime)}
+        onClick={() => triggerSetCurrentTime(splitStartTime)}
       />
     );
   });

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -17,7 +17,6 @@ export enum AudioFileStatus {
 
 export type AudioState = {
   isPlaying: boolean;
-  currentTime: number;
   reciter: Reciter;
   audioFile: AudioFile;
   audioFileStatus: AudioFileStatus;
@@ -27,7 +26,6 @@ export type AudioState = {
 
 const initialState: AudioState = {
   isPlaying: false,
-  currentTime: 0,
   audioFile: null,
   reciter: DEFAULT_RECITER,
   audioFileStatus: AudioFileStatus.NoFile,
@@ -99,7 +97,6 @@ export const playFrom = createAsyncThunk<void, PlayFromInput, { state: RootState
     }
 
     const timestampInSeconds = timestamp / 1000;
-    thunkApi.dispatch(setCurrentTime(timestampInSeconds));
     triggerSetCurrentTime(timestampInSeconds);
 
     triggerPlayAudio();
@@ -121,10 +118,6 @@ export const audioPlayerStateSlice = createSlice({
     setReciter: (state, action: PayloadAction<Reciter>) => ({
       ...state,
       reciter: action.payload,
-    }),
-    setCurrentTime: (state: AudioState, action: PayloadAction<number>) => ({
-      ...state,
-      currentTime: action.payload,
     }),
     setAudioFile: (state: AudioState, action: PayloadAction<AudioFile>) => ({
       ...state,
@@ -156,7 +149,6 @@ export const audioPlayerStateSlice = createSlice({
 
 export const {
   setIsPlaying,
-  setCurrentTime,
   setReciter,
   setAudioFile,
   setAudioStatus,


### PR DESCRIPTION
### Summary
Performance improvement, 
- remove currentTime from redux and use `useState` instead
- and we no longer dispatching `setCurrentTime` everytime currentTime is updated. Because this will trigger all selector to re run, which cost performance
![image](https://user-images.githubusercontent.com/12745166/134128278-d6dc3418-b928-4990-b2ce-f0fe815201b3.png)
[redux dev tools screen when the audio is playing, no `setCurrentTime` is dispatched]