### PR TITLE
Fix broken hrefs in the link component

### DIFF
--- a/src/components/dls/Link/Link.tsx
+++ b/src/components/dls/Link/Link.tsx
@@ -23,7 +23,7 @@ type LinkProps = {
 const Link: React.FC<LinkProps> = ({ href, children, newTab = false, variant, download }) => (
   <Wrapper shouldWrap={!download} wrapper={(node) => <NextLink href={href}>{node}</NextLink>}>
     <a
-      href={download ? href : undefined}
+      href={download || href ? href : undefined}
       download={download}
       target={newTab ? '_blank' : undefined}
       rel={newTab ? 'noreferrer' : undefined}

--- a/src/components/dls/Link/Link.tsx
+++ b/src/components/dls/Link/Link.tsx
@@ -23,7 +23,7 @@ type LinkProps = {
 const Link: React.FC<LinkProps> = ({ href, children, newTab = false, variant, download }) => (
   <Wrapper shouldWrap={!download} wrapper={(node) => <NextLink href={href}>{node}</NextLink>}>
     <a
-      href={download || href ? href : undefined}
+      href={href}
       download={download}
       target={newTab ? '_blank' : undefined}
       rel={newTab ? 'noreferrer' : undefined}


### PR DESCRIPTION
### Summary
Our link components didn't work before. Passing an href (like in the homepage welcome message) caused the href on the anchor tag to be null making it uninteractive. 
