### PR TITLE
Fix global smooth scrolling

### DIFF
--- a/src/components/QuranReader/ReadingView/Line.tsx
+++ b/src/components/QuranReader/ReadingView/Line.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import styles from './Line.module.scss';
 
 import VerseText from 'src/components/Verse/VerseText';
-import useScroll, { SMOOTH_SCROLL_TO_CENTER_OPTIONS } from 'src/hooks/useScrollToElement';
+import useScroll, { SMOOTH_SCROLL_TO_CENTER } from 'src/hooks/useScrollToElement';
 import { selectEnableAutoScrolling } from 'src/redux/slices/AudioPlayer/state';
 import { selectIsLineHighlighted } from 'src/redux/slices/QuranReader/highlightedLocation';
 import Word from 'types/Word';
@@ -20,7 +20,7 @@ export type LineProps = {
 const Line = ({ lineKey, words, isBigTextLayout }: LineProps) => {
   const isHighlighted = useSelector(selectIsLineHighlighted(words.map((word) => word.verseKey)));
   const [scrollToSelectedItem, selectedItemRef]: [() => void, RefObject<HTMLDivElement>] =
-    useScroll(SMOOTH_SCROLL_TO_CENTER_OPTIONS);
+    useScroll(SMOOTH_SCROLL_TO_CENTER);
   const enableAutoScrolling = useSelector(selectEnableAutoScrolling);
 
   useEffect(() => {

--- a/src/components/QuranReader/ReadingView/Line.tsx
+++ b/src/components/QuranReader/ReadingView/Line.tsx
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import styles from './Line.module.scss';
 
 import VerseText from 'src/components/Verse/VerseText';
-import useScroll, { SCROLL_TO_CENTER_SCREEN } from 'src/hooks/useScrollToElement';
+import useScroll, { SMOOTH_SCROLL_TO_CENTER_OPTIONS } from 'src/hooks/useScrollToElement';
 import { selectEnableAutoScrolling } from 'src/redux/slices/AudioPlayer/state';
 import { selectIsLineHighlighted } from 'src/redux/slices/QuranReader/highlightedLocation';
 import Word from 'types/Word';
@@ -20,7 +20,7 @@ export type LineProps = {
 const Line = ({ lineKey, words, isBigTextLayout }: LineProps) => {
   const isHighlighted = useSelector(selectIsLineHighlighted(words.map((word) => word.verseKey)));
   const [scrollToSelectedItem, selectedItemRef]: [() => void, RefObject<HTMLDivElement>] =
-    useScroll(SCROLL_TO_CENTER_SCREEN);
+    useScroll(SMOOTH_SCROLL_TO_CENTER_OPTIONS);
   const enableAutoScrolling = useSelector(selectEnableAutoScrolling);
 
   useEffect(() => {

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -13,7 +13,7 @@ import OverflowVerseActionsMenu from 'src/components/Verse/OverflowVerseActionsM
 import PlayVerseAudioButton from 'src/components/Verse/PlayVerseAudioButton';
 import VerseLink from 'src/components/Verse/VerseLink';
 import VerseText from 'src/components/Verse/VerseText';
-import useScroll, { SCROLL_TO_CENTER_SCREEN } from 'src/hooks/useScrollToElement';
+import useScroll, { SMOOTH_SCROLL_TO_CENTER_OPTIONS } from 'src/hooks/useScrollToElement';
 import { selectEnableAutoScrolling } from 'src/redux/slices/AudioPlayer/state';
 import { selectIsVerseHighlighted } from 'src/redux/slices/QuranReader/highlightedLocation';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
@@ -31,7 +31,7 @@ const TranslationViewCell = ({ verse }: TranslationViewCellProps) => {
   const enableAutoScrolling = useSelector(selectEnableAutoScrolling);
 
   const [scrollToSelectedItem, selectedItemRef]: [() => void, RefObject<HTMLDivElement>] =
-    useScroll(SCROLL_TO_CENTER_SCREEN);
+    useScroll(SMOOTH_SCROLL_TO_CENTER_OPTIONS);
 
   useEffect(() => {
     if (isHighlighted && enableAutoScrolling) {

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -13,7 +13,7 @@ import OverflowVerseActionsMenu from 'src/components/Verse/OverflowVerseActionsM
 import PlayVerseAudioButton from 'src/components/Verse/PlayVerseAudioButton';
 import VerseLink from 'src/components/Verse/VerseLink';
 import VerseText from 'src/components/Verse/VerseText';
-import useScroll, { SMOOTH_SCROLL_TO_CENTER_OPTIONS } from 'src/hooks/useScrollToElement';
+import useScroll, { SMOOTH_SCROLL_TO_CENTER } from 'src/hooks/useScrollToElement';
 import { selectEnableAutoScrolling } from 'src/redux/slices/AudioPlayer/state';
 import { selectIsVerseHighlighted } from 'src/redux/slices/QuranReader/highlightedLocation';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
@@ -31,7 +31,7 @@ const TranslationViewCell = ({ verse }: TranslationViewCellProps) => {
   const enableAutoScrolling = useSelector(selectEnableAutoScrolling);
 
   const [scrollToSelectedItem, selectedItemRef]: [() => void, RefObject<HTMLDivElement>] =
-    useScroll(SMOOTH_SCROLL_TO_CENTER_OPTIONS);
+    useScroll(SMOOTH_SCROLL_TO_CENTER);
 
   useEffect(() => {
     if (isHighlighted && enableAutoScrolling) {

--- a/src/hooks/useScrollToElement.ts
+++ b/src/hooks/useScrollToElement.ts
@@ -23,8 +23,9 @@ export const useScrollToElement = <T extends HTMLElement>(
   return [executeScroll, elementRef];
 };
 
-export const SCROLL_TO_CENTER_SCREEN = {
+export const SMOOTH_SCROLL_TO_CENTER_OPTIONS = {
   block: 'center', // 'block' relates to vertical alignment. see: https://stackoverflow.com/a/48635751/1931451 for nearest.
+  behavior: 'smooth',
 } as ScrollIntoViewOptions;
 
 export default useScrollToElement;

--- a/src/hooks/useScrollToElement.ts
+++ b/src/hooks/useScrollToElement.ts
@@ -23,7 +23,7 @@ export const useScrollToElement = <T extends HTMLElement>(
   return [executeScroll, elementRef];
 };
 
-export const SMOOTH_SCROLL_TO_CENTER_OPTIONS = {
+export const SMOOTH_SCROLL_TO_CENTER = {
   block: 'center', // 'block' relates to vertical alignment. see: https://stackoverflow.com/a/48635751/1931451 for nearest.
   behavior: 'smooth',
 } as ScrollIntoViewOptions;

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -446,7 +446,3 @@ textarea {
   color: #000;
   padding: 0.2em 0;
 }
-
-html {
-  scroll-behavior: smooth;
-}


### PR DESCRIPTION
### Summary
Instead of doing smooth scrolling on an html level, we set the scrolling behavior to smooth when we call `useScrollToElement`

