### PR TITLE
New Audio player follow-up design polish

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -16,7 +16,7 @@
   border-top: 1px solid var(--color-borders-hairline);
   height: constants.$audio-player-default-height;
   @include breakpoints.tablet {
-    height: constants.$audio-player-default-height;
+    height: constants.$audio-player-default-desktop-height;
   }
 }
 

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -31,7 +31,6 @@ const AudioPlayer = () => {
   const audioFileStatus = useSelector(selectAudioFileStatus);
   const isHidden = audioFileStatus === AudioFileStatus.NoFile;
   const { id: reciterId } = useSelector(selectReciter, shallowEqual);
-  const durationInSeconds = audioFile?.duration / 1000 || 0;
   const isMobileMinimizedForScrolling = useSelector(selectIsMobileMinimizedForScrolling);
   const onDirectionChange = useCallback(
     (direction: ScrollDirection) => {
@@ -125,7 +124,6 @@ const AudioPlayer = () => {
           <AudioPlayerSlider
             audioPlayerElRef={audioPlayerElRef}
             isMobileMinimizedForScrolling={isMobileMinimizedForScrolling}
-            audioDuration={durationInSeconds}
           />
         </div>
       </div>

--- a/src/components/AudioPlayer/AudioPlayerSlider.module.scss
+++ b/src/components/AudioPlayer/AudioPlayerSlider.module.scss
@@ -8,10 +8,16 @@
   justify-content: space-between;
   color: var(--color-text-faded);
   font-size: var(--font-size-small);
+  min-height: var(
+    --font-size-small
+  ); // prevents CLS when the current/total time are not loaded yet
   margin-bottom: calc(-1 * var(--spacing-xsmall));
   transition: var(--transition-regular);
   @include breakpoints.tablet {
     font-size: var(--font-size-normal);
+    min-height: var(
+      --font-size-normal
+    ); // prevents CLS when the current/total time are not loaded yet
     margin-top: var(--spacing-medium);
     margin-bottom: calc(-2 * var(--spacing-small));
   }

--- a/src/components/AudioPlayer/AudioPlayerSlider.module.scss
+++ b/src/components/AudioPlayer/AudioPlayerSlider.module.scss
@@ -2,15 +2,28 @@
 @use "src/styles/constants";
 
 .container {
-  margin-top: var(--spacing-xsmall);
+  margin-top: var(--spacing-xxsmall);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   color: var(--color-text-faded);
   font-size: var(--font-size-small);
+  margin-bottom: calc(-1 * var(--spacing-xsmall));
+  transition: var(--transition-regular);
+  @include breakpoints.tablet {
+    font-size: var(--font-size-normal);
+    margin-top: var(--spacing-medium);
+    margin-bottom: calc(-2 * var(--spacing-small));
+  }
 }
 
-.splitsContainer {
+.containerMinimized {
+  @include breakpoints.smallerThanTablet {
+    margin-bottom: 0;
+  }
+}
+
+.sliderContainer {
   display: inline-block;
   position: fixed;
   left: 50%;
@@ -21,11 +34,11 @@
   transition: var(--transition-regular);
   bottom: constants.$audio-player-default-height;
   @include breakpoints.tablet {
-    bottom: constants.$audio-player-default-height;
+    bottom: constants.$audio-player-default-desktop-height;
   }
 }
 
-.splitsContainerMinimized {
+.sliderContainerMinimized {
   @include breakpoints.smallerThanTablet {
     left: 50%;
     margin: 0 auto;

--- a/src/components/AudioPlayer/AudioPlayerSlider.tsx
+++ b/src/components/AudioPlayer/AudioPlayerSlider.tsx
@@ -7,12 +7,11 @@ import { triggerSetCurrentTime } from './EventTriggers';
 import useAudioPlayerCurrentTime from './hooks/useCurrentTime';
 
 import Slider from 'src/components/dls/Slider';
-import { secondsFormatter, milliSecondsToSeconds } from 'src/utils/datetime';
+import { secondsFormatter } from 'src/utils/datetime';
 
 const NUMBER_OF_STEPS = 100;
 
 type SliderProps = {
-  audioDuration: number;
   isMobileMinimizedForScrolling: boolean;
   audioPlayerElRef: React.MutableRefObject<HTMLAudioElement>;
 };
@@ -27,28 +26,26 @@ const AUDIO_THROTTLE_DURATION = 1000;
  * @returns {JSX.Element}
  */
 const AudioPlayerSlider = ({
-  audioDuration,
   isMobileMinimizedForScrolling,
   audioPlayerElRef,
 }: SliderProps): JSX.Element => {
   const currentTime = useAudioPlayerCurrentTime(audioPlayerElRef, AUDIO_THROTTLE_DURATION);
+  const audioDuration = audioPlayerElRef.current?.duration;
+
   const isAudioLoaded = audioDuration !== 0;
   const [currentStep, setCurrentStep] = useState(0);
-  const audioDurationMilliSeconds = useMemo(
-    () => milliSecondsToSeconds(audioDuration),
-    [audioDuration],
-  );
+
   useEffect(() => {
-    setCurrentStep(getCurrentStep(currentTime, isAudioLoaded, audioDurationMilliSeconds));
-  }, [currentTime, isAudioLoaded, audioDurationMilliSeconds]);
+    setCurrentStep(getCurrentStep(currentTime, isAudioLoaded, audioDuration));
+  }, [currentTime, isAudioLoaded, audioDuration]);
   const currentSteps = useMemo(() => [currentStep], [currentStep]);
   const handleOnValueChange = useCallback(
     (newValue: number[]) => {
       const [newStep] = newValue;
       setCurrentStep(newStep);
-      triggerSetCurrentTime(getNewCurrentTime(newStep, audioDurationMilliSeconds));
+      triggerSetCurrentTime(getNewCurrentTime(newStep, audioDuration));
     },
-    [audioDurationMilliSeconds],
+    [audioDuration],
   );
 
   return (

--- a/src/components/AudioPlayer/AudioPlayerSlider.tsx
+++ b/src/components/AudioPlayer/AudioPlayerSlider.tsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState, useEffect, useCallback } from 'react';
 
 import classNames from 'classnames';
 
+import styles from './AudioPlayerSlider.module.scss';
 import { triggerSetCurrentTime } from './EventTriggers';
 import useAudioPlayerCurrentTime from './hooks/useCurrentTime';
-import styles from './Slider.module.scss';
 
 import Slider from 'src/components/dls/Slider';
 import { secondsFormatter, milliSecondsToSeconds } from 'src/utils/datetime';
@@ -32,7 +32,6 @@ const AudioPlayerSlider = ({
   audioPlayerElRef,
 }: SliderProps): JSX.Element => {
   const currentTime = useAudioPlayerCurrentTime(audioPlayerElRef, AUDIO_THROTTLE_DURATION);
-  const remainingTime = audioDuration - currentTime;
   const isAudioLoaded = audioDuration !== 0;
   const [currentStep, setCurrentStep] = useState(0);
   const audioDurationMilliSeconds = useMemo(
@@ -53,11 +52,15 @@ const AudioPlayerSlider = ({
   );
 
   return (
-    <div className={styles.container}>
+    <div
+      className={classNames(styles.container, {
+        [styles.containerMinimized]: isMobileMinimizedForScrolling,
+      })}
+    >
       <span className={styles.currentTime}>{secondsFormatter(currentTime)}</span>
       <div
-        className={classNames(styles.splitsContainer, {
-          [styles.splitsContainerMinimized]: isMobileMinimizedForScrolling,
+        className={classNames(styles.sliderContainer, {
+          [styles.sliderContainerMinimized]: isMobileMinimizedForScrolling,
         })}
       >
         <Slider
@@ -67,7 +70,7 @@ const AudioPlayerSlider = ({
           max={NUMBER_OF_STEPS}
         />
       </div>
-      <span className={styles.remainingTime}>{secondsFormatter(remainingTime)}</span>
+      <span className={styles.remainingTime}>{secondsFormatter(audioDuration)}</span>
     </div>
   );
 };

--- a/src/components/AudioPlayer/AudioPlayerSlider.tsx
+++ b/src/components/AudioPlayer/AudioPlayerSlider.tsx
@@ -30,9 +30,10 @@ const AudioPlayerSlider = ({
   audioPlayerElRef,
 }: SliderProps): JSX.Element => {
   const currentTime = useAudioPlayerCurrentTime(audioPlayerElRef, AUDIO_THROTTLE_DURATION);
-  const audioDuration = audioPlayerElRef.current?.duration;
+  const audioDuration = audioPlayerElRef?.current?.duration || 0;
 
   const isAudioLoaded = audioDuration !== 0;
+
   const [currentStep, setCurrentStep] = useState(0);
 
   useEffect(() => {

--- a/src/components/AudioPlayer/AudioPlayerSlider.tsx
+++ b/src/components/AudioPlayer/AudioPlayerSlider.tsx
@@ -77,24 +77,23 @@ const AudioPlayerSlider = ({
  *
  * @param {number} currentTime
  * @param {boolean} isAudioLoaded
- * @param {number} audioDurationMilliSeconds
+ * @param {number} audioDuration
  * @returns {number}
  */
 const getCurrentStep = (
   currentTime: number,
   isAudioLoaded: boolean,
-  audioDurationMilliSeconds: number,
-): number =>
-  isAudioLoaded ? Math.floor((currentTime * NUMBER_OF_STEPS) / audioDurationMilliSeconds) : 0;
+  audioDuration: number,
+): number => (isAudioLoaded ? Math.floor((currentTime * NUMBER_OF_STEPS) / audioDuration) : 0);
 
 /**
  * Calculate the new current time the needs the audioPlayer needs to be set to.
  *
  * @param {number} newStep
- * @param {number} audioDurationMilliSeconds
+ * @param {number} audioDuration
  * @returns {number}
  */
-const getNewCurrentTime = (newStep: number, audioDurationMilliSeconds: number): number =>
-  (newStep * audioDurationMilliSeconds) / NUMBER_OF_STEPS;
+const getNewCurrentTime = (newStep: number, audioDuration: number): number =>
+  (newStep * audioDuration) / NUMBER_OF_STEPS;
 
 export default AudioPlayerSlider;

--- a/src/components/FeedbackWidget/FeedbackWidget.module.scss
+++ b/src/components/FeedbackWidget/FeedbackWidget.module.scss
@@ -15,7 +15,7 @@
     margin-bottom: constants.$audio-player-minimized-height;
     bottom: var(--spacing-medium);
     @include breakpoints.tablet {
-      margin-bottom: constants.$audio-player-default-height;
+      margin-bottom: constants.$audio-player-default-desktop-height;
     }
   }
 }
@@ -23,7 +23,7 @@
 .audioPlayerOpen {
   margin-bottom: constants.$audio-player-default-height;
   @include breakpoints.tablet {
-    margin-bottom: constants.$audio-player-default-height;
+    margin-bottom: constants.$audio-player-default-desktop-height;
   }
   bottom: var(--spacing-medium);
 }

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -6,6 +6,8 @@ $notes-side-bar-desktop-width: 26rem;
 
 $audio-player-minimized-height: 2rem;
 
-$audio-player-default-height: 4rem;
+$audio-player-default-height: 3.5rem;
+
+$audio-player-default-desktop-height: 3rem;
 
 $maximum-font-step: 5;

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,6 +1,6 @@
 // Converts seconds to (hours), minutes, and seconds
 export const secondsFormatter = (seconds: number) => {
-  if (Number.isNaN(seconds)) {
+  if (!seconds || Number.isNaN(seconds)) {
     return '';
   }
   let formattedTime = new Date(seconds * 1000).toISOString().substr(12, 7);


### PR DESCRIPTION
### Summary
* Reduce the height of the player on desktop and mobile (currently uses negative margin, the time and button should be combined into a single component) 
* Use total time instead of remaining time

### Mobile Screenshots

| Before | After |
| ------ | ------ |
| ![2021-09-25 at 16 49 25](https://user-images.githubusercontent.com/11590314/134775591-65a29f36-e9bf-41e4-b9bf-9c994d071158.png) | ![2021-09-25 at 16 49 38](https://user-images.githubusercontent.com/11590314/134775603-6dd2e47f-33e4-4519-93e4-0ef9c6bf32c2.png) |

### Desktop Screenshots

| Before | After |
| ------ | ------ |
| ![2021-09-25 at 16 48 43](https://user-images.githubusercontent.com/11590314/134775571-1f39a220-50e9-43eb-a002-27481689bc74.png) | ![2021-09-25 at 16 47 52](https://user-images.githubusercontent.com/11590314/134775548-323c3199-cd35-4a9c-ac7c-1b2ecdd4fb5d.png) |