### PR TITLE
Remove ComboboxItem CLS on hover

### DIFF
--- a/src/components/dls/Forms/Combobox/ComboboxItem/ComboboxItem.module.scss
+++ b/src/components/dls/Forms/Combobox/ComboboxItem/ComboboxItem.module.scss
@@ -15,7 +15,6 @@
   cursor: pointer;
   &:hover {
     background: var(--color-background-alternative);
-    font-weight: var(--font-weight-bold);
   }
 }
 .disabledItem {


### PR DESCRIPTION
### Summary
This PR remove the CLS that happens when the user hovers on an item which sometimes leads to some items being split into two lines instead of the same line.


### Screenshots

| Before | After |
| ------ | ------ |
|<img width="283" alt="Screen Shot 2021-09-26 at 19 13 15" src="https://user-images.githubusercontent.com/15169499/134807593-ec874cbc-b9db-4f9f-a572-626f241a74f0.png">|<img width="280" alt="Screen Shot 2021-09-26 at 19 12 57" src="https://user-images.githubusercontent.com/15169499/134807591-42537a10-3d43-43ef-9cec-31a9f0d548bc.png">|