### PR TITLE
add "Stop Repeating" action to repeat audio modal

### DIFF
--- a/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.tsx
+++ b/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.tsx
@@ -92,7 +92,7 @@ const RepeatAudioModal = ({
     onClose();
   };
   const onCancelClick = () => onClose();
-  const onExitRepeatMode = () => {
+  const onStopRepeating = () => {
     dispatch(exitRepeatMode());
     triggerPauseAudio();
     onClose();
@@ -155,8 +155,8 @@ const RepeatAudioModal = ({
         </div>
       </Modal.Body>
       <Modal.Footer>
-        <Modal.Action onClick={isInRepeatMode ? onExitRepeatMode : onCancelClick}>
-          {isInRepeatMode ? 'Exit Repeat Mode' : 'Cancel'}
+        <Modal.Action onClick={isInRepeatMode ? onStopRepeating : onCancelClick}>
+          {isInRepeatMode ? 'Stop Repeating' : 'Cancel'}
         </Modal.Action>
         <Modal.Action onClick={onPlayClick}>Start Playing</Modal.Action>
       </Modal.Footer>


### PR DESCRIPTION
### Summary
When repeat mode is active, the action on the left will "Exit Repeat Mode". When clicked it will exit the repeat mode and pause the audio

### Test Plan
- Repeat the range / verse
- Click the repeat button
- Click Exit Repeat Mode, it should pause the audio and exit the repeat mode (it's easier to see when the repeat mode badge PR is merged)

### Screenshots

![image](https://user-images.githubusercontent.com/12745166/135566374-b37309a4-3e38-43d9-92fa-d9d9bbc93a84.png)
