### PR TITLE
Prevent additional API call when clicking "play" button on TranslationView Cell

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -64,7 +64,10 @@ const TranslationViewCell = ({ verse }: TranslationViewCellProps) => {
           </div>
           <div className={styles.actionContainerRight}>
             <div className={styles.actionItem}>
-              <PlayVerseAudioButton verseKey={verse.verseKey} />
+              <PlayVerseAudioButton
+                verseKey={verse.verseKey}
+                timestamp={verse.timestamps.timestampFrom}
+              />
             </div>
             <div className={styles.actionItem}>
               <OverflowVerseActionsMenu verse={verse} />

--- a/src/components/Verse/PlayVerseAudioButton.tsx
+++ b/src/components/Verse/PlayVerseAudioButton.tsx
@@ -20,8 +20,9 @@ import { getChapterNumberFromKey } from 'src/utils/verse';
 
 interface PlayVerseAudioProps {
   verseKey: string;
+  timestamp: number;
 }
-const PlayVerseAudioButton = ({ verseKey }: PlayVerseAudioProps) => {
+const PlayVerseAudioButton = ({ verseKey, timestamp }: PlayVerseAudioProps) => {
   const dispatch = useDispatch();
   const [isLoading, setIsLoading] = useState(false);
   const { id: reciterId } = useSelector(selectReciter, shallowEqual);
@@ -41,7 +42,7 @@ const PlayVerseAudioButton = ({ verseKey }: PlayVerseAudioProps) => {
       playFrom({
         chapterId,
         reciterId,
-        verseKey,
+        timestamp,
       }),
     );
 

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -161,6 +161,7 @@ export const playFrom = createAsyncThunk<void, PlayFromInput, { state: RootState
       window.audioPlayerEl.load(); // load the audio file, it's not preloaded on safari mobile https://stackoverflow.com/questions/49792768/js-html5-audio-why-is-canplaythrough-not-fired-on-ios-safari
     }
 
+    // `timestamp` is not provided, we need to get the timestamp data for the verseKey by fetching it from the API
     if (!timestamp) {
       const timestampsData = await getChapterAudioFile(reciterId, chapterId, true);
       const verseTiming = getVerseTimingByVerseKey(verseKey, timestampsData.verseTimings);

--- a/src/redux/slices/AudioPlayer/state.ts
+++ b/src/redux/slices/AudioPlayer/state.ts
@@ -143,13 +143,14 @@ export const setReciterAndPauseAudio = createAsyncThunk<void, Reciter, { state: 
  *
  */
 interface PlayFromInput {
-  verseKey: string;
+  verseKey?: string;
   chapterId: number;
   reciterId: number;
+  timestamp?: number;
 }
 export const playFrom = createAsyncThunk<void, PlayFromInput, { state: RootState }>(
   'audioPlayerState/playFrom',
-  async ({ verseKey, chapterId, reciterId }, thunkApi) => {
+  async ({ verseKey, chapterId, reciterId, timestamp }, thunkApi) => {
     const state = thunkApi.getState();
     const reciter = selectReciter(state);
     let audioFile = selectAudioFile(state);
@@ -160,10 +161,13 @@ export const playFrom = createAsyncThunk<void, PlayFromInput, { state: RootState
       window.audioPlayerEl.load(); // load the audio file, it's not preloaded on safari mobile https://stackoverflow.com/questions/49792768/js-html5-audio-why-is-canplaythrough-not-fired-on-ios-safari
     }
 
-    const timestampsData = await getChapterAudioFile(reciterId, chapterId, true);
-    const verseTiming = getVerseTimingByVerseKey(verseKey, timestampsData.verseTimings);
-    const timestampInSeconds = verseTiming.timestampFrom / 1000;
-    playFromTimestamp(timestampInSeconds);
+    if (!timestamp) {
+      const timestampsData = await getChapterAudioFile(reciterId, chapterId, true);
+      const verseTiming = getVerseTimingByVerseKey(verseKey, timestampsData.verseTimings);
+      playFromTimestamp(verseTiming.timestampFrom / 1000);
+      return;
+    }
+    playFromTimestamp(timestamp / 1000);
   },
 );
 


### PR DESCRIPTION
### Summary

Clicking the play button here, now won't trigger additional API calls to fetch the timestamp data. We will use the verse's timestamp data that comes from verses API

![image](https://user-images.githubusercontent.com/12745166/135568018-c80267f0-8510-4d90-8a46-ed7339214973.png)


