### PR TITLE
Add KeyboardInput component to DLS

### DIFF
--- a/src/components/dls/KeyboardInput/KeyboardInput.module.scss
+++ b/src/components/dls/KeyboardInput/KeyboardInput.module.scss
@@ -1,0 +1,15 @@
+.container {
+  color: var(--color-text-faded);
+  background: var(--color-background-alternative);
+  border: 1px solid var(--color-borders-hairline);
+  display: inline-block;
+  text-align: center;
+  min-width: calc(0.5 * var(--spacing-medium));
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-large);
+  padding: 0 var(--spacing-xsmall);
+  border-radius: var(--border-radius-default);
+  > span + span {
+    margin-left: var(--spacing-xsmall);
+  }
+}

--- a/src/components/dls/KeyboardInput/KeyboardInput.stories.tsx
+++ b/src/components/dls/KeyboardInput/KeyboardInput.stories.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import KeyboardInput from '.';
+
+export default {
+  title: 'dls/KeyboardInput',
+  component: KeyboardInput,
+  argTypes: {
+    keyboardKey: {
+      description: 'the keyboard key.',
+      table: { category: 'Optional' },
+      control: { type: 'text' },
+    },
+    meta: {
+      description: 'whether META (cmd in MAC) modifier should be shown',
+      table: { category: 'Optional' },
+      options: [true, false],
+      control: { type: 'radio' },
+    },
+    shift: {
+      description: 'whether SHIFT modifier should be shown',
+      table: { category: 'Optional' },
+      options: [true, false],
+      control: { type: 'radio' },
+    },
+    alt: {
+      description: 'whether ALT modifier should be shown',
+      table: { category: 'Optional' },
+      options: [true, false],
+      control: { type: 'radio' },
+    },
+    ctrl: {
+      description: 'whether CTRL modifier should be shown',
+      table: { category: 'Optional' },
+      options: [true, false],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+const Template = (args) => <KeyboardInput {...args} />;
+
+export const DefaultKeyboard = Template.bind({});
+DefaultKeyboard.args = {
+  keyboardKey: 'B',
+};
+export const WithMeta = Template.bind({});
+WithMeta.args = {
+  meta: true,
+};
+export const WithShift = Template.bind({});
+WithShift.args = {
+  shift: true,
+};
+export const WithAlt = Template.bind({});
+WithAlt.args = {
+  alt: true,
+};
+export const WithCtrl = Template.bind({});
+WithCtrl.args = {
+  ctrl: true,
+};
+export const WithMetaAndK = Template.bind({});
+WithMetaAndK.args = {
+  meta: true,
+  keyboardKey: 'K',
+};
+export const WithAll = Template.bind({});
+WithAll.args = {
+  meta: true,
+  shift: true,
+  alt: true,
+  ctrl: true,
+  keyboardKey: 'T',
+};

--- a/src/components/dls/KeyboardInput/index.tsx
+++ b/src/components/dls/KeyboardInput/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import styles from './KeyboardInput.module.scss';
+
+interface Props {
+  keyboardKey?: string;
+  meta?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  ctrl?: boolean;
+}
+
+const KeyboardInput: React.FC<Props> = ({ keyboardKey, meta, shift, alt, ctrl }) => {
+  return (
+    <kbd className={styles.container}>
+      {meta && <span>⌘</span>}
+      {shift && <span>⇧</span>}
+      {alt && <span>⌥</span>}
+      {ctrl && <span>⌃</span>}
+      {keyboardKey && <span>{keyboardKey}</span>}
+    </kbd>
+  );
+};
+
+export default KeyboardInput;


### PR DESCRIPTION
### Summary
This PR adds `KeyboardInput` component to DLS. The component will be used as a UI indicator to which keyboard shortcuts are available either globally or inside a specific component.