### PR TITLE
Add CloudFlare API host and set-up link preconnect

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import Navbar from 'src/components/Navbar/Navbar';
 import ThirdPartyScripts from 'src/components/ThirdPartyScripts/ThirdPartyScripts';
 import ReduxProvider from 'src/redux/Provider';
 import ThemeProvider from 'src/styles/ThemeProvider';
+import { API_HOST } from 'src/utils/api';
 import { createSEOConfig } from 'src/utils/seo';
 
 import 'src/styles/reset.scss';
@@ -24,6 +25,7 @@ function MyApp({ Component, pageProps }): JSX.Element {
     <>
       <Head>
         <link rel="manifest" href="/manifest.json" />
+        <link rel="preconnect" href={API_HOST} />
       </Head>
       <ReduxProvider>
         <ThemeProvider>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,8 +6,10 @@ import { Mushaf, MushafLines, QuranFont, QuranFontMushaf } from 'types/QuranRead
 
 export const ITEMS_PER_PAGE = 10;
 
-const STAGING_API_HOST = 'https://staging.quran.com/api/qdc';
-const PRODUCTION_API_HOST = 'https://api.quran.com/api/qdc';
+const STAGING_API_HOST = 'https://staging.quran.com';
+const PRODUCTION_API_HOST = 'https://api.qurancdn.com';
+
+const API_ROOT_PATH = '/api/qdc/';
 
 // env variables in Vercel can't be dynamic, we have to hardcode the urls here. https://stackoverflow.com/questions/44342226/next-js-error-only-absolute-urls-are-supported
 export const API_HOST =
@@ -22,7 +24,7 @@ export const API_HOST =
  */
 export const makeUrl = (path: string, parameters?: Record<string, unknown>): string => {
   if (!parameters) {
-    return `${API_HOST}${path}`;
+    return `${API_HOST}${API_ROOT_PATH}${path}`;
   }
 
   const decamelizedParams = decamelizeKeys(parameters);
@@ -30,7 +32,7 @@ export const makeUrl = (path: string, parameters?: Record<string, unknown>): str
   // The following section parses the query params for convenience
   // E.g. parses {a: 1, b: 2} to "?a=1&b=2"
   const queryParameters = `?${stringify(decamelizedParams)}`;
-  return `${API_HOST}${path}${queryParameters}`;
+  return `${API_HOST}${API_ROOT_PATH}${path}${queryParameters}`;
 };
 
 /**


### PR DESCRIPTION
Our production environment now points to CloudFront's edge api cache causing 25-30% reduction in api response time. 

Also set up preconnection to the api host to rduce the response time. Thank you @naveed-ahmad for the tip! 