### PR TITLE
Hack: popovermenu position audioplayer

### DIFF
--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
@@ -1,11 +1,11 @@
 @use "src/styles/breakpoints";
 // This is a hack to use popover menu with a fixed element
 // Reference: https://github.com/radix-ui/primitives/issues/781
-.manualPopoverMenuContentPositioning {
+.overriddenPopoverMenuContentPositioning {
   position: relative;
 }
 
-.manualPopoverMenuContentPositioning [data-radix-popper-content-wrapper] {
+.overriddenPopoverMenuContentPositioning [data-radix-popper-content-wrapper] {
   top: initial !important;
   bottom: calc(1.5 * var(--spacing-mega)) !important;
   position: absolute !important;

--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
@@ -1,0 +1,13 @@
+// This is a hack to use popover menu with a fixed element
+// Reference: https://github.com/radix-ui/primitives/issues/781
+.manualPopoverMenuContentPositioning {
+  position: relative;
+}
+
+.manualPopoverMenuContentPositioning [data-radix-popper-content-wrapper] {
+  top: initial !important;
+  left: 50% !important;
+  transform: translate3d(-50%, 0, 0) !important;
+  bottom: calc(1.5 * var(--spacing-mega)) !important;
+  position: absolute !important;
+}

--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
@@ -1,3 +1,4 @@
+@use "src/styles/breakpoints";
 // This is a hack to use popover menu with a fixed element
 // Reference: https://github.com/radix-ui/primitives/issues/781
 .manualPopoverMenuContentPositioning {
@@ -6,8 +7,14 @@
 
 .manualPopoverMenuContentPositioning [data-radix-popper-content-wrapper] {
   top: initial !important;
-  left: 50% !important;
-  transform: translate3d(-50%, 0, 0) !important;
   bottom: calc(1.5 * var(--spacing-mega)) !important;
   position: absolute !important;
+  z-index: var(--z-index-max);
+  left: 100% !important;
+  transform: translate3d(-100%, 0, 0) !important;
+
+  @include breakpoints.tablet {
+    left: 50% !important;
+    transform: translate3d(-50%, 0, 0) !important;
+  }
 }

--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.tsx
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.tsx
@@ -9,7 +9,7 @@ import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 
 const OverflowAudioPlayerActionsMenu = () => {
   return (
-    <div className={styles.manualPopoverMenuContentPositioning}>
+    <div className={styles.overriddenPopoverMenuContentPositioning}>
       <PopoverMenu
         isPortalled={false}
         trigger={

--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.tsx
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.tsx
@@ -2,22 +2,26 @@ import OverflowMenuIcon from '../../../public/icons/menu_more_horiz.svg';
 
 import CloseButton from './Buttons/CloseButton';
 import DownloadAudioButton from './Buttons/DownloadAudioButton';
+import styles from './OverflowAudioPlayerActionsMenu.module.scss';
 
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 
 const OverflowAudioPlayerActionsMenu = () => {
   return (
-    <PopoverMenu
-      trigger={
-        <Button tooltip="More" variant={ButtonVariant.Ghost} shape={ButtonShape.Circle}>
-          <OverflowMenuIcon />
-        </Button>
-      }
-    >
-      <DownloadAudioButton />
-      <CloseButton />
-    </PopoverMenu>
+    <div className={styles.manualPopoverMenuContentPositioning}>
+      <PopoverMenu
+        isPortalled={false}
+        trigger={
+          <Button tooltip="More" variant={ButtonVariant.Ghost} shape={ButtonShape.Circle}>
+            <OverflowMenuIcon />
+          </Button>
+        }
+      >
+        <DownloadAudioButton />
+        <CloseButton />
+      </PopoverMenu>
+    </div>
   );
 };
 

--- a/src/components/dls/PopoverMenu/PopoverMenu.tsx
+++ b/src/components/dls/PopoverMenu/PopoverMenu.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-multi-comp */
 
 import * as PrimitiveDropdownMenu from '@radix-ui/react-dropdown-menu';
+import classNames from 'classnames';
 
 import styles from './PopoverMenu.module.scss';
 
@@ -8,8 +9,9 @@ type PopoverMenuProps = {
   isOpen?: boolean;
   children: React.ReactNode;
   trigger?: React.ReactNode;
+  isPortalled?: boolean;
 };
-const PopoverMenu = ({ children, isOpen, trigger }: PopoverMenuProps) => {
+const PopoverMenu = ({ children, isOpen, trigger, isPortalled = true }: PopoverMenuProps) => {
   return (
     <PrimitiveDropdownMenu.Root open={isOpen}>
       {trigger && (
@@ -17,7 +19,7 @@ const PopoverMenu = ({ children, isOpen, trigger }: PopoverMenuProps) => {
           <span>{trigger}</span>
         </PrimitiveDropdownMenu.Trigger>
       )}
-      <PrimitiveDropdownMenu.Content className={styles.content}>
+      <PrimitiveDropdownMenu.Content className={classNames(styles.content)} portalled={isPortalled}>
         {children}
       </PrimitiveDropdownMenu.Content>
     </PrimitiveDropdownMenu.Root>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,8 +35,8 @@ function MyApp({ Component, pageProps }): JSX.Element {
             <Navbar />
             <DeveloperUtility />
             <Component {...pageProps} />
-            <AudioPlayer />
             <FeedbackWidget />
+            <AudioPlayer />
           </IdProvider>
         </ThemeProvider>
       </ReduxProvider>


### PR DESCRIPTION
### Summary

Desktop
![image](https://user-images.githubusercontent.com/12745166/136647318-45afc9a9-ce71-4072-9caa-f36be7fe7525.png)

Tablet
![image](https://user-images.githubusercontent.com/12745166/136647323-6409a77a-ec48-4f84-bc24-3c4fee5e7eeb.png)

Mobile
![image](https://user-images.githubusercontent.com/12745166/136647307-0e93a2bf-490a-4482-a8e3-d8225939d0a3.png)


When auto scroll to highlhgted verse on mobile / tablet
![image](https://user-images.githubusercontent.com/12745166/136647341-2b36bce0-ac29-4d69-9953-4afcb8e7155e.png)

When auto scroll to highlighted verse on desktop
![image](https://user-images.githubusercontent.com/12745166/136647363-679e09b9-381c-4fc5-a3c5-528c61658d4c.png)

