### PR TITLE
Fix API root path

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -9,7 +9,7 @@ export const ITEMS_PER_PAGE = 10;
 const STAGING_API_HOST = 'https://staging.quran.com';
 const PRODUCTION_API_HOST = 'https://api.qurancdn.com';
 
-const API_ROOT_PATH = '/api/qdc/';
+const API_ROOT_PATH = '/api/qdc';
 
 // env variables in Vercel can't be dynamic, we have to hardcode the urls here. https://stackoverflow.com/questions/44342226/next-js-error-only-absolute-urls-are-supported
 export const API_HOST =


### PR DESCRIPTION
### Summary
This PR removes an extra `/` added at the end of the root path which resulted in the generated API path being in the following format:

`https://staging.quran.com/api/qdc//resources/translations?language=en`

instead of

`https://staging.quran.com/api/qdc/resources/translations?language=en`

<img width="1439" alt="Screen Shot 2021-10-10 at 06 28 23" src="https://user-images.githubusercontent.com/15169499/136676190-5f3de0e1-5795-42bd-809e-04f17fded30f.png">