### PR TITLE
Add global scroll listener

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -12,7 +12,6 @@ import MediaSessionApiListeners from './MediaSessionApiListeners';
 import PlaybackControls from './PlaybackControls';
 import QuranReaderHighlightDispatcher from './QuranReaderHighlightDispatcher';
 
-import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
 import {
   setIsPlaying,
   selectAudioData,
@@ -20,7 +19,6 @@ import {
   setAudioStatus,
   AudioDataStatus,
   selectReciter,
-  setIsMobileMinimizedForScrolling,
   selectIsMobileMinimizedForScrolling,
 } from 'src/redux/slices/AudioPlayer/state';
 
@@ -32,18 +30,6 @@ const AudioPlayer = () => {
   const isHidden = audioDataStatus === AudioDataStatus.NoFile;
   const { id: reciterId } = useSelector(selectReciter, shallowEqual);
   const isMobileMinimizedForScrolling = useSelector(selectIsMobileMinimizedForScrolling);
-  const onDirectionChange = useCallback(
-    (direction: ScrollDirection) => {
-      if (direction === ScrollDirection.Down && !isMobileMinimizedForScrolling) {
-        dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: true });
-      } else if (direction === ScrollDirection.Up && isMobileMinimizedForScrolling) {
-        dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: false });
-      }
-    },
-    [dispatch, isMobileMinimizedForScrolling],
-  );
-  useScrollDirection(onDirectionChange);
-
   const onAudioPlay = useCallback(() => {
     dispatch({ type: setIsPlaying.type, payload: true });
   }, [dispatch]);

--- a/src/components/GlobalListeners.tsx
+++ b/src/components/GlobalListeners.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import GlobalKeyboardListeners from 'src/components/GlobalKeyboardListeners';
+import GlobalScrollListener from 'src/components/GlobalScrollListener';
+
+const GlobalListeners = () => {
+  return (
+    <>
+      <GlobalKeyboardListeners />
+      <GlobalScrollListener />
+    </>
+  );
+};
+
+export default GlobalListeners;

--- a/src/components/GlobalScrollListener.tsx
+++ b/src/components/GlobalScrollListener.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback } from 'react';
+
+import { useDispatch } from 'react-redux';
+
+import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
+import { setIsMobileMinimizedForScrolling } from 'src/redux/slices/AudioPlayer/state';
+import { setIsVisible } from 'src/redux/slices/navbar';
+import { setIsExpanded } from 'src/redux/slices/QuranReader/contextMenu';
+
+const GlobalScrollListener = () => {
+  const dispatch = useDispatch();
+  const onDirectionChange = useCallback(
+    (direction: ScrollDirection, newYPosition: number) => {
+      /**
+       * We need to only accept when the new position is >= 0 because on mobile, if the user swipes up
+       * and the scroll bar passes the uppermost part of the viewport, the new y position becomes below
+       * zero then the browser forces the view to go to exactly 0 again so the hook detects it's
+       * a down direction and hides the navbar, context menu and audioPlayer.
+       */
+      if (newYPosition > 0 && direction === ScrollDirection.Down) {
+        dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: true });
+        dispatch({ type: setIsExpanded.type, payload: false });
+        dispatch({ type: setIsVisible.type, payload: false });
+      } else if (newYPosition >= 0 && direction === ScrollDirection.Up) {
+        dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: false });
+        dispatch({ type: setIsExpanded.type, payload: true });
+        dispatch({ type: setIsVisible.type, payload: true });
+      }
+    },
+    [dispatch],
+  );
+  useScrollDirection(onDirectionChange);
+  return <></>;
+};
+
+export default GlobalScrollListener;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import classNames from 'classnames';
 import Link from 'next/link';
@@ -16,31 +16,16 @@ import SearchDrawer from './SearchDrawer/SearchDrawer';
 import SettingsDrawer from './SettingsDrawer/SettingsDrawer';
 
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
-import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
 import {
   selectNavbar,
   setIsSearchDrawerOpen,
   setIsNavigationDrawerOpen,
   setIsSettingsDrawerOpen,
-  setIsVisible,
 } from 'src/redux/slices/navbar';
 
 const Navbar = () => {
   const { isVisible } = useSelector(selectNavbar, shallowEqual);
   const dispatch = useDispatch();
-
-  const onDirectionChange = useCallback(
-    (direction: ScrollDirection) => {
-      if (direction === ScrollDirection.Up && !isVisible) {
-        dispatch({ type: setIsVisible.type, payload: true });
-      } else if (direction === ScrollDirection.Down && isVisible) {
-        dispatch({ type: setIsVisible.type, payload: false });
-      }
-    },
-    [dispatch, isVisible],
-  );
-  useScrollDirection(onDirectionChange);
-
   const openNavigationDrawer = () => {
     dispatch({ type: setIsNavigationDrawerOpen.type, payload: true });
   };

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -1,13 +1,12 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 
 import classNames from 'classnames';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 
 import styles from './ContextMenu.module.scss';
 
-import useScrollDirection, { ScrollDirection } from 'src/hooks/useScrollDirection';
 import { selectNavbar } from 'src/redux/slices/navbar';
-import { selectContextMenu, setIsExpanded } from 'src/redux/slices/QuranReader/contextMenu';
+import { selectContextMenu } from 'src/redux/slices/QuranReader/contextMenu';
 import { selectNotes } from 'src/redux/slices/QuranReader/notes';
 import { selectLastReadVerseKey } from 'src/redux/slices/QuranReader/readingTracker';
 import { getChapterData, getChapterReadingProgress } from 'src/utils/chapter';
@@ -15,22 +14,10 @@ import { getJuzNumberByHizb } from 'src/utils/juz';
 import { getVerseNumberFromKey } from 'src/utils/verse';
 
 const ContextMenu = () => {
-  const dispatch = useDispatch();
   const isSideBarVisible = useSelector(selectNotes, shallowEqual).isVisible;
   const { isExpanded } = useSelector(selectContextMenu, shallowEqual);
   const isNavbarVisible = useSelector(selectNavbar, shallowEqual).isVisible;
   const { verseKey, chapterId, page, hizb } = useSelector(selectLastReadVerseKey, shallowEqual);
-  const onDirectionChange = useCallback(
-    (direction: ScrollDirection) => {
-      if (direction === ScrollDirection.Up && !isExpanded) {
-        dispatch({ type: setIsExpanded.type, payload: true });
-      } else if (direction === ScrollDirection.Down && isExpanded) {
-        dispatch({ type: setIsExpanded.type, payload: false });
-      }
-    },
-    [dispatch, isExpanded],
-  );
-  useScrollDirection(onDirectionChange);
   const chapterData = useMemo(() => {
     return chapterId ? getChapterData(chapterId) : null;
   }, [chapterId]);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,7 @@ import Head from 'next/head';
 import AudioPlayer from 'src/components/AudioPlayer/AudioPlayer';
 import DeveloperUtility from 'src/components/DeveloperUtility/DeveloperUtility';
 import FeedbackWidget from 'src/components/FeedbackWidget/FeedbackWidget';
-import GlobalKeyboardListeners from 'src/components/GlobalKeyboardListeners';
+import GlobalListeners from 'src/components/GlobalListeners';
 import Navbar from 'src/components/Navbar/Navbar';
 import ThirdPartyScripts from 'src/components/ThirdPartyScripts/ThirdPartyScripts';
 import ReduxProvider from 'src/redux/Provider';
@@ -31,7 +31,7 @@ function MyApp({ Component, pageProps }): JSX.Element {
         <ThemeProvider>
           <IdProvider>
             <DefaultSeo {...createSEOConfig({})} />
-            <GlobalKeyboardListeners />
+            <GlobalListeners />
             <Navbar />
             <DeveloperUtility />
             <Component {...pageProps} />


### PR DESCRIPTION
### Summary
This PR removes `useScrollDirection` from `NavBar`, `AudioPlayer` and `ContextMenu` components and adds it as a global scroll listener to avoid attaching 3 listeners to the same event instead of just 1. Also this PR solves the issue on mobile when scrolling to the top, the nav bar, context menu and the audio player minimize.