### PR TITLE
Optimize renders on scrolling

### DIFF
--- a/src/components/GlobalScrollListener.tsx
+++ b/src/components/GlobalScrollListener.tsx
@@ -17,7 +17,7 @@ const GlobalScrollListener = () => {
        * zero then the browser forces the view to go to exactly 0 again so the hook detects it's
        * a down direction and hides the navbar, context menu and audioPlayer.
        */
-      if (newYPosition > 0 && direction === ScrollDirection.Down) {
+      if (newYPosition > 50 && direction === ScrollDirection.Down) {
         dispatch({ type: setIsMobileMinimizedForScrolling.type, payload: true });
         dispatch({ type: setIsExpanded.type, payload: false });
         dispatch({ type: setIsVisible.type, payload: false });

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -1,5 +1,4 @@
 @use "src/styles/constants";
-@use "src/styles/utility";
 @use "src/styles/breakpoints";
 
 .emptySpacePlaceholder {
@@ -21,42 +20,5 @@
   transform: translateY(0 - constants.$navbar-height);
   @include breakpoints.tablet {
     transform: none;
-  }
-}
-
-.itemsContainer {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  height: 100%;
-}
-
-.centerVertically {
-  @include utility.center-vertically;
-}
-
-.leftCTA {
-  display: flex;
-  margin-left: var(--spacing-medium);
-
-  @include breakpoints.tablet {
-    margin-left: var(--spacing-mega);
-  }
-}
-
-.rightCTA {
-  display: flex;
-  margin-right: var(--spacing-medium);
-
-  > button {
-    margin-left: var(--spacing-micro);
-  }
-
-  @include breakpoints.tablet {
-    margin-right: var(--spacing-mega);
-
-    > button {
-      margin-left: var(--spacing-xsmall);
-    }
   }
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,98 +1,20 @@
 import React from 'react';
 
 import classNames from 'classnames';
-import Link from 'next/link';
-import { useSelector, useDispatch, shallowEqual } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 
-import IconMenu from '../../../public/icons/menu.svg';
-import IconQ from '../../../public/icons/Q.svg';
-import IconSearch from '../../../public/icons/search.svg';
-import IconSettings from '../../../public/icons/settings.svg';
-
-import LanguageSelector from './LanguageSelector';
 import styles from './Navbar.module.scss';
-import NavigationDrawer from './NavigationDrawer/NavigationDrawer';
-import SearchDrawer from './SearchDrawer/SearchDrawer';
-import SettingsDrawer from './SettingsDrawer/SettingsDrawer';
+import NavbarBody from './NavbarBody';
 
-import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
-import {
-  selectNavbar,
-  setIsSearchDrawerOpen,
-  setIsNavigationDrawerOpen,
-  setIsSettingsDrawerOpen,
-} from 'src/redux/slices/navbar';
+import { selectNavbar } from 'src/redux/slices/navbar';
 
 const Navbar = () => {
   const { isVisible } = useSelector(selectNavbar, shallowEqual);
-  const dispatch = useDispatch();
-  const openNavigationDrawer = () => {
-    dispatch({ type: setIsNavigationDrawerOpen.type, payload: true });
-  };
-
-  const openSearchDrawer = () => {
-    dispatch({ type: setIsSearchDrawerOpen.type, payload: true });
-  };
-
-  const openSettingsDrawer = () => {
-    dispatch({ type: setIsSettingsDrawerOpen.type, payload: true });
-  };
-
   return (
     <>
       <div className={styles.emptySpacePlaceholder} />
       <nav className={classNames(styles.container, { [styles.hiddenNav]: !isVisible })}>
-        <div className={styles.itemsContainer}>
-          <div className={styles.centerVertically}>
-            <div className={styles.leftCTA}>
-              <>
-                <Button
-                  tooltip="Menu"
-                  variant={ButtonVariant.Ghost}
-                  shape={ButtonShape.Circle}
-                  onClick={openNavigationDrawer}
-                >
-                  <IconMenu />
-                </Button>
-                <NavigationDrawer />
-              </>
-              <Link href="/">
-                <a>
-                  <Button shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>
-                    <IconQ />
-                  </Button>
-                </a>
-              </Link>
-              <LanguageSelector />
-            </div>
-          </div>
-          <div className={styles.centerVertically}>
-            <div className={styles.rightCTA}>
-              <>
-                <Button
-                  tooltip="Settings"
-                  shape={ButtonShape.Circle}
-                  variant={ButtonVariant.Ghost}
-                  onClick={openSettingsDrawer}
-                >
-                  <IconSettings />
-                </Button>
-                <SettingsDrawer />
-              </>
-              <>
-                <Button
-                  tooltip="Search"
-                  variant={ButtonVariant.Ghost}
-                  onClick={openSearchDrawer}
-                  shape={ButtonShape.Circle}
-                >
-                  <IconSearch />
-                </Button>
-                <SearchDrawer />
-              </>
-            </div>
-          </div>
-        </div>
+        <NavbarBody />
       </nav>
     </>
   );

--- a/src/components/Navbar/NavbarBody/NavbarBody.module.scss
+++ b/src/components/Navbar/NavbarBody/NavbarBody.module.scss
@@ -1,0 +1,39 @@
+@use "src/styles/utility";
+@use "src/styles/breakpoints";
+
+.itemsContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.centerVertically {
+  @include utility.center-vertically;
+}
+
+.leftCTA {
+  display: flex;
+  margin-left: var(--spacing-medium);
+
+  @include breakpoints.tablet {
+    margin-left: var(--spacing-mega);
+  }
+}
+
+.rightCTA {
+  display: flex;
+  margin-right: var(--spacing-medium);
+
+  > button {
+    margin-left: var(--spacing-micro);
+  }
+
+  @include breakpoints.tablet {
+    margin-right: var(--spacing-mega);
+
+    > button {
+      margin-left: var(--spacing-xsmall);
+    }
+  }
+}

--- a/src/components/Navbar/NavbarBody/index.tsx
+++ b/src/components/Navbar/NavbarBody/index.tsx
@@ -1,0 +1,92 @@
+import React, { memo } from 'react';
+
+import Link from 'next/link';
+import { useDispatch } from 'react-redux';
+
+import IconMenu from '../../../../public/icons/menu.svg';
+import IconQ from '../../../../public/icons/Q.svg';
+import IconSearch from '../../../../public/icons/search.svg';
+import IconSettings from '../../../../public/icons/settings.svg';
+import LanguageSelector from '../LanguageSelector';
+import NavigationDrawer from '../NavigationDrawer/NavigationDrawer';
+import SearchDrawer from '../SearchDrawer/SearchDrawer';
+import SettingsDrawer from '../SettingsDrawer/SettingsDrawer';
+
+import styles from './NavbarBody.module.scss';
+
+import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
+import {
+  setIsSearchDrawerOpen,
+  setIsNavigationDrawerOpen,
+  setIsSettingsDrawerOpen,
+} from 'src/redux/slices/navbar';
+
+const NavbarBody: React.FC = () => {
+  const dispatch = useDispatch();
+  const openNavigationDrawer = () => {
+    dispatch({ type: setIsNavigationDrawerOpen.type, payload: true });
+  };
+
+  const openSearchDrawer = () => {
+    dispatch({ type: setIsSearchDrawerOpen.type, payload: true });
+  };
+
+  const openSettingsDrawer = () => {
+    dispatch({ type: setIsSettingsDrawerOpen.type, payload: true });
+  };
+  return (
+    <div className={styles.itemsContainer}>
+      <div className={styles.centerVertically}>
+        <div className={styles.leftCTA}>
+          <>
+            <Button
+              tooltip="Menu"
+              variant={ButtonVariant.Ghost}
+              shape={ButtonShape.Circle}
+              onClick={openNavigationDrawer}
+            >
+              <IconMenu />
+            </Button>
+            <NavigationDrawer />
+          </>
+          <Link href="/">
+            <a>
+              <Button shape={ButtonShape.Circle} variant={ButtonVariant.Ghost}>
+                <IconQ />
+              </Button>
+            </a>
+          </Link>
+          <LanguageSelector />
+        </div>
+      </div>
+      <div className={styles.centerVertically}>
+        <div className={styles.rightCTA}>
+          <>
+            <Button
+              tooltip="Settings"
+              shape={ButtonShape.Circle}
+              variant={ButtonVariant.Ghost}
+              onClick={openSettingsDrawer}
+            >
+              <IconSettings />
+            </Button>
+            <SettingsDrawer />
+          </>
+          <>
+            <Button
+              tooltip="Search"
+              variant={ButtonVariant.Ghost}
+              onClick={openSearchDrawer}
+              shape={ButtonShape.Circle}
+            >
+              <IconSearch />
+            </Button>
+            <SearchDrawer />
+          </>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(NavbarBody);


### PR DESCRIPTION
### Summary
Currently scrolling when the QuranReader is open affects three components:

- `ContextMenu`
- `Navbar`
- `AudioPlayer`

On changing the direction of the scroll up/down, the above components along with their children re-render while most of the children are not related to the change on scroll and since the scrolling happen too frequent, we need to memoize the children of `Navbar`.

This PR also changes the threshold to start hiding the nav bar which is 50px.
 


### Screenshots

| Before | After |
| ------ | ------ |
|<img width="1067" alt="Screen Shot 2021-10-11 at 14 55 05" src="https://user-images.githubusercontent.com/15169499/136778889-b329f4d0-6a23-4206-8b38-d3bedce187a0.png">|<img width="1065" alt="Screen Shot 2021-10-11 at 15 00 26" src="https://user-images.githubusercontent.com/15169499/136778905-183fc6c7-d20c-4eb3-aa54-78420fc3bc75.png">|