### PR TITLE
Disable scrolling when a drawer is open

### DIFF
--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -29,11 +29,6 @@
       right: calc(-1 * constants.$side-menu-desktop-width);
     }
   }
-  &.hiddenNavbar {
-    @include breakpoints.smallerThanTablet {
-      transform: translateY(constants.$navbar-height);
-    }
-  }
 }
 
 .containerOpen {

--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -9,6 +9,7 @@ import styles from './Drawer.module.scss';
 import DrawerCloseButton from './DrawerCloseButton';
 
 import useOutsideClickDetector from 'src/hooks/useOutsideClickDetector';
+import usePreventBodyScrolling from 'src/hooks/usePreventBodyScrolling';
 import {
   Navbar,
   selectNavbar,
@@ -67,8 +68,8 @@ const Drawer: React.FC<Props> = ({ type, side = DrawerSide.Right, header, childr
   const drawerRef = useRef(null);
   const dispatch = useDispatch();
   const navbar = useSelector(selectNavbar, shallowEqual);
-  const { isVisible } = navbar;
   const isOpen = getIsOpen(type, navbar);
+  usePreventBodyScrolling(isOpen);
   const router = useRouter();
 
   const closeDrawer = useCallback(() => {
@@ -90,7 +91,6 @@ const Drawer: React.FC<Props> = ({ type, side = DrawerSide.Right, header, childr
     <div
       className={classNames(styles.container, {
         [styles.containerOpen]: isOpen,
-        [styles.hiddenNavbar]: !isVisible,
         [styles.left]: side === DrawerSide.Left,
         [styles.right]: side === DrawerSide.Right,
       })}

--- a/src/hooks/useBrowserLayoutEffect.ts
+++ b/src/hooks/useBrowserLayoutEffect.ts
@@ -1,0 +1,9 @@
+import { useLayoutEffect } from 'react';
+
+/**
+ * This is needed to avoid having the warning that useLayoutEffect
+ * does nothing in SSR. Taken from this thread
+ * {@link https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85}
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export default typeof window !== 'undefined' ? useLayoutEffect : () => {};

--- a/src/hooks/usePreventBodyScrolling.ts
+++ b/src/hooks/usePreventBodyScrolling.ts
@@ -1,0 +1,30 @@
+import useBrowserLayoutEffect from './useBrowserLayoutEffect';
+
+/**
+ * This hook disables body scrolling depending on the value passed
+ * to the hook. Inspired by {@link https://usehooks-typescript.com/react-hook/use-locked-body}
+ *
+ * @param {boolean} shouldDisableScrolling
+ */
+const usePreventBodyScrolling = (shouldDisableScrolling = false) => {
+  /**
+   * Do the side effect before render since we need to get the value of document.body.style.overflow
+   * {@see https://kentcdodds.com/blog/useeffect-vs-uselayouteffect}
+   */
+  useBrowserLayoutEffect(() => {
+    // if we shouldn't disable the scrolling, do nothing
+    if (!shouldDisableScrolling) {
+      return undefined;
+    }
+    // Save the initial body style
+    const originalOverflow = document.body.style.overflow;
+    // disable body scrolling bt setting overflow to hidden on the body
+    document.body.style.overflow = 'hidden';
+    return () => {
+      // revert it back
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [shouldDisableScrolling]);
+};
+
+export default usePreventBodyScrolling;


### PR DESCRIPTION
### Summary
This PR disables scrolling when a drawer is open since there is no point of triggering the `scroll` event since if a drawer is open, it should be the main focus of the page. This also will prevent the `scroll` event that is being listened to inside `GlobalScrollListener` from firing which would save multiple redux dispatches and re-renders from happening. It will also improve the experience on mobile since without disabling the scrolling, the drawer plays up a bit on scrolling.