### PR TITLE
Refactor GlyphWord

### DIFF
--- a/src/components/dls/QuranWord/GlyphWord.module.scss
+++ b/src/components/dls/QuranWord/GlyphWord.module.scss
@@ -1,14 +1,3 @@
 .styledWord {
   line-height: normal;
 }
-
-@mixin generate-words($version: 1) {
-  @for $i from 1 through 604 {
-    .word-#{$i}-v#{$version} {
-      font-family: p#{$i}-v#{$version};
-    }
-  }
-}
-
-@include generate-words;
-@include generate-words(2);

--- a/src/components/dls/QuranWord/GlyphWord.tsx
+++ b/src/components/dls/QuranWord/GlyphWord.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 
-import classNames from 'classnames';
-
 import styles from './GlyphWord.module.scss';
 
 type UthmaniWordTextProps = {
@@ -14,10 +12,8 @@ type UthmaniWordTextProps = {
 const GlyphWord = ({ text, pageNumber, font }: UthmaniWordTextProps) => (
   <span
     dangerouslySetInnerHTML={{ __html: text }}
-    className={classNames(
-      styles.styledWord,
-      styles[`word-${pageNumber}-${font.replace('code_', '')}`],
-    )}
+    className={styles.styledWord}
+    style={{ fontFamily: `p${pageNumber}-${font.replace('code_', '')}` }}
   />
 );
 export default GlyphWord;


### PR DESCRIPTION
### Summary
This PR refactors `GlyphWord.module.scss` to not pre-generate the `font-family` of all the pages of `QCFFont`s but rather generate the `font-family` of each word on the spot. This is done because the size of `GlyphWord.module.scss` was affecting the loading speed and web vitals metrics.