### PR TITLE
fix icon

### DIFF
--- a/src/components/Navbar/NavbarBody/NavbarBody.module.scss
+++ b/src/components/Navbar/NavbarBody/NavbarBody.module.scss
@@ -49,3 +49,19 @@
   font-weight: var(--font-weight-bold);
   margin-left: var(--spacing-xsmall);
 }
+
+.logoWrapper.QIcon {
+  > span > svg {
+    fill: unset;
+    & > path {
+      fill: unset;
+    }
+  }
+
+  &:hover > span > svg {
+    fill: unset;
+    & > path {
+      fill: unset;
+    }
+  }
+}

--- a/src/components/Navbar/NavbarBody/index.tsx
+++ b/src/components/Navbar/NavbarBody/index.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 
+import classNames from 'classnames';
 import { useDispatch } from 'react-redux';
 
 import IconMenu from '../../../../public/icons/menu.svg';
@@ -52,7 +53,7 @@ const NavbarBody: React.FC = () => {
             href="/"
             shape={ButtonShape.Circle}
             variant={ButtonVariant.Ghost}
-            className={styles.logoWrapper}
+            className={classNames(styles.logoWrapper, styles.QIcon)}
             size={ButtonSize.Large}
           >
             <IconQ />


### PR DESCRIPTION
### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/12745166/138648964-993d6a2f-1c6b-41ec-9059-86f45c8c003f.png) | ![image](https://user-images.githubusercontent.com/12745166/138648914-1565d6f5-350a-47bb-b6d1-50c4b212de48.png) |


### Notes
The previous plan was to to use 2 icons. use the inverted icons on dark mode. 
![image](https://user-images.githubusercontent.com/12745166/138649060-0405b576-5ea4-4c81-b68e-f6c2c16bf707.png)

But I decided to just use original version (black background + white foreground icon) for 2 reasons
- The implementation is simpler ( no need to use detection query, and loaded the icon dynamically according to theme)
- I subjectively found that the icon with white background is taking too much attention on dark mode (see  screenshot above, the 2nd one, that one was designed with figma)
