### PR TITLE
Fix font family not loaded button

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -12,7 +12,7 @@ body {
   }
 
   overscroll-behavior-y: none;
-  font-family: 'ProximaVara', 'Helvetica Neue', Helvetica, Arial;
+  font-family: "ProximaVara", "Helvetica Neue", Helvetica, Arial;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
### Summary
Some html element was not using `Proxima Vara`, it was using `Arial`. For example the Switch component was using Arial.

it's because some HTML element does not inherit font settings by default, it uses browser agent default styles.
https://stackoverflow.com/questions/26140050/why-is-font-family-not-inherited-in-button-tags-automatically/26140154