### PR TITLE
Fix showing loading while validation error in advanced copy ayah range selection

### DIFF
--- a/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.module.scss
+++ b/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.module.scss
@@ -8,7 +8,8 @@
 .customMessage {
   padding: var(--spacing-xxsmall);
   border: 1px solid var(--color-borders-hairline);
-  border-radius: var(var(--border-radius-default));
+  border-radius: var(--border-radius-default);
+  margin-top: var(--spacing-medium);
 }
 
 .label {

--- a/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.tsx
+++ b/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.tsx
@@ -165,6 +165,7 @@ const VerseAdvancedCopy: React.FC<Props> = ({ verse, children }) => {
       // if the validation fails
       if (validationError) {
         setCustomMessage(validationError);
+        setIsLoadingData(false);
         return;
       }
     }


### PR DESCRIPTION
### Summary
* Fix showing loading spinner while having validation error in range selection
* Add spacing for custom error message

### Test Plan


### Screenshots
## Before
![Screenshot 2021-11-05 at 11 41 07 PM](https://user-images.githubusercontent.com/26774310/140558909-6b401cd7-c9e9-48ff-9861-634885a04d7b.png)

## After
![Screenshot 2021-11-05 at 11 38 26 PM](https://user-images.githubusercontent.com/26774310/140558924-d060a91c-a6ef-4418-8065-06acc16a2827.png)
| [image here] | [image here] |