### PR TITLE
Add logical-css-linter

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,11 +1,13 @@
 {
     "plugins": [
         "stylelint-scss",
-        "stylelint-prettier"
+        "stylelint-prettier",
+        "stylelint-use-logical"
     ],
     "rules": {
         "prettier/prettier": true,
         "at-rule-no-unknown": null,
-        "scss/at-rule-no-unknown": true
+        "scss/at-rule-no-unknown": true,
+        "csstools/use-logical": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "stylelint": "^13.13.1",
     "stylelint-prettier": "^1.2.0",
     "stylelint-scss": "^3.21.0",
+    "stylelint-use-logical": "^1.1.0",
     "typescript": "^4.4.4"
   },
   "husky": {

--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -13,7 +13,7 @@
   position: fixed;
   opacity: 1;
   width: 100%;
-  bottom: 0;
+  inset-block-end: 0;
   text-align: center;
   background: var(--color-background-default);
   transition: var(--transition-regular);

--- a/src/components/AudioPlayer/AudioPlayerSlider.module.scss
+++ b/src/components/AudioPlayer/AudioPlayerSlider.module.scss
@@ -2,7 +2,7 @@
 @use "src/styles/constants";
 
 .container {
-  margin-top: var(--spacing-xxsmall);
+  margin-block: var(--spacing-xxsmall) calc(-1 * var(--spacing-xsmall));
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -11,47 +11,47 @@
   min-height: var(
     --font-size-small
   ); // prevents CLS when the current/total time are not loaded yet
-  margin-bottom: calc(-1 * var(--spacing-xsmall));
   transition: var(--transition-regular);
   @include breakpoints.tablet {
     font-size: var(--font-size-normal);
     min-height: var(
       --font-size-normal
     ); // prevents CLS when the current/total time are not loaded yet
-    margin-top: var(--spacing-medium);
-    margin-bottom: calc(-2 * var(--spacing-small));
+    margin-block: var(--spacing-medium) calc(-2 * var(--spacing-small));
   }
 }
 
 .containerMinimized {
   @include breakpoints.smallerThanTablet {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 
 .sliderContainer {
   display: inline-block;
   position: fixed;
+  /* stylelint-disable-next-line csstools/use-logical */
   left: 50%;
   transform: translate(-50%, 0);
   margin: 0;
   width: 100%;
   height: calc(1.25 * var(--spacing-xxsmall));
   transition: var(--transition-regular);
-  bottom: constants.$audio-player-default-height;
+  inset-block-end: constants.$audio-player-default-height;
   @include breakpoints.tablet {
-    bottom: constants.$audio-player-default-desktop-height;
+    inset-block-end: constants.$audio-player-default-desktop-height;
   }
 }
 
 .sliderContainerMinimized {
   @include breakpoints.smallerThanTablet {
+    /* stylelint-disable-next-line csstools/use-logical */
     left: 50%;
     margin: 0 auto;
     width: 100%;
     transform: translate(-50%, 0);
     position: fixed;
-    bottom: constants.$audio-player-minimized-height;
+    inset-block-end: constants.$audio-player-minimized-height;
     span[role="slider"] {
       @include breakpoints.smallerThanTablet {
         display: none;

--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.module.scss
@@ -14,7 +14,9 @@
 }
 
 .overriddenPopoverMenuContentPositioning [data-radix-popper-content-wrapper] {
+  /* stylelint-disable-next-line csstools/use-logical */
   top: initial !important;
+  /* stylelint-disable-next-line csstools/use-logical */
   bottom: calc(1.5 * var(--spacing-mega)) !important;
   position: absolute !important;
   z-index: var(--z-index-max);

--- a/src/components/AudioPlayer/RepeatAudioModal/RepeatSetting.module.scss
+++ b/src/components/AudioPlayer/RepeatAudioModal/RepeatSetting.module.scss
@@ -8,7 +8,7 @@
   }
 }
 .inputContainer + .inputContainer {
-  margin-top: var(--spacing-small);
+  margin-block-start: var(--spacing-small);
 }
 
 .label {

--- a/src/components/CommandBar/CommandBarBody/CommandBarBody.module.scss
+++ b/src/components/CommandBar/CommandBarBody/CommandBarBody.module.scss
@@ -9,7 +9,7 @@ $height: calc(8 * var(--spacing-mega));
 
 .inputContainer {
   border-bottom: 1px solid var(--color-borders-hairline);
-  padding-bottom: var(--spacing-small);
+  padding-block-end: var(--spacing-small);
   display: flex;
 }
 

--- a/src/components/DeveloperUtility/DeveloperUtility.module.scss
+++ b/src/components/DeveloperUtility/DeveloperUtility.module.scss
@@ -3,8 +3,8 @@
   border: 1px solid rgba(0, 0, 0, 0.13);
   color: black;
   position: fixed;
-  top: calc(var(--spacing-mega) + var(--spacing-mega));
-  right: calc(var(--spacing-mega) + var(--spacing-medium));
+  inset-block-start: calc(var(--spacing-mega) + var(--spacing-mega));
+  inset-inline-end: calc(var(--spacing-mega) + var(--spacing-medium));
   height: calc(2 * var(--spacing-mega));
   width: calc(2 * var(--spacing-mega));
 
@@ -33,7 +33,7 @@
 
 .separator {
   width: 100%;
-  margin-bottom: var(--spacing-xxxsmall);
+  margin-block-end: var(--spacing-xxxsmall);
 }
 
 .closeButton {

--- a/src/components/Error/Error.module.scss
+++ b/src/components/Error/Error.module.scss
@@ -14,5 +14,5 @@
 
 .text {
   text-align: center;
-  padding-bottom: var(--spacing-xsmall);
+  padding-block-end: var(--spacing-xsmall);
 }

--- a/src/components/FeedbackWidget/FeedbackWidget.module.scss
+++ b/src/components/FeedbackWidget/FeedbackWidget.module.scss
@@ -3,10 +3,8 @@
 
 .container {
   position: fixed;
-  /* stylelint-disable-next-line csstools/use-logical */
-  bottom: var(--spacing-mega);
-  /* stylelint-disable-next-line csstools/use-logical */
-  right: calc(1 * var(--spacing-medium));
+  inset-block-end: var(--spacing-mega);
+  inset-inline-end: calc(1 * var(--spacing-medium));
   transition: var(--transition-regular);
   z-index: var(--z-index-sticky);
   @include breakpoints.tablet {

--- a/src/components/FeedbackWidget/FeedbackWidget.module.scss
+++ b/src/components/FeedbackWidget/FeedbackWidget.module.scss
@@ -3,27 +3,29 @@
 
 .container {
   position: fixed;
+  /* stylelint-disable-next-line csstools/use-logical */
   bottom: var(--spacing-mega);
+  /* stylelint-disable-next-line csstools/use-logical */
   right: calc(1 * var(--spacing-medium));
   transition: var(--transition-regular);
   z-index: var(--z-index-sticky);
   @include breakpoints.tablet {
     display: inherit;
-    right: calc(var(--spacing-mega) + var(--spacing-medium));
+    inset-inline-end: calc(var(--spacing-mega) + var(--spacing-medium));
   }
   &.isMobileMinimizedForScrolling.audioPlayerOpen {
-    margin-bottom: constants.$audio-player-minimized-height;
-    bottom: var(--spacing-medium);
+    margin-block-end: constants.$audio-player-minimized-height;
+    inset-block-end: var(--spacing-medium);
     @include breakpoints.tablet {
-      margin-bottom: constants.$audio-player-default-desktop-height;
+      margin-block-end: constants.$audio-player-default-desktop-height;
     }
   }
 }
 
 .audioPlayerOpen {
-  margin-bottom: constants.$audio-player-default-height;
+  margin-block-end: constants.$audio-player-default-height;
   @include breakpoints.tablet {
-    margin-bottom: constants.$audio-player-default-desktop-height;
+    margin-block-end: constants.$audio-player-default-desktop-height;
   }
-  bottom: var(--spacing-medium);
+  inset-block-end: var(--spacing-medium);
 }

--- a/src/components/HomePage/HomePageWelcomeMessage.module.scss
+++ b/src/components/HomePage/HomePageWelcomeMessage.module.scss
@@ -17,15 +17,15 @@
   color: var(--color-success-deep);
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-large);
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
   line-height: var(--line-height-large);
 }
 
 .link {
-  margin-top: var(--spacing-small);
+  margin-block-start: var(--spacing-small);
 }
 .description {
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
 }
 .version {
   font-weight: var(--font-weight-bold);
@@ -33,7 +33,7 @@
   color: var(--color-text-faded);
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
 
   & > svg {
     height: var(--spacing-small);
@@ -45,6 +45,6 @@
 
 .closeIcon {
   position: absolute;
-  top: var(--spacing-xxsmall);
+  inset-block-start: var(--spacing-xxsmall);
   inset-inline-end: var(--spacing-xxsmall);
 }

--- a/src/components/HomePage/PrayerTimes.module.scss
+++ b/src/components/HomePage/PrayerTimes.module.scss
@@ -1,8 +1,7 @@
 $shadow-background: linear-gradient(180deg, #000000a6, transparent);
 .container {
   width: 100%;
-  right: 0;
-  left: 0;
+  inset-inline: 0;
   box-sizing: border-box;
   padding: var(--spacing-medium);
   position: absolute;
@@ -18,5 +17,5 @@ $shadow-background: linear-gradient(180deg, #000000a6, transparent);
 }
 
 .prayerTimesContainer {
-  text-align: right;
+  text-align: end;
 }

--- a/src/components/HomePage/QuickLinks/QuickLinks.module.scss
+++ b/src/components/HomePage/QuickLinks/QuickLinks.module.scss
@@ -1,7 +1,7 @@
 @use "src/styles/breakpoints";
 
 .header {
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
   padding-inline-start: var(--flow-side-spacing, var(--spacing-small));
 }
 

--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -6,8 +6,7 @@
   position: fixed;
   height: 100vh;
   width: 100%;
-  top: 0;
-  bottom: 0;
+  inset-block: 0;
   z-index: var(--z-index-header);
   transition: var(--transition-regular);
   transition-timing-function: ease-in;
@@ -57,14 +56,14 @@
 }
 
 .bodyContainer {
-  margin-top: constants.$navbar-height;
-  padding-top: var(--spacing-small);
+  margin-block-start: constants.$navbar-height;
+  padding-block-start: var(--spacing-small);
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
 }
 
 .bodyWithBottomPadding {
-  padding-bottom: calc(4 * var(--spacing-large));
+  padding-block-end: calc(4 * var(--spacing-large));
 }
 
 .navigationBodyContainer {

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -6,7 +6,7 @@
 }
 
 .container {
-  top: 0;
+  inset-block-start: 0;
   position: fixed;
   height: constants.$navbar-height;
   width: 100%;

--- a/src/components/Navbar/NavigationDrawer/CommunitySection.module.scss
+++ b/src/components/Navbar/NavigationDrawer/CommunitySection.module.scss
@@ -11,7 +11,7 @@
 }
 
 .flow > div {
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
 }
 .platformLogo {
   width: var(--spacing-medium);

--- a/src/components/Navbar/NavigationDrawer/MobileApps.module.scss
+++ b/src/components/Navbar/NavigationDrawer/MobileApps.module.scss
@@ -19,6 +19,5 @@ $images-container-width: 17.5rem;
   margin-inline-end: auto;
   margin-block-end: auto;
   margin-inline-start: auto;
-  padding-top: var(--spacing-xxsmall);
-  padding-bottom: var(--spacing-mega);
+  padding-block: var(--spacing-xxsmall) var(--spacing-mega);
 }

--- a/src/components/Navbar/SearchDrawer/AdvancedSearchLink.module.scss
+++ b/src/components/Navbar/SearchDrawer/AdvancedSearchLink.module.scss
@@ -1,5 +1,5 @@
 .linkContainer {
-  margin-top: var(--spacing-small);
+  margin-block-start: var(--spacing-small);
   a {
     color: var(--color-text-link);
     text-decoration: none;

--- a/src/components/Navbar/SettingsDrawer/AudioSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/AudioSection.module.scss
@@ -4,5 +4,5 @@
 .changeAudioButtonContainer {
   display: flex;
   flex-direction: column;
-  margin-top: var(--spacing-xsmall);
+  margin-block-start: var(--spacing-xsmall);
 }

--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.module.scss
@@ -1,8 +1,7 @@
 @use "src/styles/breakpoints";
 
 .verseSampleContainer {
-  margin-top: var(--spacing-medium);
-  margin-bottom: var(--spacing-medium);
+  margin-block: var(--spacing-medium);
   border-radius: var(--border-radius-default);
   padding-block-start: var(--spacing-medium);
   padding-block-end: var(--spacing-medium);

--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.module.scss
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.module.scss
@@ -1,5 +1,5 @@
 .reciter {
-  margin-bottom: var(--spacing-small);
+  margin-block-end: var(--spacing-small);
   display: flex;
   align-items: center;
   font-size: var(--font-size-large);

--- a/src/components/Navbar/SettingsDrawer/Section/Footer.module.scss
+++ b/src/components/Navbar/SettingsDrawer/Section/Footer.module.scss
@@ -1,5 +1,5 @@
 .footer {
-  padding-top: var(--spacing-medium);
+  padding-block-start: var(--spacing-medium);
   font-style: italic;
 }
 .invisible {

--- a/src/components/Navbar/SettingsDrawer/Section/Row.module.scss
+++ b/src/components/Navbar/SettingsDrawer/Section/Row.module.scss
@@ -10,5 +10,5 @@
   flex: 1;
 }
 .row + .row {
-  margin-top: var(--spacing-xsmall);
+  margin-block-start: var(--spacing-xsmall);
 }

--- a/src/components/Navbar/SettingsDrawer/Section/Section.module.scss
+++ b/src/components/Navbar/SettingsDrawer/Section/Section.module.scss
@@ -1,4 +1,3 @@
 .separator {
-  margin-top: var(--spacing-mega);
-  margin-bottom: var(--spacing-mega);
+  margin-block: var(--spacing-mega);
 }

--- a/src/components/Navbar/SettingsDrawer/Section/Title.module.scss
+++ b/src/components/Navbar/SettingsDrawer/Section/Title.module.scss
@@ -1,5 +1,5 @@
 .title {
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-semibold);
-  padding-bottom: var(--spacing-medium);
+  padding-block-end: var(--spacing-medium);
 }

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.module.scss
@@ -4,5 +4,5 @@
 .changeReciterButtonContainer {
   display: flex;
   flex-direction: column;
-  margin-top: var(--spacing-xsmall);
+  margin-block-start: var(--spacing-xsmall);
 }

--- a/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.module.scss
+++ b/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.module.scss
@@ -6,14 +6,14 @@
 
 .language {
   text-transform: capitalize;
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-semibold);
 }
 
 .translation {
   font-size: var(--font-size-large);
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
   display: flex;
   align-items: center;
   & > input {
@@ -22,5 +22,5 @@
 }
 
 .translationGroup {
-  margin-bottom: var(--spacing-large);
+  margin-block-end: var(--spacing-large);
 }

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -9,10 +9,10 @@
   z-index: var(--z-index-sticky);
   transition: var(--transition-regular);
   width: 100%;
-  top: 0;
+  inset-block-start: 0;
   min-height: var(--spacing-medium);
   @include breakpoints.tablet {
-    top: constants.$navbar-height;
+    inset-block-start: constants.$navbar-height;
     transition: var(--transition-regular);
     margin-inline-end: 0;
   }
@@ -25,7 +25,7 @@
     height: var(--spacing-micro);
     background: var(--color-success-deep);
     position: absolute;
-    bottom: calc(-1 * var(--spacing-micro));
+    inset-block-end: calc(-1 * var(--spacing-micro));
   }
 }
 
@@ -35,7 +35,7 @@
 }
 
 .visibleContainer {
-  top: constants.$navbar-height;
+  inset-block-start: constants.$navbar-height;
 }
 
 .expandedContainer {

--- a/src/components/QuranReader/DebuggingObserverWindow/ObserverWindow.module.scss
+++ b/src/components/QuranReader/DebuggingObserverWindow/ObserverWindow.module.scss
@@ -5,14 +5,12 @@ $reading-mode-bottom: 70vh;
 
 .container {
   position: fixed;
-  top: $default-mode-top;
-  bottom: $default-mode-bottom;
+  inset-block: $default-mode-top $default-mode-bottom;
   z-index: var(--z-index-sticky);
   width: 100%;
   border: 1px solid var(--color-background-inverse);
 }
 
 .readingMode {
-  top: $reading-mode-top;
-  bottom: $reading-mode-bottom;
+  inset-block: $reading-mode-top $reading-mode-bottom;
 }

--- a/src/components/QuranReader/EndOfScrollingControls/EndOfScrollingControls.module.scss
+++ b/src/components/QuranReader/EndOfScrollingControls/EndOfScrollingControls.module.scss
@@ -13,7 +13,7 @@
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  margin-top: var(--spacing-xsmall);
+  margin-block-start: var(--spacing-xsmall);
   > a {
     margin-block-start: var(--spacing-xxsmall);
     margin-inline-end: var(--spacing-xxsmall);

--- a/src/components/QuranReader/Notes/Notes.module.scss
+++ b/src/components/QuranReader/Notes/Notes.module.scss
@@ -4,11 +4,11 @@
 .container {
   height: 100%;
   position: fixed;
-  top: 0;
+  inset-block-start: 0;
   inset-inline-end: 0;
   background-color: #2e75ff;
   overflow-x: hidden;
-  padding-top: constants.$navbar-height;
+  padding-block-start: constants.$navbar-height;
   z-index: var(--z-index-default);
   transition: var(--transition-regular);
   width: 0;

--- a/src/components/QuranReader/ReadingView/Page.module.scss
+++ b/src/components/QuranReader/ReadingView/Page.module.scss
@@ -3,7 +3,7 @@
 
 .container {
   border-bottom: 1px var(--color-borders-hairline) solid;
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
   max-width: 100%;
 }
 

--- a/src/components/QuranReader/TafsirView/TafsirView.module.scss
+++ b/src/components/QuranReader/TafsirView/TafsirView.module.scss
@@ -32,9 +32,10 @@
   letter-spacing: 0;
   line-height: normal;
   direction: ltr;
+  /* stylelint-disable-next-line csstools/use-logical */
   text-align: left;
   p {
-    margin-bottom: var(--spacing-small);
+    margin-block-end: var(--spacing-small);
   }
   br {
     content: "";
@@ -46,7 +47,7 @@
   }
   h2 {
     font-weight: var(--font-weight-bold);
-    margin-bottom: var(--spacing-small);
+    margin-block-end: var(--spacing-small);
   }
   * {
     letter-spacing: 0;
@@ -55,8 +56,9 @@
   // target any item which has a class that contains arabic
   *[class~="arabic"] {
     direction: rtl;
+    /* stylelint-disable-next-line csstools/use-logical */
     text-align: right;
-    margin-bottom: var(--spacing-small);
+    margin-block-end: var(--spacing-small);
   }
   // target any item which has a class that contains uthmani
   *[class~="uthmani"] {
@@ -66,6 +68,7 @@
 
 .rtl {
   direction: rtl;
+  /* stylelint-disable-next-line csstools/use-logical */
   text-align: right;
 }
 

--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.module.scss
@@ -18,11 +18,13 @@ $container-min-height: calc(3 * var(--spacing-large));
 }
 
 .rtl {
+  /* stylelint-disable-next-line csstools/use-logical */
   text-align: right;
   direction: rtl;
 }
 
 .ltr {
+  /* stylelint-disable-next-line csstools/use-logical */
   text-align: left;
   direction: ltr;
 }
@@ -35,6 +37,6 @@ $container-min-height: calc(3 * var(--spacing-large));
   width: 100%;
   display: flex;
   justify-content: space-between;
-  padding-bottom: var(--spacing-xxsmall);
+  padding-block-end: var(--spacing-xxsmall);
   font-weight: var(--font-weight-bold);
 }

--- a/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
@@ -4,19 +4,21 @@
 .text {
   letter-spacing: 0;
   line-height: normal;
-  padding-bottom: var(--spacing-micro);
+  padding-block-end: var(--spacing-micro);
   @include footnote.footnote-styling;
 }
 
 @include utility.generate-font-sizes("translation");
 
 .ltr {
+  /* stylelint-disable-next-line csstools/use-logical */
   text-align: left;
   direction: ltr;
 }
 
 .rtl {
   direction: rtl;
+  /* stylelint-disable-next-line csstools/use-logical */
   text-align: right;
 }
 

--- a/src/components/QuranReader/TranslationView/TranslationText/_footnote.scss
+++ b/src/components/QuranReader/TranslationView/TranslationText/_footnote.scss
@@ -1,7 +1,7 @@
 @mixin footnote-styling {
   sup {
     color: var(--color-text-link);
-    top: calc(-1 * var(--spacing-xsmall));
+    inset-block-start: calc(-1 * var(--spacing-xsmall));
     position: relative;
     font-size: var(--font-size-small);
     line-height: 0;

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.module.scss
@@ -12,11 +12,11 @@
   padding-block-end: var(--spacing-medium);
   padding-inline-start: 0;
   padding-inline-end: 0;
-  padding-bottom: 0;
+  padding-block-end: 0;
 }
 .contentContainer {
   flex: 1;
-  padding-top: var(--spacing-medium);
+  padding-block-start: var(--spacing-medium);
   position: relative;
 }
 .actionContainer {
@@ -24,13 +24,13 @@
   justify-content: space-between;
 }
 .arabicVerseContainer {
-  padding-bottom: var(--spacing-medium);
+  padding-block-end: var(--spacing-medium);
 }
 .verseTranslationContainer {
-  padding-bottom: var(--spacing-xsmall);
+  padding-block-end: var(--spacing-xsmall);
 }
 .translationContainer {
-  padding-bottom: var(--spacing-xsmall);
+  padding-block-end: var(--spacing-xsmall);
 }
 
 .actionContainerLeft,

--- a/src/components/Search/PreInput/PreInput.module.scss
+++ b/src/components/Search/PreInput/PreInput.module.scss
@@ -8,6 +8,6 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: var(--spacing-micro);
-  padding-bottom: var(--spacing-large);
+  padding-block-end: var(--spacing-large);
   width: 100%;
 }

--- a/src/components/Search/SearchHistory/SearchHistory.module.scss
+++ b/src/components/Search/SearchHistory/SearchHistory.module.scss
@@ -1,3 +1,3 @@
 .container {
-  padding-bottom: var(--spacing-large);
+  padding-block-end: var(--spacing-large);
 }

--- a/src/components/Search/SearchResults/SearchResults.module.scss
+++ b/src/components/Search/SearchResults/SearchResults.module.scss
@@ -1,5 +1,5 @@
 .resultsSummaryContainer {
-  margin-top: var(--spacing-medium);
+  margin-block-start: var(--spacing-medium);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -7,6 +7,6 @@
 
 .boldHeader {
   font-weight: var(--font-weight-bold);
-  margin-bottom: var(--spacing-small);
+  margin-block-end: var(--spacing-small);
   text-transform: capitalize;
 }

--- a/src/components/TarteelVoiceSearch/BodyContainer/Error/Error.module.scss
+++ b/src/components/TarteelVoiceSearch/BodyContainer/Error/Error.module.scss
@@ -5,7 +5,7 @@
   align-items: center;
   text-align: center;
   & > svg {
-    margin-bottom: var(--spacing-mega);
+    margin-block-end: var(--spacing-mega);
     width: calc(2 * var(--spacing-mega));
     height: calc(2 * var(--spacing-mega));
     & > path {

--- a/src/components/TarteelVoiceSearch/BodyContainer/PartialResult/PartialResult.module.scss
+++ b/src/components/TarteelVoiceSearch/BodyContainer/PartialResult/PartialResult.module.scss
@@ -8,7 +8,7 @@
   flex-direction: row;
   align-items: flex-end;
   justify-content: space-between;
-  margin-bottom: calc(2 * var(--spacing-mega));
+  margin-block-end: calc(2 * var(--spacing-mega));
 }
 
 .transcript {

--- a/src/components/TarteelVoiceSearch/BodyContainer/VoiceSearchBodyContainer.module.scss
+++ b/src/components/TarteelVoiceSearch/BodyContainer/VoiceSearchBodyContainer.module.scss
@@ -19,5 +19,5 @@ $body-min-height-mobile: 65vh;
 }
 
 .commandBarContainer {
-  margin-top: calc(2 * var(--spacing-mega));
+  margin-block-start: calc(2 * var(--spacing-mega));
 }

--- a/src/components/Verse/AdvancedCopy/SelectorContainer.module.scss
+++ b/src/components/Verse/AdvancedCopy/SelectorContainer.module.scss
@@ -1,9 +1,7 @@
 .comboboxLabel {
-  margin-top: var(--spacing-xsmall);
-  margin-bottom: var(--spacing-xsmall);
+  margin-block: var(--spacing-xsmall);
   font-weight: var(--font-weight-bold);
 }
 .selectedContainer {
-  margin-top: var(--spacing-micro);
-  margin-bottom: var(--spacing-micro);
+  margin-block: var(--spacing-micro);
 }

--- a/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.module.scss
+++ b/src/components/Verse/AdvancedCopy/VerseAdvancedCopy.module.scss
@@ -12,18 +12,16 @@
   padding-inline-end: var(--spacing-xxsmall);
   border: 1px solid var(--color-borders-hairline);
   border-radius: var(--border-radius-default);
-  margin-top: var(--spacing-medium);
+  margin-block-start: var(--spacing-medium);
 }
 
 .label {
-  margin-top: var(--spacing-xsmall);
-  margin-bottom: var(--spacing-xsmall);
+  margin-block: var(--spacing-xsmall);
 }
 
 // clone of checkbox properties
 .emptyCheckbox {
   min-height: var(--spacing-medium);
   border: 1px solid transparent;
-  margin-top: var(--spacing-micro);
-  margin-bottom: var(--spacing-micro);
+  margin-block: var(--spacing-micro);
 }

--- a/src/components/Verses/BookmarkedVersesList.module.scss
+++ b/src/components/Verses/BookmarkedVersesList.module.scss
@@ -1,7 +1,7 @@
 @use "src/styles/breakpoints";
 
 .bookmarksHeader {
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
 }
 
 .verseLinksContainer {

--- a/src/components/Verses/BookmarksAndQuickLinks.module.scss
+++ b/src/components/Verses/BookmarksAndQuickLinks.module.scss
@@ -1,6 +1,6 @@
 $contentMinHeight: calc(1.3 * var(--spacing-mega));
 .tabsContainer {
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
   padding-inline-start: var(--flow-side-spacing, 0);
 }
 .contentContainer {

--- a/src/components/Verses/RecentReadingSessions.module.scss
+++ b/src/components/Verses/RecentReadingSessions.module.scss
@@ -7,7 +7,7 @@ $verseLinkMinWidth: calc(6 * var(--spacing-mega));
 }
 
 .sessionsHeader {
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
   padding-block-start: 0;
   padding-block-end: 0;
   padding-inline-start: var(--flow-side-spacing, 0);

--- a/src/components/chapters/ChapterAndJuzList.module.scss
+++ b/src/components/chapters/ChapterAndJuzList.module.scss
@@ -24,9 +24,9 @@
 }
 
 .chapterContainer + .chapterContainer {
-  margin-top: var(--spacing-small);
+  margin-block-start: var(--spacing-small);
   @include breakpoints.tablet {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }
 
@@ -43,13 +43,13 @@
 
 // tabs
 .tabsContainer {
-  padding-bottom: var(--spacing-medium);
+  padding-block-end: var(--spacing-medium);
 }
 
 // sorter
 .sorter {
   display: flex;
-  margin-top: var(--spacing-xsmall);
+  margin-block-start: var(--spacing-xsmall);
   justify-content: flex-end;
   align-items: baseline;
   font-size: var(--font-size-small);
@@ -60,7 +60,7 @@
   font-weight: var(--font-weight-bold);
   text-transform: uppercase;
   cursor: pointer;
-  margin-left: var(--spacing-xxsmall);
+  margin-inline-start: var(--spacing-xxsmall);
   & > span {
     display: flex;
     align-items: center;
@@ -70,7 +70,7 @@
   }
   & > span > svg {
     width: var(--spacing-small);
-    margin-left: var(--spacing-xxsmall);
+    margin-inline-start: var(--spacing-xxsmall);
     transition: transform var(--transition-regular);
   }
 }

--- a/src/components/chapters/ChapterBlock.module.scss
+++ b/src/components/chapters/ChapterBlock.module.scss
@@ -4,14 +4,14 @@
   border: 1px solid var(--color-background-alternative-deep);
   border-radius: var(--border-radius-default);
   min-height: calc(4 * var(--spacing-medium));
-  margin-bottom: var(--spacing-small);
+  margin-block-end: var(--spacing-small);
   &:hover {
     background: var(--color-background-alternative-medium);
     box-shadow: var(--shadow-normal);
     border-color: var(--color-background-inverse);
   }
   @include breakpoints.tablet {
-    margin-bottom: 0;
+    margin-block-end: 0;
   }
 }
 

--- a/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
+++ b/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
@@ -30,8 +30,7 @@
 .QOutlineWrapper {
   height: 100%;
   position: absolute;
-  top: 0;
-  bottom: 0;
+  inset-block: 0;
   inset-inline-end: var(--spacing-medium);
   > svg {
     height: 100%;
@@ -44,35 +43,34 @@
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-faded);
-  margin-bottom: var(--spacing-xxsmall);
+  margin-block-end: var(--spacing-xxsmall);
   z-index: var(--z-index-default);
 }
 
 .bismillahContainer {
   display: flex;
   justify-content: center;
-  margin-top: var(--spacing-mega);
-  margin-bottom: var(--spacing-mega);
+  margin-block: var(--spacing-mega);
 }
 .translatedName {
   font-weight: var(--font-weight-bold);
   color: var(--color-text-faded);
   font-size: var(--font-size-small);
-  margin-bottom: var(--spacing-xxsmall);
+  margin-block-end: var(--spacing-xxsmall);
   z-index: var(--z-index-default);
 }
 .arabicSurahNameContainer {
   box-sizing: border-box;
   display: flex;
   justify-content: flex-end;
-  padding-top: var(--spacing-xsmall);
-  margin-bottom: var(--spacing-xxsmall);
+  padding-block-start: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xxsmall);
   z-index: var(--z-index-default);
 }
 .nameSimple {
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size-large);
-  margin-bottom: var(--spacing-xxsmall);
+  margin-block-end: var(--spacing-xxsmall);
   z-index: var(--z-index-default);
 }
 .actionContainer {

--- a/src/components/chapters/Info/Info.module.scss
+++ b/src/components/chapters/Info/Info.module.scss
@@ -61,12 +61,12 @@
 
 .textBody {
   p {
-    margin-bottom: var(--spacing-small);
+    margin-block-end: var(--spacing-small);
   }
   h2,
   h3 {
     font-weight: var(--font-weight-bold);
-    margin-bottom: var(--spacing-small);
+    margin-block-end: var(--spacing-small);
   }
   em {
     font-style: italic;
@@ -77,7 +77,7 @@
     margin-block-start: var(--spacing-medium);
     margin-block-end: var(--spacing-medium);
     padding-inline-start: calc(2 * var(--spacing-large));
-    margin-bottom: var(--spacing-small);
+    margin-block-end: var(--spacing-small);
   }
   li {
     display: list-item;
@@ -97,7 +97,7 @@
   margin-block-end: var(--spacing-xsmall);
   margin-inline-start: 0;
   margin-inline-end: 0;
-  padding-bottom: var(--spacing-xsmall);
+  padding-block-end: var(--spacing-xsmall);
   border-bottom: 1px solid var(--color-borders-hairline);
   @include breakpoints.tablet {
     display: flex;
@@ -118,15 +118,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: var(--spacing-xsmall);
+  padding-block-start: var(--spacing-xsmall);
   width: 100%;
   @include breakpoints.tablet {
-    padding-top: 0;
+    padding-block-start: 0;
     width: 50%;
   }
 }
 
 .detailHeader {
   font-weight: var(--font-weight-bold);
-  padding-bottom: var(--spacing-xxsmall);
+  padding-block-end: var(--spacing-xxsmall);
 }

--- a/src/components/chapters/JuzView.module.scss
+++ b/src/components/chapters/JuzView.module.scss
@@ -1,16 +1,16 @@
 @use "src/styles/breakpoints";
 
 .juzContainer + .juzContainer {
-  margin-top: var(--spacing-small);
+  margin-block-start: var(--spacing-small);
   @include breakpoints.tablet {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }
 
 .juzContainer {
   display: inline-block;
   width: 100%;
-  margin-bottom: var(--spacing-small);
+  margin-block-end: var(--spacing-small);
   box-sizing: border-box;
   padding-block-start: var(--spacing-small);
   padding-block-end: var(--spacing-small);
@@ -21,7 +21,7 @@
   border-radius: var(--border-radius-default);
 
   .chapterContainer + .chapterContainer {
-    margin-top: var(--spacing-small);
+    margin-block-start: var(--spacing-small);
   }
 }
 
@@ -30,7 +30,7 @@
 }
 
 .juzTitle {
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
 }
 
 .loadingContainer {

--- a/src/components/dls/Badge/Badge.module.scss
+++ b/src/components/dls/Badge/Badge.module.scss
@@ -16,6 +16,6 @@
   font-size: var(--font-size-small);
 }
 .positionBottomRight {
-  bottom: var(--spacing-xxsmall);
+  inset-block-end: var(--spacing-xxsmall);
   inset-inline-end: var(--spacing-xxsmall);
 }

--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -8,13 +8,13 @@
 .title {
   font-size: var(--font-size-xlarge);
   font-weight: var(--font-weight-bold);
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
   line-height: var(--line-height-xlarge);
 }
 
 .itemsContainer {
   display: flex;
-  margin-bottom: var(--spacing-xxsmall);
+  margin-block-end: var(--spacing-xxsmall);
   flex-wrap: wrap;
 }
 .itemsContainer > div {
@@ -22,7 +22,7 @@
 }
 
 .itemsContainer > div {
-  margin-bottom: var(--spacing-xxsmall);
+  margin-block-end: var(--spacing-xxsmall);
   &::after {
     content: "·";
     margin-block-start: 0;
@@ -36,7 +36,7 @@
 }
 
 .iconContainer {
-  margin-top: calc(0.2 * var(--spacing-xxsmall));
+  margin-block-start: calc(0.2 * var(--spacing-xxsmall));
 }
 
 .copyright {

--- a/src/components/dls/Forms/Combobox/Combobox.module.scss
+++ b/src/components/dls/Forms/Combobox/Combobox.module.scss
@@ -74,7 +74,7 @@
 
 .placeholder {
   position: absolute;
-  top: 50%;
+  inset-block-start: 50%;
   transform: translateY(-50%);
   flex: 1;
   overflow: hidden;

--- a/src/components/dls/Forms/Combobox/ComboboxItems/ComboboxItems.module.scss
+++ b/src/components/dls/Forms/Combobox/ComboboxItems/ComboboxItems.module.scss
@@ -2,7 +2,7 @@ $webkit-thumb-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
 
 .comboboxBodyContainer {
   position: absolute;
-  margin-top: var(--spacing-micro);
+  margin-block-start: var(--spacing-micro);
   border-radius: var(--border-radius-default);
   box-shadow: var(--shadow-large);
   &.fixedWidth {

--- a/src/components/dls/Forms/Combobox/Icons/CaretInputIcon.module.scss
+++ b/src/components/dls/Forms/Combobox/Icons/CaretInputIcon.module.scss
@@ -3,7 +3,7 @@
   height: var(--spacing-medium);
   position: absolute;
   inset-inline-end: var(--spacing-medium);
-  top: 50%;
+  inset-block-start: 50%;
   transform: translateY(-50%);
   color: var(--color-background-alternative-deep);
   svg {

--- a/src/components/dls/Forms/Combobox/Icons/ClearInputIcon.module.scss
+++ b/src/components/dls/Forms/Combobox/Icons/ClearInputIcon.module.scss
@@ -9,7 +9,7 @@
   color: var(--color-background-alternative-deep);
   position: absolute;
   inset-inline-end: var(--spacing-medium);
-  top: 50%;
+  inset-block-start: 50%;
   transform: translateY(-50%);
   outline: none;
   margin-block-start: 0;

--- a/src/components/dls/Forms/Combobox/Icons/SearchInputIcon.module.scss
+++ b/src/components/dls/Forms/Combobox/Icons/SearchInputIcon.module.scss
@@ -1,6 +1,6 @@
 .iconContainer {
   position: absolute;
-  top: 50%;
+  inset-block-start: 50%;
   transform: translateY(-50%);
   z-index: 1;
   display: inline-block;

--- a/src/components/dls/Modal/Content.module.scss
+++ b/src/components/dls/Modal/Content.module.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable csstools/use-logical */
 @use "src/styles/breakpoints";
 @use "src/components/dls/Modal/constants";
 

--- a/src/components/dls/Separator/Separator.stories.module.scss
+++ b/src/components/dls/Separator/Separator.stories.module.scss
@@ -1,6 +1,5 @@
 .horizontalSeparator {
-  margin-top: var(--spacing-medium);
-  margin-bottom: var(--spacing-medium);
+  margin-block: var(--spacing-medium);
 }
 
 .verticalSeparator {

--- a/src/components/dls/Skeleton/Skeleton.module.scss
+++ b/src/components/dls/Skeleton/Skeleton.module.scss
@@ -38,10 +38,9 @@ $animationDuration: 8s;
   position: absolute;
 
   // using -1px to avoid some part of children border leaking outside
-  top: -1px;
+  inset-block: -1px;
   inset-inline-start: -1px;
   inset-inline-end: -1px;
-  bottom: -1px;
 }
 
 .rounded::before {

--- a/src/components/dls/Spinner/Spinner.module.scss
+++ b/src/components/dls/Spinner/Spinner.module.scss
@@ -28,7 +28,7 @@
   height: 100%;
   position: relative;
   inset-inline-start: 50%;
-  top: 50%;
+  inset-block-start: 50%;
 }
 
 @keyframes spinner {
@@ -43,7 +43,7 @@
 .span {
   background-color: var(--color-text-default);
   position: absolute;
-  top: -3.9%;
+  inset-block-start: -3.9%;
   width: 24%;
   height: 8%;
   inset-inline-start: -10%;

--- a/src/components/dls/SurahPreview/SurahPreviewBlock.module.scss
+++ b/src/components/dls/SurahPreview/SurahPreviewBlock.module.scss
@@ -43,13 +43,13 @@ $containerMaxWidth: calc(5 * var(--spacing-mega));
 .translatedSurahName {
   font-weight: var(--font-weight-bold);
   color: var(--color-text-faded);
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
 }
 
 .surahName {
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-bold);
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
 }
 
 .description {

--- a/src/components/dls/Toast/Toast.module.scss
+++ b/src/components/dls/Toast/Toast.module.scss
@@ -44,7 +44,7 @@
   box-shadow: var(--shadow-xlarge);
   transition: transform 0.4s, opacity 0.4s ease;
   position: absolute;
-  bottom: 0;
+  inset-block-end: 0;
   inset-inline-start: 0;
   inset-inline-end: 0;
 

--- a/src/pages/_error.module.scss
+++ b/src/pages/_error.module.scss
@@ -14,7 +14,7 @@
 
 .title {
   font-size: var(--font-size-jumbo);
-  margin-bottom: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
   text-align: center;
   line-height: normal;
 }
@@ -22,9 +22,9 @@
 .goBack {
   display: flex;
   justify-content: center;
-  margin-top: var(--spacing-medium);
+  margin-block-start: var(--spacing-medium);
 }
 
 .reportBug {
-  margin-top: var(--spacing-mega);
+  margin-block-start: var(--spacing-mega);
 }

--- a/src/pages/contentPage.module.scss
+++ b/src/pages/contentPage.module.scss
@@ -1,5 +1,5 @@
 .contentPage {
-  padding-top: var(--spacing-mega);
+  padding-block-start: var(--spacing-mega);
   max-width: 40rem;
   margin-block-start: 0;
   margin-block-end: 0;
@@ -12,17 +12,17 @@
   h1 {
     font-size: var(--font-size-xlarge);
     line-height: var(--line-height-jumbo);
-    margin-bottom: var(--spacing-xsmall);
+    margin-block-end: var(--spacing-xsmall);
     font-weight: var(--font-weight-bold);
   }
   h2 {
     font-size: var(--font-size-large);
-    margin-bottom: var(--spacing-xsmall);
+    margin-block-end: var(--spacing-xsmall);
     font-weight: var(--font-weight-semibold);
   }
   p {
     line-height: var(--line-height-large);
-    margin-bottom: var(--spacing-medium);
+    margin-block-end: var(--spacing-medium);
   }
   a {
     text-decoration: underline;

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -11,7 +11,7 @@ $list-max-width: 80rem;
 }
 
 .flow > .flowItem + .flowItem {
-  margin-top: var(--spacing-medium);
+  margin-block-start: var(--spacing-medium);
 }
 
 .flowItem {

--- a/src/pages/search.module.scss
+++ b/src/pages/search.module.scss
@@ -59,12 +59,12 @@
 
 .pageBody {
   width: 100%;
-  padding-top: var(--spacing-small);
+  padding-block-start: var(--spacing-small);
 }
 
 .filtersHeader {
   font-weight: var(--font-weight-bold);
-  padding-top: var(--spacing-small);
+  padding-block-start: var(--spacing-small);
   width: 100%;
   text-align: start;
 }
@@ -77,7 +77,7 @@
   padding-block-end: var(--spacing-small);
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
-  margin-top: var(--spacing-small);
+  margin-block-start: var(--spacing-small);
   @include breakpoints.tablet {
     display: flex;
     justify-content: space-between;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15117,6 +15117,11 @@ stylelint-scss@^3.21.0:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
+stylelint-use-logical@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-use-logical/-/stylelint-use-logical-1.1.0.tgz#f419386f48dae19fc59b024255c04f36738d879f"
+  integrity sha512-WwYAEoUNXxu4A9tZ+mPnvFSf3wKG9mY9+ZqnNjVHikfOQA4MTO6XeSC8BGCsY7LOG0GnDfmxMrRUJXFZRtaCmg==
+
 stylelint@^13.13.1:
   version "13.13.1"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-13.13.1.tgz#fca9c9f5de7990ab26a00f167b8978f083a18f3c"


### PR DESCRIPTION
### Summary
This PR enforces using [CSS logical properties and values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) by using  [stylelint-use-logical plugin](https://github.com/csstools/stylelint-use-logical). We need to enforce it to make sure that our styling works well in both right-to-left and left-to-right languages.

Closes #699 