### PR TITLE
Add "on word click" settings

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -114,6 +114,11 @@
         "reading": "Reading",
         "translation": "Translation"
     },
+    "word-click": {
+        "title": "Word Click",
+        "play-audio": "Play Audio",
+        "no-audio": "No Audio"
+    },
     "reciter": "Reciter",
     "remove": "Remove",
     "retry": "Retry",

--- a/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
@@ -15,11 +15,11 @@ import {
   setShowTooltipFor,
   selectShowTooltipFor,
   selectWordByWordByWordPreferences,
-  selectOnWordClick,
-  setOnWordClick,
+  selectWordClickFunctionality,
+  setWordClickFunctionality,
 } from 'src/redux/slices/QuranReader/readingPreferences';
 import { areArraysEqual } from 'src/utils/array';
-import { ReadingPreference, WordByWordType, OnWordClick } from 'types/QuranReader';
+import { ReadingPreference, WordByWordType, WordClickFunctionality } from 'types/QuranReader';
 
 const ReadingExperienceSection = () => {
   const { t } = useTranslation('common');
@@ -30,7 +30,7 @@ const ReadingExperienceSection = () => {
     shallowEqual,
   );
   const showTooltipFor = useSelector(selectShowTooltipFor, areArraysEqual);
-  const onWordClick = useSelector(selectOnWordClick);
+  const wordClickFunctionality = useSelector(selectWordClickFunctionality);
 
   const wordByWordValue = getWordByWordValue(
     showWordByWordTranslation,
@@ -89,7 +89,7 @@ const ReadingExperienceSection = () => {
 
   const wordClickOptions = useMemo(
     () =>
-      Object.values(OnWordClick).map((item) => ({
+      Object.values(WordClickFunctionality).map((item) => ({
         label: t(`word-click.${item}`),
         id: item,
         value: item,
@@ -133,8 +133,8 @@ const ReadingExperienceSection = () => {
       <Section.Row>
         <Section.Label>{t('word-click.title')}</Section.Label>
         <RadioGroup
-          onChange={(value) => dispatch(setOnWordClick(value as OnWordClick))}
-          value={onWordClick}
+          onChange={(value) => dispatch(setWordClickFunctionality(value as WordClickFunctionality))}
+          value={wordClickFunctionality}
           label="Word Click"
           items={wordClickOptions}
           orientation={RadioGroupOrientation.Horizontal}

--- a/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReadingExperienceSection.tsx
@@ -15,9 +15,11 @@ import {
   setShowTooltipFor,
   selectShowTooltipFor,
   selectWordByWordByWordPreferences,
+  selectOnWordClick,
+  setOnWordClick,
 } from 'src/redux/slices/QuranReader/readingPreferences';
 import { areArraysEqual } from 'src/utils/array';
-import { ReadingPreference, WordByWordType } from 'types/QuranReader';
+import { ReadingPreference, WordByWordType, OnWordClick } from 'types/QuranReader';
 
 const ReadingExperienceSection = () => {
   const { t } = useTranslation('common');
@@ -28,6 +30,7 @@ const ReadingExperienceSection = () => {
     shallowEqual,
   );
   const showTooltipFor = useSelector(selectShowTooltipFor, areArraysEqual);
+  const onWordClick = useSelector(selectOnWordClick);
 
   const wordByWordValue = getWordByWordValue(
     showWordByWordTranslation,
@@ -84,6 +87,16 @@ const ReadingExperienceSection = () => {
     [t],
   );
 
+  const wordClickOptions = useMemo(
+    () =>
+      Object.values(OnWordClick).map((item) => ({
+        label: t(`word-click.${item}`),
+        id: item,
+        value: item,
+      })),
+    [t],
+  );
+
   return (
     <Section>
       <Section.Title>{t('settings.reading-experience')}</Section.Title>
@@ -115,6 +128,16 @@ const ReadingExperienceSection = () => {
           options={wordByWordOptions}
           value={tooltipWordByWordValue}
           onChange={onTooltipWordByWordChange}
+        />
+      </Section.Row>
+      <Section.Row>
+        <Section.Label>{t('word-click.title')}</Section.Label>
+        <RadioGroup
+          onChange={(value) => dispatch(setOnWordClick(value as OnWordClick))}
+          value={onWordClick}
+          label="Word Click"
+          items={wordClickOptions}
+          orientation={RadioGroupOrientation.Horizontal}
         />
       </Section.Row>
     </Section>

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -15,6 +15,7 @@ import Wrapper from 'src/components/Wrapper/Wrapper';
 import { selectReciter } from 'src/redux/slices/AudioPlayer/state';
 import { selectIsWordHighlighted } from 'src/redux/slices/QuranReader/highlightedLocation';
 import {
+  selectOnWordClick,
   selectReadingPreference,
   selectShowTooltipFor,
   selectWordByWordByWordPreferences,
@@ -23,7 +24,7 @@ import { makeChapterAudioDataUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import { isQCFFont } from 'src/utils/fontFaceHelper';
 import { getChapterNumberFromKey, makeWordLocation } from 'src/utils/verse';
-import { ReadingPreference, QuranFont, WordByWordType } from 'types/QuranReader';
+import { ReadingPreference, QuranFont, WordByWordType, OnWordClick } from 'types/QuranReader';
 import Word, { CharType } from 'types/Word';
 
 export const DATA_ATTRIBUTE_WORD_LOCATION = 'data-word-location';
@@ -48,6 +49,7 @@ const QuranWord = ({
   isAudioHighlightingAllowed = true,
   isHighlighted,
 }: QuranWordProps) => {
+  const onWordClick = useSelector(selectOnWordClick);
   const reciter = useSelector(selectReciter, shallowEqual);
   const chapterId = getChapterNumberFromKey(word.verseKey);
   const { data: audioData } = useSWRImmutable(
@@ -97,7 +99,9 @@ const QuranWord = ({
     [isWordByWordAllowed, showTooltipFor, word],
   );
 
-  const onClick = useCallback(() => onQuranWordClick(word, audioData), [audioData, word]);
+  const onClick = useCallback(() => {
+    if (onWordClick === OnWordClick.PlayAudio) onQuranWordClick(word, audioData);
+  }, [audioData, word, onWordClick]);
   return (
     <div
       onClick={onClick}

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -15,7 +15,7 @@ import Wrapper from 'src/components/Wrapper/Wrapper';
 import { selectReciter } from 'src/redux/slices/AudioPlayer/state';
 import { selectIsWordHighlighted } from 'src/redux/slices/QuranReader/highlightedLocation';
 import {
-  selectOnWordClick,
+  selectWordClickFunctionality,
   selectReadingPreference,
   selectShowTooltipFor,
   selectWordByWordByWordPreferences,
@@ -24,7 +24,12 @@ import { makeChapterAudioDataUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import { isQCFFont } from 'src/utils/fontFaceHelper';
 import { getChapterNumberFromKey, makeWordLocation } from 'src/utils/verse';
-import { ReadingPreference, QuranFont, WordByWordType, OnWordClick } from 'types/QuranReader';
+import {
+  ReadingPreference,
+  QuranFont,
+  WordByWordType,
+  WordClickFunctionality,
+} from 'types/QuranReader';
 import Word, { CharType } from 'types/Word';
 
 export const DATA_ATTRIBUTE_WORD_LOCATION = 'data-word-location';
@@ -49,7 +54,7 @@ const QuranWord = ({
   isAudioHighlightingAllowed = true,
   isHighlighted,
 }: QuranWordProps) => {
-  const onWordClick = useSelector(selectOnWordClick);
+  const wordClickFunctionality = useSelector(selectWordClickFunctionality);
   const reciter = useSelector(selectReciter, shallowEqual);
   const chapterId = getChapterNumberFromKey(word.verseKey);
   const { data: audioData } = useSWRImmutable(
@@ -100,8 +105,9 @@ const QuranWord = ({
   );
 
   const onClick = useCallback(() => {
-    if (onWordClick === OnWordClick.PlayAudio) onQuranWordClick(word, audioData);
-  }, [audioData, word, onWordClick]);
+    if (wordClickFunctionality === WordClickFunctionality.PlayAudio)
+      onQuranWordClick(word, audioData);
+  }, [audioData, word, wordClickFunctionality]);
   return (
     <div
       onClick={onClick}

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -86,7 +86,7 @@ export default {
     ...state,
     readingPreferences: {
       ...state.readingPreferences,
-      onWordClick: readingPreferencesInitialState.onWordClick,
+      wordClickFunctionality: readingPreferencesInitialState.wordClickFunctionality,
     },
   }),
 };

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_RECITER } from './slices/AudioPlayer/defaultData';
 import { defaultRepeatProgress, defaultRepeatSettings } from './slices/AudioPlayer/state';
+import { initialState as readingPreferencesInitialState } from './slices/QuranReader/readingPreferences';
 import { DEFAULT_TAFSIRS } from './slices/QuranReader/tafsirs';
 import { initialState as welcomeMessageInitialState } from './slices/welcomeMessage';
 
@@ -79,6 +80,13 @@ export default {
     audioPlayerState: {
       ...state.audioPlayerState,
       reciter: DEFAULT_RECITER,
+    },
+  }),
+  14: (state) => ({
+    ...state,
+    readingPreferences: {
+      ...state.readingPreferences,
+      onWordClick: readingPreferencesInitialState.onWordClick,
     },
   }),
 };

--- a/src/redux/slices/QuranReader/readingPreferences.ts
+++ b/src/redux/slices/QuranReader/readingPreferences.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { RootState } from 'src/redux/RootState';
 import resetSettings from 'src/redux/slices/reset-settings';
-import { ReadingPreference, WordByWordType } from 'types/QuranReader';
+import { ReadingPreference, WordByWordType, OnWordClick } from 'types/QuranReader';
 
 const DEFAULT_TRANSLATION = 20; // just a placeholder.
 const DEFAULT_TRANSLITERATION = 12; // just a placeholder.
@@ -14,15 +14,17 @@ export type ReadingPreferences = {
   showWordByWordTransliteration: boolean;
   selectedWordByWordTransliteration: number;
   showTooltipFor: WordByWordType[];
+  onWordClick: OnWordClick;
 };
 
-const initialState: ReadingPreferences = {
+export const initialState: ReadingPreferences = {
   readingPreference: ReadingPreference.Translation,
   showWordByWordTranslation: false,
   selectedWordByWordTranslation: DEFAULT_TRANSLATION,
   showWordByWordTransliteration: false,
   selectedWordByWordTransliteration: DEFAULT_TRANSLITERATION,
   showTooltipFor: [WordByWordType.Translation],
+  onWordClick: OnWordClick.PlayAudio,
 };
 
 export const readingPreferencesSlice = createSlice({
@@ -53,6 +55,10 @@ export const readingPreferencesSlice = createSlice({
       ...state,
       showTooltipFor: action.payload,
     }),
+    setOnWordClick: (state, action: PayloadAction<OnWordClick>) => ({
+      ...state,
+      onWordClick: action.payload,
+    }),
   },
   // reset the state to initial state
   // when `reset` action is dispatched
@@ -68,6 +74,7 @@ export const {
   setSelectedWordByWordTranslation,
   setSelectedWordByWordTransliteration,
   setShowTooltipFor,
+  setOnWordClick,
 } = readingPreferencesSlice.actions;
 
 export const selectWordByWordByWordPreferences = (state: RootState) => ({
@@ -79,5 +86,6 @@ export const selectWordByWordByWordPreferences = (state: RootState) => ({
 export const selectShowTooltipFor = (state: RootState) => state.readingPreferences.showTooltipFor;
 export const selectReadingPreference = (state: RootState) =>
   state.readingPreferences.readingPreference;
+export const selectOnWordClick = (state: RootState) => state.readingPreferences.onWordClick;
 
 export default readingPreferencesSlice.reducer;

--- a/src/redux/slices/QuranReader/readingPreferences.ts
+++ b/src/redux/slices/QuranReader/readingPreferences.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { RootState } from 'src/redux/RootState';
 import resetSettings from 'src/redux/slices/reset-settings';
-import { ReadingPreference, WordByWordType, OnWordClick } from 'types/QuranReader';
+import { ReadingPreference, WordByWordType, WordClickFunctionality } from 'types/QuranReader';
 
 const DEFAULT_TRANSLATION = 20; // just a placeholder.
 const DEFAULT_TRANSLITERATION = 12; // just a placeholder.
@@ -14,7 +14,7 @@ export type ReadingPreferences = {
   showWordByWordTransliteration: boolean;
   selectedWordByWordTransliteration: number;
   showTooltipFor: WordByWordType[];
-  onWordClick: OnWordClick;
+  wordClickFunctionality: WordClickFunctionality;
 };
 
 export const initialState: ReadingPreferences = {
@@ -24,7 +24,7 @@ export const initialState: ReadingPreferences = {
   showWordByWordTransliteration: false,
   selectedWordByWordTransliteration: DEFAULT_TRANSLITERATION,
   showTooltipFor: [WordByWordType.Translation],
-  onWordClick: OnWordClick.PlayAudio,
+  wordClickFunctionality: WordClickFunctionality.PlayAudio,
 };
 
 export const readingPreferencesSlice = createSlice({
@@ -55,9 +55,9 @@ export const readingPreferencesSlice = createSlice({
       ...state,
       showTooltipFor: action.payload,
     }),
-    setOnWordClick: (state, action: PayloadAction<OnWordClick>) => ({
+    setWordClickFunctionality: (state, action: PayloadAction<WordClickFunctionality>) => ({
       ...state,
-      onWordClick: action.payload,
+      wordClickFunctionality: action.payload,
     }),
   },
   // reset the state to initial state
@@ -74,7 +74,7 @@ export const {
   setSelectedWordByWordTranslation,
   setSelectedWordByWordTransliteration,
   setShowTooltipFor,
-  setOnWordClick,
+  setWordClickFunctionality,
 } = readingPreferencesSlice.actions;
 
 export const selectWordByWordByWordPreferences = (state: RootState) => ({
@@ -86,6 +86,7 @@ export const selectWordByWordByWordPreferences = (state: RootState) => ({
 export const selectShowTooltipFor = (state: RootState) => state.readingPreferences.showTooltipFor;
 export const selectReadingPreference = (state: RootState) =>
   state.readingPreferences.readingPreference;
-export const selectOnWordClick = (state: RootState) => state.readingPreferences.onWordClick;
+export const selectWordClickFunctionality = (state: RootState) =>
+  state.readingPreferences.wordClickFunctionality;
 
 export default readingPreferencesSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -35,7 +35,7 @@ import welcomeMessage from './slices/welcomeMessage';
 
 const persistConfig = {
   key: 'root',
-  version: 13,
+  version: 14,
   storage,
   migrate: createMigrate(migrations, {
     debug: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development',

--- a/types/QuranReader.ts
+++ b/types/QuranReader.ts
@@ -8,6 +8,11 @@ export enum ReadingPreference {
   Reading = 'reading', // Displays the Quran text only similar to a physical Quran page without any translations.
 }
 
+export enum OnWordClick {
+  PlayAudio = 'play-audio',
+  NoAudio = 'no-audio',
+}
+
 export enum QuranReaderDataType {
   Chapter = 'chapter',
   Verse = 'verse',

--- a/types/QuranReader.ts
+++ b/types/QuranReader.ts
@@ -8,7 +8,7 @@ export enum ReadingPreference {
   Reading = 'reading', // Displays the Quran text only similar to a physical Quran page without any translations.
 }
 
-export enum OnWordClick {
+export enum WordClickFunctionality {
   PlayAudio = 'play-audio',
   NoAudio = 'no-audio',
 }


### PR DESCRIPTION
### Summary

Adding new settings "Word Click"

Expected behavior
- When "Play Audio" option is selected. Clicking the word will "play word by word audio", or update the timestamp of the current playing audio.
- When "No audio" option is selected. Clicking the word will do nothing