### PR TITLE
Persist selected locale

### DIFF
--- a/src/components/Navbar/LanguageSelector.tsx
+++ b/src/components/Navbar/LanguageSelector.tsx
@@ -33,7 +33,7 @@ const options = locales.map((lng) => ({
   value: lng,
 }));
 
-const COOKIE_PERSISTENCE_PERIOD_MS = 100 * 24 * 60 * 60 * 1000; // 100 days
+const COOKIE_PERSISTENCE_PERIOD_MS = 86400000000000; // maximum milliseconds-since-the-epoch value https://stackoverflow.com/a/56980560/1931451
 
 const LanguageSelector = () => {
   const { lang } = useTranslation();
@@ -54,7 +54,7 @@ const LanguageSelector = () => {
   const onChange = async (newLocale: string) => {
     await setLanguage(newLocale);
     const date = new Date();
-    date.setTime(date.getTime() + COOKIE_PERSISTENCE_PERIOD_MS);
+    date.setTime(COOKIE_PERSISTENCE_PERIOD_MS);
     // eslint-disable-next-line i18next/no-literal-string
     document.cookie = `NEXT_LOCALE=${newLocale};expires=${date.toUTCString()};path=/`;
   };

--- a/src/components/Navbar/LanguageSelector.tsx
+++ b/src/components/Navbar/LanguageSelector.tsx
@@ -33,11 +33,30 @@ const options = locales.map((lng) => ({
   value: lng,
 }));
 
+const COOKIE_PERSISTENCE_PERIOD_MS = 100 * 24 * 60 * 60 * 1000; // 100 days
+
 const LanguageSelector = () => {
   const { lang } = useTranslation();
 
-  const onChange = async (value: string) => {
-    await setLanguage(value);
+  /**
+   * When the user changes the language, we will:
+   *
+   * 1. Call next-translate's setLanguage with the new value.
+   * 2. Store the new value of the locale in the cookies so that next time the user
+   * lands on the `/` route, he will be redirected to the homepage with the
+   * saved locale. This is to over-ride next.js's default behavior which takes
+   * into consideration `Accept-language` header {@see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language}
+   * as a locale detection mechanism. For further reading on Next.js's behavior
+   * {@see https://nextjs.org/docs/advanced-features/i18n-routing}.
+   *
+   * @param {string} newLocale
+   */
+  const onChange = async (newLocale: string) => {
+    await setLanguage(newLocale);
+    const date = new Date();
+    date.setTime(date.getTime() + COOKIE_PERSISTENCE_PERIOD_MS);
+    // eslint-disable-next-line i18next/no-literal-string
+    document.cookie = `NEXT_LOCALE=${newLocale};expires=${date.toUTCString()};path=/`;
   };
 
   return (


### PR DESCRIPTION
### Summary
This PR persists the user's locale in the Cookies so that we can redirect him to his previously selected locale whenever he lands on `/` route.  

Reference: [Next.js's docs](https://nextjs.org/docs/advanced-features/i18n-routing#leveraging-the-next_locale-cookie).

Closes #694 