### PR TITLE
Fix Playback Speed issue

### DIFF
--- a/src/components/Navbar/SettingsDrawer/AudioSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/AudioSection.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 
-import capitalize from 'lodash/lodash';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
@@ -85,8 +84,15 @@ const AudioSection = () => {
   );
 };
 
-const playbackRates = generateSelectOptions(
-  ['0.25', '0.5', '0.75', '1', '1.25', '1.5', '1.75', '2'].map(capitalize),
-);
+const playbackRates = generateSelectOptions([
+  '0.25',
+  '0.5',
+  '0.75',
+  '1',
+  '1.25',
+  '1.5',
+  '1.75',
+  '2',
+]);
 
 export default AudioSection;


### PR DESCRIPTION
### Summary
This PR fixes Playback Speed options issue inside the Settings Drawer where the options were not showing.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="387" alt="Screen Shot 2021-11-11 at 12 49 36" src="https://user-images.githubusercontent.com/15169499/141245030-edbfc0e9-9a18-455d-8c64-9c99364149ce.png">|<img width="381" alt="Screen Shot 2021-11-11 at 12 50 26" src="https://user-images.githubusercontent.com/15169499/141245037-47f4841c-0901-4730-95bd-b379ddc57faa.png">|