### PR TITLE
Added Skeleton components for sidemenus and homepage

### DIFF
--- a/src/components/Navbar/NavigationDrawer/NavigationDrawer.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawer.tsx
@@ -9,14 +9,14 @@ import IconQ from '../../../../public/icons/Q_simple.svg';
 import Drawer, { DrawerSide, DrawerType } from '../Drawer';
 
 import styles from './NavigationDrawer.module.scss';
+import NavigationDrawerBodySkeleton from './NavigationDrawerBodySkeleton';
 
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
-import Spinner from 'src/components/dls/Spinner/Spinner';
 import { selectNavbar } from 'src/redux/slices/navbar';
 
 const NavigationDrawerBody = dynamic(() => import('./NavigationDrawerBody'), {
   ssr: false,
-  loading: () => <Spinner />,
+  loading: () => <NavigationDrawerBodySkeleton />,
 });
 
 const NavigationDrawer = () => {

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.module.scss
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.module.scss
@@ -1,0 +1,16 @@
+.skeletonContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.navRow {
+  width: auto;
+  height: 40px;
+  margin: 8px 10px 4px;
+}
+
+.blockRow {
+    width: auto;
+    height: 200px;
+    margin: 8px 10px 4px;
+}

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.module.scss
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.module.scss
@@ -5,12 +5,15 @@
 
 .navRow {
   width: auto;
-  height: 40px;
-  margin: 8px 10px 4px;
+  height: var(--spacing-mega);
+  padding: var(--spacing-xxsmall) 0;
+  margin: var(--spacing-xxsmall) var(--spacing-xsmall);
+  margin-inline-start: var(--spacing-small);
 }
 
 .blockRow {
-    width: auto;
-    height: 200px;
-    margin: 8px 10px 4px;
+  width: auto;
+  height: calc(var(--spacing-mega) * 6);
+  margin: var(--spacing-xxsmall) var(--spacing-xsmall);
+  margin-inline-start: var(--spacing-small);
 }

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.tsx
@@ -1,6 +1,6 @@
-import Skeleton from "../../dls/Skeleton/Skeleton";
+import Skeleton from '../../dls/Skeleton/Skeleton';
 
-import styles from "./NavigationDrawerBodySkeleton.module.scss";
+import styles from './NavigationDrawerBodySkeleton.module.scss';
 
 const NAV_ROW_COUNT = 6;
 const rowsArr = Array(NAV_ROW_COUNT).fill(null);
@@ -8,12 +8,7 @@ const rowsArr = Array(NAV_ROW_COUNT).fill(null);
 const renderLinesSkeleton = (index) => {
   return rowsArr.map((k, i) => (
     // eslint-disable-next-line react/no-array-index-key
-    <Skeleton
-      key={`skeleton_${index}_${i}`}
-      isActive
-      isSquared
-      className={styles.navRow}
-    />
+    <Skeleton key={`skeleton_${index}_${i}`} isActive isSquared className={styles.navRow} />
   ));
 };
 

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.tsx
@@ -1,0 +1,24 @@
+import Skeleton from '../../dls/Skeleton/Skeleton';
+
+import styles from './NavigationDrawerBodySkeleton.module.scss';
+
+const NAV_ROW_COUNT = 6;
+const rowsArr = Array(NAV_ROW_COUNT).fill(null);
+
+const NavigationDrawerBodySkeleton = () => {
+  return (
+    <span className={styles.skeletonContainer}>
+      {rowsArr.map((k, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Skeleton key={`skeleton_${i}`} isActive isSquared className={styles.navRow} />
+      ))}
+      <Skeleton isActive isSquared className={styles.blockRow} />
+      {rowsArr.map((k, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Skeleton key={`skeleton_${i}`} isActive isSquared className={styles.navRow} />
+      ))}
+    </span>
+  );
+};
+
+export default NavigationDrawerBodySkeleton;

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerBodySkeleton.tsx
@@ -1,22 +1,28 @@
-import Skeleton from '../../dls/Skeleton/Skeleton';
+import Skeleton from "../../dls/Skeleton/Skeleton";
 
-import styles from './NavigationDrawerBodySkeleton.module.scss';
+import styles from "./NavigationDrawerBodySkeleton.module.scss";
 
 const NAV_ROW_COUNT = 6;
 const rowsArr = Array(NAV_ROW_COUNT).fill(null);
 
+const renderLinesSkeleton = (index) => {
+  return rowsArr.map((k, i) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <Skeleton
+      key={`skeleton_${index}_${i}`}
+      isActive
+      isSquared
+      className={styles.navRow}
+    />
+  ));
+};
+
 const NavigationDrawerBodySkeleton = () => {
   return (
     <span className={styles.skeletonContainer}>
-      {rowsArr.map((k, i) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <Skeleton key={`skeleton_${i}`} isActive isSquared className={styles.navRow} />
-      ))}
+      {renderLinesSkeleton(1)}
       <Skeleton isActive isSquared className={styles.blockRow} />
-      {rowsArr.map((k, i) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <Skeleton key={`skeleton_${i}`} isActive isSquared className={styles.navRow} />
-      ))}
+      {renderLinesSkeleton(2)}
     </span>
   );
 };

--- a/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.module.scss
+++ b/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.module.scss
@@ -7,12 +7,12 @@
   display: flex;
   flex-direction: row;
   width: 100%;
-  margin: 8px;
+  margin: var(--spacing-xxsmall);
 }
 
 .titleSkeleton {
-  width: 100px;
-  height: 16px;
+  width: calc(3 * var(--spacing-mega));
+  height: var(--spacing-medium);
 }
 
 .rowSkeleton {
@@ -22,26 +22,21 @@
 }
 
 .inputRow {
-  margin-bottom: 18px;
-  padding-bottom: 18px;
+  margin-bottom: var(--spacing-large);
+  padding-bottom: var(--spacing-large);
   border-bottom: 1px solid;
-  [data-theme="dark"] & {
-    border-color: rgba(255, 255, 255, 0.13);
-  }
-  [data-theme="light"] & {
-    border-color: rgba(0, 0, 0, 0.11);
-  }
+  border-color: var(--color-secondary-faded);
 }
 
 .label {
-  margin: 8px;
+  margin: var(--spacing-xxsmall);
   margin-inline-end: auto;
   width: 20%;
-  height: 16px;
+  height: var(--spacing-large);
 }
 
 .input {
-  margin: 8px;
+  margin: var(--spacing-medium);
   width: 60%;
-  height: 28px;
+  height: calc(2 * var(--spacing-small));
 }

--- a/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.module.scss
+++ b/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.module.scss
@@ -1,0 +1,47 @@
+.skeletonContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  margin: 8px;
+}
+
+.titleSkeleton {
+  width: 100px;
+  height: 16px;
+}
+
+.rowSkeleton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.inputRow {
+  margin-bottom: 18px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid;
+  [data-theme="dark"] & {
+    border-color: rgba(255, 255, 255, 0.13);
+  }
+  [data-theme="light"] & {
+    border-color: rgba(0, 0, 0, 0.11);
+  }
+}
+
+.label {
+  margin: 8px;
+  margin-inline-end: auto;
+  width: 20%;
+  height: 16px;
+}
+
+.input {
+  margin: 8px;
+  width: 60%;
+  height: 28px;
+}

--- a/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.module.scss
+++ b/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.module.scss
@@ -22,8 +22,8 @@
 }
 
 .inputRow {
-  margin-bottom: var(--spacing-large);
-  padding-bottom: var(--spacing-large);
+  margin-block-end: var(--spacing-large);
+  padding-block-end: var(--spacing-large);
   border-bottom: 1px solid;
   border-color: var(--color-secondary-faded);
 }

--- a/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.tsx
+++ b/src/components/Navbar/SettingsDrawer/SettingsBodySkeleton.tsx
@@ -1,0 +1,27 @@
+import Skeleton from '../../dls/Skeleton/Skeleton';
+
+import styles from './SettingsBodySkeleton.module.scss';
+
+const SETTINGS_ROW_COUNT = 4;
+const rowsArr = Array(SETTINGS_ROW_COUNT).fill(null);
+
+const SettingsBodySkeleton = () => {
+  return (
+    <span className={styles.skeletonContainer}>
+      {rowsArr.map((k, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <span key={`skeleton_${i}`} className={styles.inputRow}>
+          <div className={styles.title}>
+            <Skeleton isActive isSquared className={styles.titleSkeleton} />
+          </div>
+          <div className={styles.rowSkeleton}>
+            <Skeleton isActive isSquared className={styles.label} />
+            <Skeleton isActive isSquared className={styles.input} />
+          </div>
+        </span>
+      ))}
+    </span>
+  );
+};
+
+export default SettingsBodySkeleton;

--- a/src/components/Navbar/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/components/Navbar/SettingsDrawer/SettingsDrawer.tsx
@@ -7,16 +7,16 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import BackIcon from '../../../../public/icons/west.svg';
 
+import SettingsBodySkeleton from './SettingsBodySkeleton';
 import styles from './SettingsDrawer.module.scss';
 
 import Button, { ButtonVariant } from 'src/components/dls/Button/Button';
-import Spinner from 'src/components/dls/Spinner/Spinner';
 import Drawer, { DrawerType } from 'src/components/Navbar/Drawer';
 import { selectNavbar, setSettingsView, SettingsView } from 'src/redux/slices/navbar';
 
 const SettingsBody = dynamic(() => import('./SettingsBody'), {
   ssr: false,
-  loading: () => <Spinner />,
+  loading: () => <SettingsBodySkeleton />,
 });
 
 const ReciterSelectionBody = dynamic(() => import('./ReciterSelectionBody'), {

--- a/src/components/Navbar/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/components/Navbar/SettingsDrawer/SettingsDrawer.tsx
@@ -27,7 +27,7 @@ const TranslationSelectionBody = dynamic(() => import('./TranslationSelectionBod
   ssr: false,
 });
 
-const TafisrSelectionBody = dynamic(() => import('./TafsirSelectionBody'), {
+const TafsirSelectionBody = dynamic(() => import('./TafsirSelectionBody'), {
   ssr: false,
 });
 
@@ -59,7 +59,7 @@ const SettingsDrawer = () => {
         <TranslationSelectionBody />
       )}
       {isSettingsDrawerOpen && settingsView === SettingsView.Reciter && <ReciterSelectionBody />}
-      {isSettingsDrawerOpen && settingsView === SettingsView.Tafsir && <TafisrSelectionBody />}
+      {isSettingsDrawerOpen && settingsView === SettingsView.Tafsir && <TafsirSelectionBody />}
     </Drawer>
   );
 };

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -3,26 +3,17 @@ import React, { useState, useMemo } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
-import dynamic from 'next/dynamic';
 
 import CaretDownIcon from '../../../public/icons/caret-down.svg';
 import Link from '../dls/Link/Link';
-import Spinner from '../dls/Spinner/Spinner';
 import SurahPreviewRow from '../dls/SurahPreview/SurahPreviewRow';
 import Tabs from '../dls/Tabs/Tabs';
 
 import styles from './ChapterAndJuzList.module.scss';
+import JuzView from './JuzView';
 
 import { shouldUseMinimalLayout } from 'src/utils/locale';
 import Chapter from 'types/Chapter';
-
-const JuzView = dynamic(() => import('./JuzView'), {
-  loading: () => (
-    <div className={styles.loadingContainer}>
-      <Spinner />
-    </div>
-  ),
-});
 
 enum View {
   Surah = 'surah',

--- a/src/components/chapters/ChapterAndJuzListSkeleton.module.scss
+++ b/src/components/chapters/ChapterAndJuzListSkeleton.module.scss
@@ -1,0 +1,33 @@
+@use "src/styles/breakpoints";
+.skeletonContainer {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.skeletonItem {
+  margin: 8px;
+  display: flex;
+  flex: 1 0 30%;
+  height: 74px;
+  @include breakpoints.smallerThanDesktop {
+    flex: 1 0 42%;
+  }
+  @include breakpoints.smallerThanMobileL {
+    margin: 8px 2px;
+    flex: 1 0 100%;
+  }
+}
+
+.tabSkeleton {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  margin: 8px;
+}
+
+.tabSkeletonItem {
+  width: 100px;
+  margin-inline-end: 12px;
+  margin-bottom: 8px;
+}

--- a/src/components/chapters/ChapterAndJuzListSkeleton.module.scss
+++ b/src/components/chapters/ChapterAndJuzListSkeleton.module.scss
@@ -33,7 +33,7 @@
 .firstTabSkeleton {
   width: calc(3 * var(--spacing-mega));
   margin-inline-end: var(--spacing-small);
-  margin-bottom: var(--spacing-xsmall);
+  margin-block-end: var(--spacing-xsmall);
 }
 
 .secondTabSkeleton {

--- a/src/components/chapters/ChapterAndJuzListSkeleton.module.scss
+++ b/src/components/chapters/ChapterAndJuzListSkeleton.module.scss
@@ -6,15 +6,16 @@
 }
 
 .skeletonItem {
-  margin: 8px;
   display: flex;
   flex: 1 0 30%;
-  height: 74px;
+  margin: var(--spacing-xsmall);
+  padding: var(--spacing-xsmall) 0;
+  height: calc(2 * var(--spacing-mega));
   @include breakpoints.smallerThanDesktop {
     flex: 1 0 42%;
   }
   @include breakpoints.smallerThanMobileL {
-    margin: 8px 2px;
+    margin: var(--spacing-xsmall) var(--spacing-micro);
     flex: 1 0 100%;
   }
 }
@@ -23,11 +24,18 @@
   display: flex;
   flex-direction: row;
   width: 100%;
-  margin: 8px;
+  margin: var(--spacing-xsmall);
+  @include breakpoints.smallerThanMobileL {
+    margin-inline-start: var(--spacing-micro);
+  }
 }
 
-.tabSkeletonItem {
-  width: 100px;
-  margin-inline-end: 12px;
-  margin-bottom: 8px;
+.firstTabSkeleton {
+  width: calc(3 * var(--spacing-mega));
+  margin-inline-end: var(--spacing-small);
+  margin-bottom: var(--spacing-xsmall);
+}
+
+.secondTabSkeleton {
+  width: calc(3 * var(--spacing-mega));
 }

--- a/src/components/chapters/ChapterAndJuzListSkeleton.tsx
+++ b/src/components/chapters/ChapterAndJuzListSkeleton.tsx
@@ -1,0 +1,28 @@
+import Skeleton from '../dls/Skeleton/Skeleton';
+
+import styles from './ChapterAndJuzListSkeleton.module.scss';
+
+const CHAPTERS_COUNT = 114;
+const chaptersArr = Array(CHAPTERS_COUNT).fill(null);
+
+const ChapterAndJuzListSkeleton = () => {
+  return (
+    <span className={styles.skeletonContainer}>
+      <div className={styles.tabSkeleton}>
+        <Skeleton isActive isSquared className={styles.tabSkeletonItem} />
+        <Skeleton isActive isSquared style={{ width: '100px' }} />
+      </div>
+      {chaptersArr.map((k, i) => (
+        <Skeleton
+          // eslint-disable-next-line react/no-array-index-key
+          key={`skeleton_${i}`}
+          isActive
+          isSquared
+          className={styles.skeletonItem}
+        />
+      ))}
+    </span>
+  );
+};
+
+export default ChapterAndJuzListSkeleton;

--- a/src/components/chapters/ChapterAndJuzListSkeleton.tsx
+++ b/src/components/chapters/ChapterAndJuzListSkeleton.tsx
@@ -9,8 +9,8 @@ const ChapterAndJuzListSkeleton = () => {
   return (
     <span className={styles.skeletonContainer}>
       <div className={styles.tabSkeleton}>
-        <Skeleton isActive isSquared className={styles.tabSkeletonItem} />
-        <Skeleton isActive isSquared style={{ width: '100px' }} />
+        <Skeleton isActive isSquared className={styles.firstTabSkeleton} />
+        <Skeleton isActive isSquared className={styles.secondTabSkeleton} />
       </div>
       {chaptersArr.map((k, i) => (
         <Skeleton

--- a/src/components/dls/Skeleton/Skeleton.module.scss
+++ b/src/components/dls/Skeleton/Skeleton.module.scss
@@ -16,10 +16,10 @@ $animationDuration: 8s;
   border-radius: var(--border-radius-default);
 
   [data-theme="dark"] & {
-    background-color: rgba(255, 255, 255, 0.13);
+    background-color: var(--color-background-alternative-faint);
   }
   [data-theme="light"] & {
-    background-color: rgba(0, 0, 0, 0.11);
+    background-color: var(--color-secondary-faded);
   }
   animation: 1.5s ease-in-out 0.5s infinite normal none running loading;
 

--- a/src/components/dls/Skeleton/Skeleton.module.scss
+++ b/src/components/dls/Skeleton/Skeleton.module.scss
@@ -1,3 +1,4 @@
+@use "src/styles/theme";
 $baseSize: var(--spacing-mega);
 $animationDuration: 8s;
 
@@ -15,12 +16,13 @@ $animationDuration: 8s;
 .active::before {
   border-radius: var(--border-radius-default);
 
-  [data-theme="dark"] & {
-    background-color: var(--color-background-alternative-faint);
-  }
-  [data-theme="light"] & {
+  @include theme.light {
     background-color: var(--color-secondary-faded);
   }
+  @include theme.dark {
+    background-color: var(--color-background-alternative-faded);
+  }
+
   animation: 1.5s ease-in-out 0.5s infinite normal none running loading;
 
   content: " ";
@@ -36,17 +38,6 @@ $animationDuration: 8s;
   border-radius: var(--border-radius-circle);
 }
 
-@-webkit-keyframes loading {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
-  100% {
-    opacity: 1;
-  }
-}
 @keyframes loading {
   0% {
     opacity: 1;

--- a/src/components/dls/Skeleton/Skeleton.module.scss
+++ b/src/components/dls/Skeleton/Skeleton.module.scss
@@ -1,15 +1,6 @@
 $baseSize: var(--spacing-mega);
 $animationDuration: 8s;
 
-@keyframes loading {
-  from {
-    background-position: 200% 0;
-  }
-  to {
-    background-position: -200% 0;
-  }
-}
-
 .baseSize {
   height: $baseSize;
   width: $baseSize;
@@ -23,18 +14,16 @@ $animationDuration: 8s;
 
 .active::before {
   border-radius: var(--border-radius-default);
-  background-image: linear-gradient(
-    270deg,
-    var(--shade-0),
-    var(--shade-1),
-    var(--shade-2),
-    var(--shade-1),
-    var(--shade-0)
-  );
-  background-size: 400% 100%; // increase background size's width to 4x to make background animate-able
-  animation: loading $animationDuration ease-in-out infinite;
 
-  content: "";
+  [data-theme="dark"] & {
+    background-color: rgba(255, 255, 255, 0.13);
+  }
+  [data-theme="light"] & {
+    background-color: rgba(0, 0, 0, 0.11);
+  }
+  animation: 1.5s ease-in-out 0.5s infinite normal none running loading;
+
+  content: " ";
   position: absolute;
 
   // using -1px to avoid some part of children border leaking outside
@@ -47,6 +36,25 @@ $animationDuration: 8s;
   border-radius: var(--border-radius-circle);
 }
 
-.squared::before {
-  border-radius: var(--border-radius-sharp);
+@-webkit-keyframes loading {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@keyframes loading {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/src/components/dls/Skeleton/Skeleton.tsx
+++ b/src/components/dls/Skeleton/Skeleton.tsx
@@ -16,7 +16,6 @@ const Skeleton = ({
   isRounded,
   isSquared,
   isActive = true,
-  style,
   className,
 }: SkeletonProps) => {
   return (
@@ -28,7 +27,6 @@ const Skeleton = ({
         [styles.squared]: isSquared,
         [className]: className,
       })}
-      style={style}
     >
       {children}
     </span>

--- a/src/components/dls/Skeleton/Skeleton.tsx
+++ b/src/components/dls/Skeleton/Skeleton.tsx
@@ -7,9 +7,18 @@ type SkeletonProps = {
   isRounded?: boolean;
   isSquared?: boolean;
   isActive?: boolean;
+  style?: React.CSSProperties;
+  className?: string;
 };
 
-const Skeleton = ({ children, isRounded, isSquared, isActive = true }: SkeletonProps) => {
+const Skeleton = ({
+  children,
+  isRounded,
+  isSquared,
+  isActive = true,
+  style,
+  className,
+}: SkeletonProps) => {
   return (
     <span
       className={classNames(styles.skeleton, {
@@ -17,7 +26,9 @@ const Skeleton = ({ children, isRounded, isSquared, isActive = true }: SkeletonP
         [styles.active]: isActive,
         [styles.rounded]: isRounded,
         [styles.squared]: isSquared,
+        [className]: className,
       })}
+      style={style}
     >
       {children}
     </span>

--- a/src/components/dls/Skeleton/Skeleton.tsx
+++ b/src/components/dls/Skeleton/Skeleton.tsx
@@ -22,7 +22,7 @@ const Skeleton = ({
   return (
     <span
       className={classNames(styles.skeleton, {
-        [styles.baseSize]: !children,
+        [styles.baseSize]: !children && !className,
         [styles.active]: isActive,
         [styles.rounded]: isRounded,
         [styles.squared]: isSquared,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,13 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react';
 
 import classNames from 'classnames';
 import { NextPage, GetStaticProps } from 'next';
+import dynamic from 'next/dynamic';
 
 import styles from './index.module.scss';
 
-import ChapterAndJuzList from 'src/components/chapters/ChapterAndJuzList';
+import ChapterAndJuzListSkeleton from 'src/components/chapters/ChapterAndJuzListSkeleton';
 import Footer from 'src/components/dls/Footer/Footer';
 import Separator from 'src/components/dls/Separator/Separator';
 import HomePageHero from 'src/components/HomePage/HomePageHero';
@@ -14,6 +16,14 @@ import BookmarksSection from 'src/components/Verses/BookmarksSection';
 import RecentReadingSessions from 'src/components/Verses/RecentReadingSessions';
 import { getAllChaptersData } from 'src/utils/chapter';
 import { ChaptersResponse } from 'types/ApiResponses';
+
+const ChapterAndJuzListWrapper = dynamic(
+  () => import('src/components/chapters/ChapterAndJuzList'),
+  {
+    ssr: false,
+    loading: () => <ChapterAndJuzListSkeleton />,
+  },
+);
 
 type IndexProps = {
   chaptersResponse: ChaptersResponse;
@@ -33,7 +43,7 @@ const Index: NextPage<IndexProps> = ({ chaptersResponse: { chapters } }) => (
         <BookmarksSection />
       </div>
       <div className={styles.flowItem}>
-        <ChapterAndJuzList chapters={chapters} />
+        <ChapterAndJuzListWrapper chapters={chapters} />
       </div>
       <div className={styles.flowItem}>
         <Separator />


### PR DESCRIPTION
### Summary
Replaced `Spinner` component with Skeleton for homepage's side menus and Chapters list.

### Test Plan
The skeletons disappear once their component loads, so to test it you mostly have to throttle the network to have enough time to see the skeleton loader.
I tested it on different screen sizes and RTL.

**Chapters list skeleton:**
https://user-images.githubusercontent.com/3989750/141656066-44e282a5-bc07-4138-8194-62de8aaefe3b.mp4

**Settings Menu Skeleton**
https://user-images.githubusercontent.com/3989750/141656281-72d36b72-6a12-47d8-9c11-8d88330191ca.mp4

**Nav Menu Skeleton:**
https://user-images.githubusercontent.com/3989750/141656168-e52c09ea-2c76-492c-b340-b298780252b6.mp4


