### PR TITLE
fix: search icon not centered in search drawer

### DIFF
--- a/src/components/Navbar/SearchDrawer/Buttons/DrawerSearchIcon.module.scss
+++ b/src/components/Navbar/SearchDrawer/Buttons/DrawerSearchIcon.module.scss
@@ -4,6 +4,7 @@
   margin-block-end: var(--spacing-small);
   margin-inline-start: var(--spacing-small);
   opacity: var(--opacity-75);
+  display: flex;
   > svg {
     height: calc(1.25 * var(--spacing-medium));
     width: calc(1.25 * var(--spacing-medium));


### PR DESCRIPTION
### Summary

After
![image](https://user-images.githubusercontent.com/12745166/141725480-9e782a96-e74e-4e85-b35f-d17effa45dd9.png)

Before
![image](https://user-images.githubusercontent.com/12745166/141725533-f8967065-9ce9-46bd-81f2-3236bc065175.png)
