### PR TITLE
Fix combobox menu item width when no fixedWidth and inline advance range selectors

### DIFF
--- a/src/components/Verse/AdvancedCopy/SelectorContainer.module.scss
+++ b/src/components/Verse/AdvancedCopy/SelectorContainer.module.scss
@@ -3,5 +3,10 @@
   font-weight: var(--font-weight-bold);
 }
 .selectedContainer {
+  flex: 1;
   margin-block: var(--spacing-micro);
+}
+
+.selectedContainer + .selectedContainer {
+  margin-inline-start: var(--spacing-xsmall);
 }

--- a/src/components/Verse/AdvancedCopy/SelectorContainer.tsx
+++ b/src/components/Verse/AdvancedCopy/SelectorContainer.tsx
@@ -26,13 +26,13 @@ interface SelectorProps {
 }
 
 /*
-Memoizing the selector will save re-renders to each selector and its items when: 
-1. The state of the parent component changes because of a change in the value of any other field 
+Memoizing the selector will save re-renders to each selector and its items when:
+1. The state of the parent component changes because of a change in the value of any other field
     that is not related to the range e.g. which translations to include in the copying.
-2. A change that happens to one of the two selectors in which the other selector and its items 
+2. A change that happens to one of the two selectors in which the other selector and its items
     will be saved from having to re-render.
 
-[NOTE] The more the verses of a chapter the more beneficial the memoization will be 
+[NOTE] The more the verses of a chapter the more beneficial the memoization will be
         since we will have higher number items which will be re-rendering un-necessarily.
 */
 const SelectorContainer: React.FC<SelectorProps> = ({ type, value, dropdownItems, onChange }) => {
@@ -47,6 +47,7 @@ const SelectorContainer: React.FC<SelectorProps> = ({ type, value, dropdownItems
         onChange={onChange}
         placeholder={t('audio.player.search-verse')}
         initialInputValue={value}
+        fixedWidth={false}
         label={
           <span className={styles.comboboxLabel}>
             {`${type === RangeSelectorType.START ? t('from') : t('to')} ${t('verse')}:`}

--- a/src/components/dls/Forms/Combobox/Combobox.module.scss
+++ b/src/components/dls/Forms/Combobox/Combobox.module.scss
@@ -12,6 +12,7 @@
 }
 
 .comboboxContainer {
+  position: relative;
   max-width: 100%;
   &.fixedWidth {
     width: calc(8 * var(--spacing-mega));

--- a/src/components/dls/Forms/Combobox/ComboboxItems/ComboboxItems.module.scss
+++ b/src/components/dls/Forms/Combobox/ComboboxItems/ComboboxItems.module.scss
@@ -2,6 +2,9 @@ $webkit-thumb-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12);
 
 .comboboxBodyContainer {
   position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
   margin-block-start: var(--spacing-micro);
   border-radius: var(--border-radius-default);
   box-shadow: var(--shadow-large);

--- a/src/components/dls/Forms/Combobox/SingleSelect.stories.tsx
+++ b/src/components/dls/Forms/Combobox/SingleSelect.stories.tsx
@@ -16,11 +16,12 @@ export default {
     size: ComboboxSize.Medium,
     clearable: true,
     disabled: false,
-    isMulti: false,
+    isMultiSelect: false,
     hasError: false,
     minimumRequiredItems: 0,
     emptyMessage: 'No results',
     placeholder: 'Search...',
+    fixedWidth: true,
   },
   argTypes: {
     id: {
@@ -134,6 +135,14 @@ export default {
       },
       description: 'The placeholder of the search input.',
     },
+    fixedWidth: {
+      options: [true, false],
+      control: { type: 'radio' },
+      table: {
+        category: 'Optional',
+      },
+      description: 'Whether the combobox should support multi-select.',
+    },
   },
 };
 
@@ -183,7 +192,9 @@ const generateItems = (numberOfItems = 10, hasSuffix = false, hasPrefix = false)
       value: `Item${index}`,
       label: `Item ${index}`,
       ...(hasSuffix && { suffix: index % 2 ? `Item` : 'Another-Item' }),
-      ...(hasPrefix && { prefix: index % 2 ? <SettingIcon /> : <SearchIcon /> }),
+      ...(hasPrefix && {
+        prefix: index % 2 ? <SettingIcon /> : <SearchIcon />,
+      }),
     });
   }
   return items;


### PR DESCRIPTION
### Summary
* Fix combobox menu items not taking full width when `fixedWidth` prop is `false`
* Change Range selectors in the advance copy to inline 

### Test Plan


### Screenshots
#### Before
![Screenshot 2021-11-16 at 7 35 22 PM](https://user-images.githubusercontent.com/26774310/142000478-ee9648af-d6d8-4191-b08f-ac239c980733.png)

#### After
![Screenshot 2021-11-16 at 7 34 22 PM](https://user-images.githubusercontent.com/26774310/142000559-d28f7e1c-4e59-49e2-85e6-1dd054b6e8d4.png)

![Screenshot 2021-11-16 at 7 30 48 PM](https://user-images.githubusercontent.com/26774310/142000581-30f5a4a0-a8dd-4939-a26f-db032005881b.png)

