### PR TITLE
Update Melayu locale name

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -22,7 +22,7 @@ const LOCALE_NAME = {
   tr: 'Türkçe',
   ur: 'اردو',
   zh: '简体中文',
-  ms: 'bahasa Melayu',
+  ms: 'Melayu',
   de: 'Deutsch',
   inh: 'ʁəlʁɑj mot',
   ta: 'தமிழ்', // tamil


### PR DESCRIPTION
### Summary
`bahasa` mean `language`. We can just remove it to make the UI width shorter. #798 

Google does this as well 
![image](https://user-images.githubusercontent.com/12745166/142748004-0b974481-a55b-4f5a-8d09-7416754d09df.png)
