### PR TITLE
Select language does not have enough width #798 bug fixed

### DIFF
--- a/src/components/Navbar/LanguageSelector.module.scss
+++ b/src/components/Navbar/LanguageSelector.module.scss
@@ -1,8 +1,8 @@
 @use "src/styles/utility";
 @use "src/styles/breakpoints";
 
-$select-width: calc(6.3 * var(--spacing-small));
-$select-width-mobile: calc(7 * var(--spacing-small));
+$select-width: calc(10 * var(--spacing-medium));
+$select-width-mobile: calc(8 * var(--spacing-medium));
 
 .container {
   @include utility.center-vertically;
@@ -16,9 +16,10 @@ $select-width-mobile: calc(7 * var(--spacing-small));
 
 .select {
   & > select {
-    width: $select-width-mobile;
-    @include breakpoints.tablet {
-      width: $select-width;
+    width: $select-width;
+
+    @include breakpoints.smallerThanMobileM {
+      width: $select-width-mobile;
     }
   }
 }


### PR DESCRIPTION
### Summary
Width of Navbar Selectbox changed to 160px. 

### Test Plan

### Screenshots

<img width="267" alt="Screenshot 2021-11-22 at 01 36 44" src="https://user-images.githubusercontent.com/11756762/142779897-dc1de5fb-e5e3-42b7-9439-36aa7d591ea2.png">
<img width="267" alt="Screenshot 2021-11-22 at 01 37 18" src="https://user-images.githubusercontent.com/11756762/142779898-2555516f-8772-4413-ae91-5962c668a162.png">
