### PR TITLE
Fix text color of search input and DLS input component

### DIFF
--- a/src/components/Navbar/SearchDrawer/Header/Header.module.scss
+++ b/src/components/Navbar/SearchDrawer/Header/Header.module.scss
@@ -14,6 +14,7 @@
 .searchInput {
   width: 100%;
   border: 0;
+  color: var(--color-text-default);
   background: transparent;
   &:focus {
     outline: none;
@@ -29,5 +30,6 @@
   text-transform: uppercase;
   text-decoration: underline;
   cursor: pointer;
+  color: var(--color-text-default);
   font-size: var(--font-size-small);
 }

--- a/src/components/dls/Forms/Input/Input.module.scss
+++ b/src/components/dls/Forms/Input/Input.module.scss
@@ -56,6 +56,7 @@
   height: 80%;
   width: 100%;
   font-size: var(--font-size-normal);
+  color: var(--color-text-default);
   background: var(--color-background-default);
   &:focus {
     outline: none;


### PR DESCRIPTION
### Summary

Closes #814
Closes #816

This is a very minimal change. In dark mode, the text color of the `Input` component and search input was dark since it was not set using the theme's CSS variables. This adds the color style property to the input elements.

### Test Plan

None. Since you guys don't have any screenshot testing I think? And the change is only visual, so no unit tests either.

### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/36920441/143567639-22b75191-cbfa-4c32-be3b-7d79c15055e2.png) | ![image](https://user-images.githubusercontent.com/36920441/143567056-7b5432c9-9ad2-42e0-bcc7-522bd58cb9c6.png) |