### PR TITLE
Update Notion image rendering logic

### DIFF
--- a/src/components/Notion/Blocks/index.tsx
+++ b/src/components/Notion/Blocks/index.tsx
@@ -4,8 +4,6 @@ import styles from './Blocks.module.scss';
 
 import Text from 'src/components/Changelog/Text';
 
-export const getPageTitle = (page) => (!page ? null : page.properties.Name.title[0].plain_text);
-
 export const renderBlock = (block) => {
   const { type } = block;
   const value = block[type];

--- a/src/components/Notion/Page/index.tsx
+++ b/src/components/Notion/Page/index.tsx
@@ -4,11 +4,12 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
 import BackIcon from '../../../../public/icons/west.svg';
-import Blocks, { getPageTitle } from '../Blocks';
+import Blocks from '../Blocks';
 
 import styles from './Page.module.scss';
 
 import Link, { LinkVariant } from 'src/components/dls/Link/Link';
+import { getPageTitle } from 'src/utils/notion';
 
 interface Props {
   page: any;

--- a/src/pages/product-updates/[id].tsx
+++ b/src/pages/product-updates/[id].tsx
@@ -5,15 +5,12 @@ import styles from './changelog.module.scss';
 
 import Spinner from 'src/components/dls/Spinner/Spinner';
 import NextSeoWrapper from 'src/components/NextSeoWrapper';
-import { getPageTitle } from 'src/components/Notion/Blocks';
 import LocalizationMessage from 'src/components/Notion/LocalizationMessage';
 import NotionPage from 'src/components/Notion/Page';
 import { retrieveBlockChildren, retrieveDatabase, retrievePage } from 'src/lib/notion';
 import Error from 'src/pages/_error';
-import {
-  ONE_DAY_REVALIDATION_PERIOD_SECONDS,
-  REVALIDATION_PERIOD_ON_ERROR_SECONDS,
-} from 'src/utils/staticPageGeneration';
+import { getPageTitle, getRevalidationTime } from 'src/utils/notion';
+import { REVALIDATION_PERIOD_ON_ERROR_SECONDS } from 'src/utils/staticPageGeneration';
 
 interface Props {
   hasError?: boolean;
@@ -55,7 +52,7 @@ export const getStaticProps = async (context) => {
         page: response[0],
         blocks: response[1],
       },
-      revalidate: ONE_DAY_REVALIDATION_PERIOD_SECONDS,
+      revalidate: getRevalidationTime(response[1], true),
     };
   } catch (error) {
     return {

--- a/src/pages/product-updates/[id].tsx
+++ b/src/pages/product-updates/[id].tsx
@@ -47,12 +47,13 @@ export const getStaticProps = async (context) => {
   const { id } = context.params;
   try {
     const response = await Promise.all([retrievePage(id), retrieveBlockChildren(id)]);
+    const blocks = response[1];
     return {
       props: {
         page: response[0],
-        blocks: response[1],
+        blocks,
       },
-      revalidate: getRevalidationTime(response[1], true),
+      revalidate: getRevalidationTime([blocks]),
     };
   } catch (error) {
     return {

--- a/src/pages/product-updates/index.tsx
+++ b/src/pages/product-updates/index.tsx
@@ -10,10 +10,8 @@ import LocalizationMessage from 'src/components/Notion/LocalizationMessage';
 import Page from 'src/components/Notion/Page';
 import { retrieveBlockChildren, retrieveDatabase } from 'src/lib/notion';
 import Error from 'src/pages/_error';
-import {
-  ONE_DAY_REVALIDATION_PERIOD_SECONDS,
-  REVALIDATION_PERIOD_ON_ERROR_SECONDS,
-} from 'src/utils/staticPageGeneration';
+import { getRevalidationTime } from 'src/utils/notion';
+import { REVALIDATION_PERIOD_ON_ERROR_SECONDS } from 'src/utils/staticPageGeneration';
 
 interface Props {
   hasError?: boolean;
@@ -56,7 +54,7 @@ export const getStaticProps: GetStaticProps = async () => {
         pages,
         pagesBlocks,
       },
-      revalidate: ONE_DAY_REVALIDATION_PERIOD_SECONDS,
+      revalidate: getRevalidationTime(pagesBlocks),
     };
   } catch (error) {
     return {

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -1,0 +1,10 @@
+import { getEarliestDate } from './datetime';
+
+it('getEarliestDate returns earliest date', () => {
+  const result = getEarliestDate([
+    '2021-12-02T23:22:00.000Z',
+    '2021-12-02T23:21:00.000Z',
+    '2021-12-02T23:20:00.000Z',
+  ]);
+  expect(result).toBe(1638487200000);
+});

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -21,4 +21,19 @@ export const secondsFormatter = (seconds: number) => {
  */
 export const milliSecondsToSeconds = (milliSeconds: number): number => milliSeconds / 1000;
 
-export default secondsFormatter;
+/**
+ * Get the earliest date of a groups of date string.
+ *
+ * @param {string[]} dates
+ * @returns {number}
+ */
+export const getEarliestDate = (dates: string[]): number =>
+  dates.map((dateString) => parseDate(dateString)).sort((a, b) => a - b)[0];
+
+/**
+ * Parse a date string.
+ *
+ * @param {string} date
+ * @returns {number}
+ */
+export const parseDate = (date: string): number => Date.parse(date);

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -23,19 +23,13 @@ export const getPageTitle = (page) => {
  *    to be statically generated and the soonest time an image will expire.
  *
  * @param {any[]} pagesBlocks
- * @param {boolean} isSinglePage this is to indicate whether we are getting the revalidation time for a single page or all pages.
  * @returns {number}
  */
-export const getRevalidationTime = (pagesBlocks, isSinglePage = false): number => {
+export const getRevalidationTime = (pagesBlocks): number => {
   let filesExpiryTime = [];
-  // if it's a Next.js page of all notion pages
-  if (!isSinglePage) {
-    pagesBlocks.forEach((pageBlocks) => {
-      filesExpiryTime = [...filesExpiryTime, ...getPageBlocksImageExpiryTime(pageBlocks)];
-    });
-  } else {
-    filesExpiryTime = getPageBlocksImageExpiryTime(pagesBlocks);
-  }
+  pagesBlocks.forEach((pageBlocks) => {
+    filesExpiryTime = [...filesExpiryTime, ...getPageBlocksImageExpiryTime(pageBlocks)];
+  });
   // if the are no image block, we use the default value
   if (!filesExpiryTime.length) {
     return ONE_DAY_REVALIDATION_PERIOD_SECONDS;

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -1,0 +1,57 @@
+import { getEarliestDate, parseDate } from './datetime';
+import { ONE_DAY_REVALIDATION_PERIOD_SECONDS } from './staticPageGeneration';
+
+export const getPageTitle = (page) => {
+  if (!page) {
+    return null;
+  }
+  let title = '';
+  page.properties.Name.title.forEach((titleObject) => {
+    title = `${title} ${titleObject.plain_text}`;
+  });
+  return title;
+};
+
+/**
+ * Get the revalidation time for the notion Incrementally Static Regenerated page:
+ *
+ * 1. If there are no image blocks, return the default value (1 day).
+ * 2. If there are some images, each will have an expiry date which
+ *    is 1 hour from the time it was requested. We get the one that will
+ *    expire the soonest (there will be slight difference between them e.g. '2021-12-06T06:04:59.684Z', '2021-12-06T06:04:59.731Z').
+ *    and then we calculate the difference in seconds between the time the page is about
+ *    to be statically generated and the soonest time an image will expire.
+ *
+ * @param {any[]} pagesBlocks
+ * @param {boolean} isSinglePage this is to indicate whether we are getting the revalidation time for a single page or all pages.
+ * @returns {number}
+ */
+export const getRevalidationTime = (pagesBlocks, isSinglePage = false): number => {
+  let filesExpiryTime = [];
+  // if it's a Next.js page of all notion pages
+  if (!isSinglePage) {
+    pagesBlocks.forEach((pageBlocks) => {
+      filesExpiryTime = [...filesExpiryTime, ...getPageBlocksImageExpiryTime(pageBlocks)];
+    });
+  } else {
+    filesExpiryTime = getPageBlocksImageExpiryTime(pagesBlocks);
+  }
+  // if the are no image block, we use the default value
+  if (!filesExpiryTime.length) {
+    return ONE_DAY_REVALIDATION_PERIOD_SECONDS;
+  }
+  // the difference in seconds between the soonest expiry time and now (the time the page is being statically generated)
+  return Math.floor(
+    (getEarliestDate(filesExpiryTime) - parseDate(new Date().toUTCString())) / 1000,
+  );
+};
+
+const getPageBlocksImageExpiryTime = (pageBlocks) => {
+  const filesExpiryTime = [];
+  pageBlocks.forEach((pageBlock) => {
+    if (pageBlock.type === 'image') {
+      filesExpiryTime.push(pageBlock.image.file.expiry_time);
+    }
+  });
+  return filesExpiryTime;
+};


### PR DESCRIPTION
### Summary
This PR updates the revalidation value of the Notion pages to match that of the earliest expiry date of an image (if found).
Closes #866 