### PR TITLE
chore: add eslint rule react/jsx-key

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
         "react/jsx-fragments": 2,
         "react/jsx-handler-names": 2,
         "react/jsx-sort-default-props": 2,
+        "react/jsx-key": 1,
         "react-func/max-lines-per-function": ["error", {
             "max": 30,
             "skipBlankLines": true,


### PR DESCRIPTION
### Summary
Adding react/jsx-key rule as a warning for now

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

Turns out we have jsx missing "key". Will upgrade this rule into "error" later once we gradually fixed this issue.

<img width="424" alt="image" src="https://user-images.githubusercontent.com/12745166/145350550-6f44865a-d656-44f9-9562-02d29592ac5a.png">
