### PR TITLE
fix default font when switching back to uthmani

### DIFF
--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
@@ -41,12 +41,6 @@ const QuranFontSection = () => {
       ],
       [QuranFont.Uthmani]: [
         {
-          id: QuranFont.QPCHafs,
-          label: t(`fonts.${QuranFont.QPCHafs}`),
-          value: QuranFont.QPCHafs,
-          name: QuranFont.QPCHafs,
-        },
-        {
           id: QuranFont.MadaniV1,
           label: t(`fonts.${QuranFont.MadaniV1}`),
           value: QuranFont.MadaniV1,
@@ -57,6 +51,12 @@ const QuranFontSection = () => {
           label: t(`fonts.${QuranFont.MadaniV2}`),
           value: QuranFont.MadaniV2,
           name: QuranFont.MadaniV2,
+        },
+        {
+          id: QuranFont.QPCHafs,
+          label: t(`fonts.${QuranFont.QPCHafs}`),
+          value: QuranFont.QPCHafs,
+          name: QuranFont.QPCHafs,
         },
       ],
     }),


### PR DESCRIPTION
### Summary
Right now our default font is King Fahad Complex (which is uthmani)

But when user switch to "Indopak" and switch back to "Uthamani", they will be switched into QPCHafs. 
This PR fixed that issue, and instead they will switch back into King Fahad Complex