### PR TITLE
Add language selction in WordTooltipSection

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -177,7 +177,6 @@
         "selected-tafsirs": "Selected Tafsirs",
         "selected-translations": "Selected Translations",
         "title": "Settings",
-        "tooltip-desc": "Click on any Quran Word to see the tooltip",
         "value-and-others": "{{value}}, and {{othersCount}} others",
         "wbw-helper": "Display the translation or transliteration directly under the word",
         "word-tooltip-helper": "Display the translation or transliteration when hovering or clicking the word"

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -236,6 +236,7 @@
     },
     "wbw": "Word By Word",
     "wbw-trans-lang": "Word By Word Language",
+    "tooltip-trans-lang": "Tooltip Language",
     "word-click": {
         "no-audio": "No Audio",
         "play-audio": "Play Audio",

--- a/src/components/Navbar/SettingsDrawer/WordByWordSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/WordByWordSection.tsx
@@ -18,8 +18,8 @@ import {
 } from 'src/redux/slices/QuranReader/readingPreferences';
 import { getLocaleName } from 'src/utils/locale';
 
-const WBW_LOCALES = ['en', 'ur', 'id', 'bn', 'tr', 'fa', 'ru', 'hi', 'de', 'ta', 'inh'];
-const WORD_BY_WORD_LOCALES_OPTIONS = WBW_LOCALES.map((locale) => ({
+export const WBW_LOCALES = ['en', 'ur', 'id', 'bn', 'tr', 'fa', 'ru', 'hi', 'de', 'ta', 'inh'];
+export const WORD_BY_WORD_LOCALES_OPTIONS = WBW_LOCALES.map((locale) => ({
   label: getLocaleName(locale),
   value: locale,
 }));

--- a/src/components/Navbar/SettingsDrawer/WordTooltipSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/WordTooltipSection.tsx
@@ -4,21 +4,31 @@ import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, useSelector } from 'react-redux';
 
 import Section from './Section';
+import { WORD_BY_WORD_LOCALES_OPTIONS } from './WordByWordSection';
 import styles from './WordByWordSection.module.scss';
 
 import Checkbox from 'src/components/dls/Forms/Checkbox/Checkbox';
+import Select, { SelectSize } from 'src/components/dls/Forms/Select';
 import HelperTooltip from 'src/components/dls/HelperTooltip/HelperTooltip';
 import {
   setShowTooltipFor,
   selectShowTooltipFor,
+  selectWordByWordLocale,
+  setSelectedWordByWordLocale,
 } from 'src/redux/slices/QuranReader/readingPreferences';
 import { removeItemFromArray, areArraysEqual } from 'src/utils/array';
 import { WordByWordType } from 'types/QuranReader';
 
 const WordTooltipSection = () => {
-  const { t } = useTranslation('common');
+  const { t, lang } = useTranslation('common');
   const dispatch = useDispatch();
   const showTooltipFor = useSelector(selectShowTooltipFor, areArraysEqual);
+
+  const wordByWordLocale = useSelector(selectWordByWordLocale);
+
+  const onWordByWordLocaleChange = (value: string) => {
+    dispatch(setSelectedWordByWordLocale({ value, locale: lang }));
+  };
 
   const onChange = (type: WordByWordType) => (checked: boolean) => {
     const nextShowTooltipFor = checked
@@ -55,6 +65,19 @@ const WordTooltipSection = () => {
           </div>
         </div>
       </Section.Row>
+      {showTooltipFor && showTooltipFor.includes(WordByWordType.Translation) && (
+        <Section.Row>
+          <Section.Label>{t('tooltip-trans-lang')}</Section.Label>
+          <Select
+            size={SelectSize.Small}
+            id="wordByWord"
+            name="wordByWord"
+            options={WORD_BY_WORD_LOCALES_OPTIONS}
+            value={wordByWordLocale}
+            onChange={onWordByWordLocaleChange}
+          />
+        </Section.Row>
+      )}
       <Section.Footer visible={showTooltipFor.length > 0}>
         {t('settings.tooltip-desc')}
       </Section.Footer>

--- a/src/components/Navbar/SettingsDrawer/WordTooltipSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/WordTooltipSection.tsx
@@ -78,9 +78,6 @@ const WordTooltipSection = () => {
           />
         </Section.Row>
       )}
-      <Section.Footer visible={showTooltipFor.length > 0}>
-        {t('settings.tooltip-desc')}
-      </Section.Footer>
     </Section>
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12745166/145520041-08ff382d-0470-41c9-a8b6-41be276762b2.png)

There's a feedback, a user is a bit confused that there's no language selection in word tooltip section. 
What we do is basically, taking the lang selection from word by word, and duplicate it here in tooltip section. A quick fix for now.