### PR TITLE
Shorten description meta tags

### DIFF
--- a/src/components/CommandBar/CommandBarBody/index.tsx
+++ b/src/components/CommandBar/CommandBarBody/index.tsx
@@ -19,7 +19,7 @@ import { selectIsCommandBarVoiceFlowStarted } from 'src/redux/slices/voiceSearch
 import { makeSearchResultsUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import { toLocalizedVerseKey } from 'src/utils/locale';
-import { shortenVerseText } from 'src/utils/verse';
+import { shortenString } from 'src/utils/string';
 import { getVerseTextByWords } from 'src/utils/word';
 import { SearchResponse } from 'types/ApiResponses';
 import { SearchNavigationType } from 'types/SearchNavigationResult';
@@ -120,7 +120,7 @@ const CommandBarBody: React.FC = () => {
             return {
               key: verse.verseKey,
               resultType: SearchNavigationType.AYAH,
-              name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${shortenVerseText(
+              name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${shortenString(
                 getVerseTextByWords(verse),
               )}`,
               group: t('verses'),

--- a/src/components/CommandBar/CommandBarBody/index.tsx
+++ b/src/components/CommandBar/CommandBarBody/index.tsx
@@ -19,7 +19,7 @@ import { selectIsCommandBarVoiceFlowStarted } from 'src/redux/slices/voiceSearch
 import { makeSearchResultsUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import { toLocalizedVerseKey } from 'src/utils/locale';
-import { shortenString } from 'src/utils/string';
+import { truncateString } from 'src/utils/string';
 import { getVerseTextByWords } from 'src/utils/word';
 import { SearchResponse } from 'types/ApiResponses';
 import { SearchNavigationType } from 'types/SearchNavigationResult';
@@ -59,8 +59,7 @@ const CommandBarBody: React.FC = () => {
    * @returns {void}
    */
   const onSearchQueryChange = useCallback((event: React.FormEvent<HTMLInputElement>): void => {
-    const newSearchQuery = event.currentTarget.value;
-    setSearchQuery(newSearchQuery || null);
+    setSearchQuery(event.currentTarget.value || null);
   }, []);
 
   /**
@@ -120,8 +119,9 @@ const CommandBarBody: React.FC = () => {
             return {
               key: verse.verseKey,
               resultType: SearchNavigationType.AYAH,
-              name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${shortenString(
+              name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${truncateString(
                 getVerseTextByWords(verse),
+                150,
               )}`,
               group: t('verses'),
             };

--- a/src/components/NextSeoWrapper.tsx
+++ b/src/components/NextSeoWrapper.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { NextSeo } from 'next-seo';
 
 import { SEOProps } from 'src/utils/seo';
-import { shortenString } from 'src/utils/string';
+import { truncateString } from 'src/utils/string';
 
 interface Props extends SEOProps {
   url?: string;
@@ -25,7 +25,7 @@ const NextSeoWrapper: React.FC<Props> = (props) => {
   const params = {
     ...rest,
     ...(url && { canonical: url }),
-    ...(description && { description: shortenString(description) }),
+    ...(description && { description: truncateString(description, 150) }),
   };
   return <NextSeo {...params} openGraph={openGraphParams} />;
 };

--- a/src/components/NextSeoWrapper.tsx
+++ b/src/components/NextSeoWrapper.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { NextSeo } from 'next-seo';
 
 import { SEOProps } from 'src/utils/seo';
+import { shortenString } from 'src/utils/string';
 
 interface Props extends SEOProps {
   url?: string;
@@ -13,7 +14,7 @@ interface Props extends SEOProps {
 }
 
 const NextSeoWrapper: React.FC<Props> = (props) => {
-  const { url, image, imageAlt, imageHeight, imageWidth, openGraph, ...rest } = props;
+  const { url, image, imageAlt, imageHeight, imageWidth, openGraph, description, ...rest } = props;
   const openGraphParams = {
     ...(openGraph && { openGraph }),
     ...(url && { url }),
@@ -24,6 +25,7 @@ const NextSeoWrapper: React.FC<Props> = (props) => {
   const params = {
     ...rest,
     ...(url && { canonical: url }),
+    ...(description && { description: shortenString(description, 160) }),
   };
   return <NextSeo {...params} openGraph={openGraphParams} />;
 };

--- a/src/components/NextSeoWrapper.tsx
+++ b/src/components/NextSeoWrapper.tsx
@@ -25,7 +25,7 @@ const NextSeoWrapper: React.FC<Props> = (props) => {
   const params = {
     ...rest,
     ...(url && { canonical: url }),
-    ...(description && { description: shortenString(description, 160) }),
+    ...(description && { description: shortenString(description) }),
   };
   return <NextSeo {...params} openGraph={openGraphParams} />;
 };

--- a/src/components/TarteelVoiceSearch/BodyContainer/SearchResults.tsx
+++ b/src/components/TarteelVoiceSearch/BodyContainer/SearchResults.tsx
@@ -11,7 +11,7 @@ import { selectSelectedTranslations } from 'src/redux/slices/QuranReader/transla
 import { makeVersesFilterUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import { toLocalizedVerseKey } from 'src/utils/locale';
-import { shortenVerseText } from 'src/utils/verse';
+import { shortenString } from 'src/utils/string';
 import { VersesResponse } from 'types/ApiResponses';
 import { SearchNavigationType } from 'types/SearchNavigationResult';
 import SearchResult from 'types/Tarteel/SearchResult';
@@ -45,7 +45,7 @@ const SearchResults: React.FC<Props> = ({ searchResult, isCommandBar }) => {
           return {
             key: verse.verseKey,
             resultType: SearchNavigationType.AYAH,
-            name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${shortenVerseText(
+            name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${shortenString(
               verse.textUthmani,
               80,
             )}`,

--- a/src/components/TarteelVoiceSearch/BodyContainer/SearchResults.tsx
+++ b/src/components/TarteelVoiceSearch/BodyContainer/SearchResults.tsx
@@ -11,7 +11,7 @@ import { selectSelectedTranslations } from 'src/redux/slices/QuranReader/transla
 import { makeVersesFilterUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import { toLocalizedVerseKey } from 'src/utils/locale';
-import { shortenString } from 'src/utils/string';
+import { truncateString } from 'src/utils/string';
 import { VersesResponse } from 'types/ApiResponses';
 import { SearchNavigationType } from 'types/SearchNavigationResult';
 import SearchResult from 'types/Tarteel/SearchResult';
@@ -45,7 +45,7 @@ const SearchResults: React.FC<Props> = ({ searchResult, isCommandBar }) => {
           return {
             key: verse.verseKey,
             resultType: SearchNavigationType.AYAH,
-            name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${shortenString(
+            name: `[${toLocalizedVerseKey(verse.verseKey, lang)}] ${truncateString(
               verse.textUthmani,
               80,
             )}`,

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,0 +1,23 @@
+import { shortenString } from './string';
+
+describe('Test shortenString', () => {
+  it('should shorten english text correctly', () => {
+    const verseText = 'test';
+    const result = shortenString(verseText, 1);
+
+    expect(result).toEqual('t...');
+  });
+  it('should shorten arabic text correctly', () => {
+    const verseText =
+      'ٱللَّهُ لَآ إِلَـٰهَ إِلَّا هُوَ ٱلْحَىُّ ٱلْقَيُّومُ ۚ لَا تَأْخُذُهُۥ سِنَةٌ وَلَا نَوْمٌ ۚ لَّهُۥ مَا فِى ٱلسَّمَـٰوَٰتِ وَمَا فِى ٱلْأَرْضِ ۗ مَن ذَا ٱلَّذِى يَشْفَعُ عِندَهُۥٓ إِلَّا بِإِذْنِهِۦ ۚ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ ۖ وَلَا يُحِيطُونَ بِشَىْءٍ مِّنْ عِلْمِهِۦٓ إِلَّا بِمَا شَآءَ ۚ وَسِعَ كُرْسِيُّهُ ٱلسَّمَـٰوَٰتِ وَٱلْأَرْضَ ۖ وَلَا يَـُٔودُهُۥ حِفْظُهُمَا ۚ وَهُوَ ٱلْعَلِىُّ ٱلْعَظِيمُ';
+    const result = shortenString(verseText, 50);
+
+    expect(result).toEqual('ٱللَّهُ لَآ إِلَـٰهَ إِلَّا هُوَ ٱلْحَىُّ ٱلْقَيّ...');
+  });
+  it('should not shorten when text is below the limit', () => {
+    const verseText = 'test';
+    const result = shortenString(verseText, 10);
+
+    expect(result).toEqual('test');
+  });
+});

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,22 +1,22 @@
-import { shortenString } from './string';
+import { truncateString } from './string';
 
-describe('Test shortenString', () => {
+describe('Test truncateString', () => {
   it('should shorten english text correctly', () => {
     const verseText = 'test';
-    const result = shortenString(verseText, 1);
+    const result = truncateString(verseText, 1);
 
     expect(result).toEqual('t...');
   });
   it('should shorten arabic text correctly', () => {
     const verseText =
       'ٱللَّهُ لَآ إِلَـٰهَ إِلَّا هُوَ ٱلْحَىُّ ٱلْقَيُّومُ ۚ لَا تَأْخُذُهُۥ سِنَةٌ وَلَا نَوْمٌ ۚ لَّهُۥ مَا فِى ٱلسَّمَـٰوَٰتِ وَمَا فِى ٱلْأَرْضِ ۗ مَن ذَا ٱلَّذِى يَشْفَعُ عِندَهُۥٓ إِلَّا بِإِذْنِهِۦ ۚ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ ۖ وَلَا يُحِيطُونَ بِشَىْءٍ مِّنْ عِلْمِهِۦٓ إِلَّا بِمَا شَآءَ ۚ وَسِعَ كُرْسِيُّهُ ٱلسَّمَـٰوَٰتِ وَٱلْأَرْضَ ۖ وَلَا يَـُٔودُهُۥ حِفْظُهُمَا ۚ وَهُوَ ٱلْعَلِىُّ ٱلْعَظِيمُ';
-    const result = shortenString(verseText, 50);
+    const result = truncateString(verseText, 50);
 
     expect(result).toEqual('ٱللَّهُ لَآ إِلَـٰهَ إِلَّا هُوَ ٱلْحَىُّ ٱلْقَيّ...');
   });
   it('should not shorten when text is below the limit', () => {
     const verseText = 'test';
-    const result = shortenString(verseText, 10);
+    const result = truncateString(verseText, 10);
 
     expect(result).toEqual('test');
   });

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,22 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * Shorten a text by setting the maximum number of characters
+ * by the value of the parameter and adding "..." at the end.
+ *
+ * @param {string} rawString
+ * @param {number} length
+ * @returns {string}
+ */
+export const shortenString = (rawString: string, length = 150): string => {
+  const characters = rawString.split('', length);
+  let shortenedText = '';
+  for (let index = 0; index < characters.length; index += 1) {
+    const character = characters[index];
+    if (shortenedText.length === length - 1) {
+      shortenedText = `${shortenedText}${character}...`;
+      break;
+    }
+    shortenedText = `${shortenedText}${character}`;
+  }
+  return shortenedText;
+};

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -7,7 +7,7 @@
  * @param {number} length
  * @returns {string}
  */
-export const shortenString = (rawString: string, length = 150): string => {
+export const truncateString = (rawString: string, length: number): string => {
   const characters = rawString.split('', length);
   let shortenedText = '';
   for (let index = 0; index < characters.length; index += 1) {

--- a/src/utils/verse.test.ts
+++ b/src/utils/verse.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable react-func/max-lines-per-function */
-import { getDistanceBetweenVerses, sortWordLocation, shortenVerseText } from './verse';
+import { getDistanceBetweenVerses, sortWordLocation } from './verse';
 
 describe('sort verse word position', () => {
   it('should sort based on chapter', () => {
@@ -146,27 +146,5 @@ describe('get the distance between 2 verses', () => {
     const result = getDistanceBetweenVerses(firstVerseKey, secondVerseKey);
 
     expect(result).toEqual(expected);
-  });
-});
-
-describe('Test shortenVerseText', () => {
-  it('should shorten english text correctly', () => {
-    const verseText = 'test';
-    const result = shortenVerseText(verseText, 1);
-
-    expect(result).toEqual('t...');
-  });
-  it('should shorten arabic text correctly', () => {
-    const verseText =
-      'ٱللَّهُ لَآ إِلَـٰهَ إِلَّا هُوَ ٱلْحَىُّ ٱلْقَيُّومُ ۚ لَا تَأْخُذُهُۥ سِنَةٌ وَلَا نَوْمٌ ۚ لَّهُۥ مَا فِى ٱلسَّمَـٰوَٰتِ وَمَا فِى ٱلْأَرْضِ ۗ مَن ذَا ٱلَّذِى يَشْفَعُ عِندَهُۥٓ إِلَّا بِإِذْنِهِۦ ۚ يَعْلَمُ مَا بَيْنَ أَيْدِيهِمْ وَمَا خَلْفَهُمْ ۖ وَلَا يُحِيطُونَ بِشَىْءٍ مِّنْ عِلْمِهِۦٓ إِلَّا بِمَا شَآءَ ۚ وَسِعَ كُرْسِيُّهُ ٱلسَّمَـٰوَٰتِ وَٱلْأَرْضَ ۖ وَلَا يَـُٔودُهُۥ حِفْظُهُمَا ۚ وَهُوَ ٱلْعَلِىُّ ٱلْعَظِيمُ';
-    const result = shortenVerseText(verseText, 50);
-
-    expect(result).toEqual('ٱللَّهُ لَآ إِلَـٰهَ إِلَّا هُوَ ٱلْحَىُّ ٱلْقَيّ...');
-  });
-  it('should not shorten when text is below the limit', () => {
-    const verseText = 'test';
-    const result = shortenVerseText(verseText, 10);
-
-    expect(result).toEqual('test');
   });
 });


### PR DESCRIPTION
### Summary
This PR shortens the `description` meta tags to match the [recommended number of characters](https://yoast.com/meta-descriptions/) (150-160 characters).

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="1072" alt="Screen Shot 2021-12-13 at 14 26 30" src="https://user-images.githubusercontent.com/15169499/145770067-960cc965-2b59-4ca5-a3c0-4dd29e6e6e22.png">|<img width="1077" alt="Screen Shot 2021-12-13 at 14 26 23" src="https://user-images.githubusercontent.com/15169499/145770060-3ad5b688-5817-457e-babc-c18313f1c6bc.png">|