### PR TITLE
design update: update secondary color on dark theme

### DIFF
--- a/src/components/dls/Button/Button.module.scss
+++ b/src/components/dls/Button/Button.module.scss
@@ -313,7 +313,7 @@
 }
 
 // when button used as Popover's trigger, add style when Popover is open
-[data-state="open"] .base {
+[data-state="open"] > button > .base {
   background-color: var(--color-primary-medium);
   @include utility.lighten-background-color;
 }

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -8,7 +8,7 @@
 
   --color-secondary-faded: #333;
   --color-secondary-faint: #444;
-  --color-secondary-medium: #888;
+  --color-secondary-medium: var(--shade-7);
   --color-secondary-deep: #eaeaea;
 
   --color-success-faded: #272f33;


### PR DESCRIPTION
This is just a temporary fix. I will do a more systematic update related to color token later.

Before
<img width="1306" alt="image" src="https://user-images.githubusercontent.com/12745166/145960563-31a3e8bc-f718-4dc4-a8b8-9eb30dba2406.png">

After
<img width="1358" alt="image" src="https://user-images.githubusercontent.com/12745166/145960523-09fb8023-a414-4775-977a-705b6ce976e4.png">
