### PR TITLE
[SEO] Remove multiple h1 tags

### DIFF
--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -19,33 +19,42 @@ const AboutUsPage = () => {
           <Trans i18nKey="common:quran-com" />
         </h1>
         <p>{t('main-desc')}</p>
-        <h1>{t('meccan.surahs')}</h1>
+        <p className={styles.heading}>{t('meccan.surahs')}</p>
         <p>{t('meccan.desc')}</p>
-        <h1>{t('median.surahs')}</h1>
+        <p className={styles.heading}>{t('median.surahs')}</p>
         <p>{t('median.desc')}</p>
         <p>
           <Trans
             i18nKey="about:redesign"
-            components={[<a target="_blank" href="https://feedback.quran.com" rel="noreferrer" />]}
+            components={[
+              <a key={0} target="_blank" href="https://feedback.quran.com" rel="noreferrer" />,
+            ]}
           />
         </p>
-        <h1>{t('credits.title')}</h1>
+        <p className={styles.heading}>{t('credits.title')}</p>
         <p>
           <Trans
             i18nKey="about:credits.desc"
             components={[
-              <a target="_blank" href="https://tanzil.net/" rel="noreferrer" />,
-              <a target="_blank" href="https://qurancomplex.gov.sa/" rel="noreferrer" />,
-              <a target="_blank" href="https://github.com/cpfair/quran-align" rel="noreferrer" />,
-              <a target="_blank" href="https://quranenc.com/en/home" rel="noreferrer" />,
-              <a target="_blank" href="https://zekr.org" rel="noreferrer" />,
+              <a key={0} target="_blank" href="https://tanzil.net/" rel="noreferrer" />,
+              <a key={1} target="_blank" href="https://qurancomplex.gov.sa/" rel="noreferrer" />,
+              <a
+                key={2}
+                target="_blank"
+                href="https://github.com/cpfair/quran-align"
+                rel="noreferrer"
+              />,
+              <a key={3} target="_blank" href="https://quranenc.com/en/home" rel="noreferrer" />,
+              <a key={4} target="_blank" href="https://zekr.org" rel="noreferrer" />,
             ]}
           />
         </p>
         <div>
           <Trans
             i18nKey="about:credits.lokalize"
-            components={[<a target="_blank" href="https://lokalise.com/" rel="noreferrer" />]}
+            components={[
+              <a key={0} target="_blank" href="https://lokalise.com/" rel="noreferrer" />,
+            ]}
           />
           <div className={styles.lokalizeImage}>
             <Image
@@ -61,7 +70,9 @@ const AboutUsPage = () => {
         <p>
           <Trans
             i18nKey="about:questions"
-            components={[<a target="_blank" href="https://feedback.quran.com" rel="noreferrer" />]}
+            components={[
+              <a key={0} target="_blank" href="https://feedback.quran.com" rel="noreferrer" />,
+            ]}
           />
         </p>
       </div>

--- a/src/pages/apps.tsx
+++ b/src/pages/apps.tsx
@@ -12,15 +12,20 @@ import NextSeoWrapper from 'src/components/NextSeoWrapper';
 type AppProps = {
   app: any;
   isFlipped?: boolean;
+  isMain?: boolean;
 };
-const App = ({ app, isFlipped }: AppProps) => {
+const App = ({ app, isFlipped, isMain }: AppProps) => {
   return (
     <div
       className={classNames(styles.sideBySideLayout, isFlipped && styles.layoutFlipped)}
       key={app.title}
     >
       <div className={styles.texts}>
-        <h1 className={styles.heading}>{app.title}</h1>
+        {isMain ? (
+          <h1 className={styles.heading}>{app.title}</h1>
+        ) : (
+          <p className={styles.heading}>{app.title}</p>
+        )}
         <p>{app.description}</p>
         <div className={styles.downloadButtonsContainer}>
           <a href={app.ios}>
@@ -63,7 +68,7 @@ const AppsPage = () => {
     <>
       <NextSeoWrapper title={t('common:mobile-apps')} />
       <div className={styles.container}>
-        <App app={apps.quran} />
+        <App app={apps.quran} isMain />
         <App app={apps.tarteel} isFlipped />
       </div>
     </>

--- a/src/pages/contentPage.module.scss
+++ b/src/pages/contentPage.module.scss
@@ -9,16 +9,12 @@
   padding-block-end: var(--spacing-mega);
   padding-inline-start: var(--spacing-medium);
   padding-inline-end: var(--spacing-medium);
-  h1 {
+  h1,
+  & .heading {
     font-size: var(--font-size-xlarge);
     line-height: var(--line-height-jumbo);
     margin-block-end: var(--spacing-xsmall);
     font-weight: var(--font-weight-bold);
-  }
-  h2 {
-    font-size: var(--font-size-large);
-    margin-block-end: var(--spacing-xsmall);
-    font-weight: var(--font-weight-semibold);
   }
   p {
     line-height: var(--line-height-large);


### PR DESCRIPTION
### Summary
This PR removes multipls `h1` tags from `/apps` and `/about-us` routes as per [ahrefs](http://ahrefs.com/) recommendation:

<img width="385" alt="Screen Shot 2021-12-15 at 16 44 32" src="https://user-images.githubusercontent.com/15169499/146162804-275afeb1-e1b4-4ee1-b4d5-5b420079929d.png">

