### PR TITLE
fix: on iphone chrome reset settings not accessible

### DIFF
--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -63,7 +63,7 @@
 }
 
 .bodyWithBottomPadding {
-  padding-block-end: calc(4 * var(--spacing-large));
+  padding-block-end: calc(8 * var(--spacing-large));
 }
 
 .navigationBodyContainer {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/12745166/146489324-db511974-f5c5-4a96-9b93-09b5f79f03a1.png)

After
![image](https://user-images.githubusercontent.com/12745166/146489293-899499e6-52f1-402e-97ce-0479c8178d47.png)

