### PR TITLE
fix: missing gap after first word

### DIFF
--- a/src/components/dls/QuranWord/QuranWord.module.scss
+++ b/src/components/dls/QuranWord/QuranWord.module.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   cursor: pointer;
 }
-.additionalWordGap + .additionalWordGap {
+.additionalWordGap {
   margin-inline-end: var(--spacing-xxsmall);
 }
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/12745166/147185914-ed5b665d-0b00-4177-93a5-7c1aba40fd88.png)


After
![image](https://user-images.githubusercontent.com/12745166/147185893-8a6de615-68a3-43b2-993e-9fb16e482e25.png)
