### PR TITLE
fix(tafsir): close icon not visible on small screen

### DIFF
--- a/src/components/QuranReader/TafsirView/SurahAndAyahSelection.tsx
+++ b/src/components/QuranReader/TafsirView/SurahAndAyahSelection.tsx
@@ -46,6 +46,7 @@ const SurahAndAyahSelection = ({
       />
       <div className={styles.selectionItem}>
         <Select
+          className={styles.ayahSelection}
           size={SelectSize.Small}
           id="ayah-selection"
           name="ayah-selection"

--- a/src/components/QuranReader/TafsirView/TafsirView.module.scss
+++ b/src/components/QuranReader/TafsirView/TafsirView.module.scss
@@ -127,6 +127,9 @@ $container-max-width: calc(23 * var(--spacing-mega));
 .selectionItem {
   margin-inline-start: var(--spacing-medium);
 }
+.ayahSelection {
+  max-width: calc(2.5 * var(--spacing-mega));
+}
 
 .tafsirSkeletonItem {
   height: var(--spacing-mega);


### PR DESCRIPTION
The close icon was not overlapping with the ayah selection

Before
![image](https://user-images.githubusercontent.com/12745166/147539493-1c8aaff2-6f6c-40cc-b95b-730c5192818c.png)

After
![image](https://user-images.githubusercontent.com/12745166/147539472-4bea4e91-0a76-4f51-9e89-c48fd044604d.png)


