### PR TITLE
add slugs to tafsirs

### DIFF
--- a/src/components/DeveloperUtility/TafsirsAdjustment.tsx
+++ b/src/components/DeveloperUtility/TafsirsAdjustment.tsx
@@ -9,7 +9,7 @@ import styles from './TafsirsAdjustment.module.scss';
 
 import { getTafsirs } from 'src/api';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
-import { areArraysEqual, numbersToStringsArray } from 'src/utils/array';
+import { areArraysEqual } from 'src/utils/array';
 import TafsirInfo from 'types/TafsirInfo';
 
 const TafsirsAdjustment = () => {
@@ -67,7 +67,7 @@ const TafsirsAdjustment = () => {
           multiple
           className={styles.select}
           onChange={onSelectedTafsirsChange}
-          defaultValue={numbersToStringsArray(selectedTafsirs)}
+          defaultValue={selectedTafsirs}
         >
           {tafsirs.map((tafsir) => (
             <option key={tafsir.id} value={tafsir.id}>

--- a/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
@@ -58,7 +58,7 @@ const TafsirSection = () => {
   }, [dispatch]);
   const renderTafsirs = useCallback(
     (data: TafsirsResponse) => {
-      const firstSelectedTafsir = data.tafsirs.find((tafsir) => tafsir.id === selectedTafsirs[0]);
+      const firstSelectedTafsir = data.tafsirs.find((tafsir) => tafsir.slug === selectedTafsirs[0]);
 
       let selectedValueString = t('settings.no-tafsir-selected');
       if (selectedTafsirs.length === 1) selectedValueString = firstSelectedTafsir.name;

--- a/src/components/Navbar/SettingsDrawer/TafsirSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSelectionBody.tsx
@@ -50,8 +50,8 @@ const TafsirsSelectionBody = () => {
     // add the selectedTranslationId to redux
     // if unchecked, remove it from redux
     const nextTafsirs = isChecked
-      ? [...selectedTafsirs, Number(selectedTafsirId)]
-      : selectedTafsirs.filter((id) => id !== Number(selectedTafsirId)); // remove the id
+      ? [...selectedTafsirs, selectedTafsirId]
+      : selectedTafsirs.filter((id) => id !== selectedTafsirId); // remove the id
 
     logItemSelectionChange('tafsir', selectedTafsirId, isChecked);
     logValueChange('selected_tafsirs', selectedTafsirs, nextTafsirs);
@@ -84,15 +84,15 @@ const TafsirsSelectionBody = () => {
                   <div className={styles.group} key={language}>
                     <div className={styles.language}>{language}</div>
                     {tafsirs.map((tafsir) => (
-                      <div key={tafsir.id} className={styles.item}>
+                      <div key={tafsir.slug} className={styles.item}>
                         <input
-                          id={tafsir.id.toString()}
+                          id={tafsir.slug.toString()}
                           type="checkbox"
-                          value={tafsir.id}
-                          checked={selectedTafsirs.includes(tafsir.id)}
+                          value={tafsir.slug}
+                          checked={selectedTafsirs.includes(tafsir.slug)}
                           onChange={onTafsirsChange}
                         />
-                        <label className={styles.label} htmlFor={tafsir.id.toString()}>
+                        <label className={styles.label} htmlFor={tafsir.slug.toString()}>
                           <span>{tafsir.name}</span>{' '}
                           <span className={styles.author}>{tafsir.authorName}</span>
                         </label>

--- a/src/components/QuranReader/TafsirView/LanguageAndTafsirSelection.tsx
+++ b/src/components/QuranReader/TafsirView/LanguageAndTafsirSelection.tsx
@@ -12,14 +12,14 @@ import { getLocaleNameByFullName } from 'src/utils/locale';
 import { TafsirsResponse } from 'types/ApiResponses';
 
 type LanguageAndTafsirSelectionProps = {
-  selectedTafsirId: number;
-  onTafsirSelected: (tafsirId: number) => void;
+  selectedTafsirIdOrSlug: number | string;
+  onTafsirSelected: (tafsirId: number, tafsirSlug: string) => void;
   selectedLanguage: string;
   onSelectLanguage: (lang: string) => void;
   languageOptions: string[];
 };
 const LanguageAndTafsirSelection = ({
-  selectedTafsirId,
+  selectedTafsirIdOrSlug,
   onTafsirSelected,
   selectedLanguage,
   onSelectLanguage,
@@ -52,13 +52,17 @@ const LanguageAndTafsirSelection = ({
             {data.tafsirs
               .filter(
                 (tafsir) =>
-                  tafsir.languageName === selectedLanguage || selectedTafsirId === tafsir.id,
+                  tafsir.languageName === selectedLanguage ||
+                  selectedTafsirIdOrSlug === tafsir.slug ||
+                  Number(selectedTafsirIdOrSlug) === tafsir.id,
               )
               .map((tafsir) => {
-                const selected = selectedTafsirId === tafsir.id;
+                const selected =
+                  selectedTafsirIdOrSlug === tafsir.slug ||
+                  Number(selectedTafsirIdOrSlug) === tafsir.id;
                 return (
                   <Button
-                    onClick={() => onTafsirSelected(tafsir.id)}
+                    onClick={() => onTafsirSelected(tafsir.id, tafsir.slug)}
                     size={ButtonSize.Small}
                     key={tafsir.id}
                     className={classNames(styles.tafsirSelectionItem, {

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -35,14 +35,14 @@ type TafsirBodyProps = {
   initialChapterId: string;
   initialVerseNumber: string;
   initialTafsirData?: TafsirContentResponse;
-  initialTafsirId?: number;
+  initialTafsirIdOrSlug?: number | string;
 };
 
 const TafsirBody = ({
   initialChapterId,
   initialVerseNumber,
   initialTafsirData,
-  initialTafsirId,
+  initialTafsirIdOrSlug,
 }: TafsirBodyProps) => {
   const dispatch = useDispatch();
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual) as QuranReaderStyles;
@@ -53,34 +53,34 @@ const TafsirBody = ({
   const [selectedVerseNumber, setSelectedVerseNumber] = useState(initialVerseNumber);
   const [selectedLanguage, setSelectedLanguage] = useState('');
   const selectedVerseKey = makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber));
-  const [selectedTafsirId, setSelectedTafsirId] = useState(
-    initialTafsirId || userPreferredTafsirIds?.[0],
+  const [selectedTafsirIdOrSlug, setSelectedTafsirIdOrSlug] = useState<number | string>(
+    initialTafsirIdOrSlug || userPreferredTafsirIds?.[0],
   );
 
-  // if user opened tafsirBody via a url, we will have initialTafsirId
-  // we need to set this `initialTafsirId` as a selectedTafsirId
-  // we did not use `useState(initialTafsirId)` because `useRouter`'s query string is undefined on first render
+  // if user opened tafsirBody via a url, we will have initialTafsirIdOrSlug
+  // we need to set this `initialTafsirIdOrSlug` as a selectedTafsirIdOrSlug
+  // we did not use `useState(initialTafsirIdOrSlug)` because `useRouter`'s query string is undefined on first render
   useEffect(() => {
-    if (initialTafsirId) {
+    if (initialTafsirIdOrSlug) {
       logEvent('tafsir_url_access');
-      setSelectedTafsirId(initialTafsirId);
+      setSelectedTafsirIdOrSlug(initialTafsirIdOrSlug);
     }
-  }, [initialTafsirId]);
+  }, [initialTafsirIdOrSlug]);
 
   const onTafsirSelected = useCallback(
-    (id: number) => {
+    (id: number, slug: string) => {
       logItemSelectionChange('tafsir', id);
-      setSelectedTafsirId(id);
+      setSelectedTafsirIdOrSlug(slug);
       fakeNavigate(
         getVerseSelectedTafsirNavigationUrl(
           Number(selectedChapterId),
           Number(selectedVerseNumber),
-          id,
+          slug,
         ),
       );
       dispatch(
         setSelectedTafsirs({
-          tafsirs: [id],
+          tafsirs: [slug],
           locale: lang,
         }),
       );
@@ -91,14 +91,14 @@ const TafsirBody = ({
   const { data: tafsirSelectionList } = useSWR<TafsirsResponse>(makeTafsirsUrl(lang), fetcher);
 
   // selectedLanguage is based on selectedTafir's language
-  // but we need to fetch the data from the API first to know what is the lanaguage of `selectedTafsirId`
+  // but we need to fetch the data from the API first to know what is the lanaguage of `selectedTafsirIdOrSlug`
   // so we get the data from the API and set the selectedLanguage once it is loaded
   useEffect(() => {
     if (tafsirSelectionList) {
-      const languageName = getSelectedTafsirLanguage(tafsirSelectionList, selectedTafsirId);
+      const languageName = getSelectedTafsirLanguage(tafsirSelectionList, selectedTafsirIdOrSlug);
       setSelectedLanguage(languageName);
     }
-  }, [onTafsirSelected, selectedTafsirId, tafsirSelectionList]);
+  }, [onTafsirSelected, selectedTafsirIdOrSlug, tafsirSelectionList]);
 
   // there's no 1:1 data that can map our locale options to the tafsir language options
   // so we're using options that's available from tafsir for now
@@ -137,7 +137,7 @@ const TafsirBody = ({
     );
   }, []);
 
-  const tafsirContentQueryKey = makeTafsirContentUrl(selectedTafsirId, selectedVerseKey, {
+  const tafsirContentQueryKey = makeTafsirContentUrl(selectedTafsirIdOrSlug, selectedVerseKey, {
     words: true,
     ...getDefaultWordFields(quranReaderStyles.quranFont),
   });
@@ -149,8 +149,8 @@ const TafsirBody = ({
       Object.keys(initialTafsirData.tafsir.verses).includes(
         makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber)),
       ) &&
-      selectedTafsirId === initialTafsirData?.tafsir?.resourceId,
-    [initialTafsirData, selectedChapterId, selectedTafsirId, selectedVerseNumber],
+      selectedTafsirIdOrSlug === initialTafsirData?.tafsir?.resourceId,
+    [initialTafsirData, selectedChapterId, selectedTafsirIdOrSlug, selectedVerseNumber],
   );
 
   return (
@@ -161,7 +161,11 @@ const TafsirBody = ({
         onChapterIdChange={(newChapterId) => {
           logItemSelectionChange('tafsir_chapter_id', newChapterId);
           fakeNavigate(
-            getVerseSelectedTafsirNavigationUrl(Number(newChapterId), Number(1), selectedTafsirId),
+            getVerseSelectedTafsirNavigationUrl(
+              Number(newChapterId),
+              Number(1),
+              selectedTafsirIdOrSlug,
+            ),
           );
           setSelectedChapterId(newChapterId.toString());
           setSelectedVerseNumber('1'); // reset verse number to 1 every time chapter changes
@@ -173,13 +177,13 @@ const TafsirBody = ({
             getVerseSelectedTafsirNavigationUrl(
               Number(selectedChapterId),
               Number(newVerseNumber),
-              selectedTafsirId,
+              selectedTafsirIdOrSlug,
             ),
           );
         }}
       />
       <LanguageAndTafsirSelection
-        selectedTafsirId={selectedTafsirId}
+        selectedTafsirIdOrSlug={selectedTafsirIdOrSlug}
         selectedLanguage={selectedLanguage}
         onTafsirSelected={onTafsirSelected}
         onSelectLanguage={(newLang) => {
@@ -221,14 +225,17 @@ const getTafsirsLanguageOptions = (tafsirs: Tafsir[]): string[] =>
  * Get the language of the selected Tafsir.
  *
  * @param {TafsirsResponse} tafsirListData
- * @param {number} selectedTafsirId
+ * @param {number|string} selectedTafsirIdOrSlug
  * @returns {string}
  */
 const getSelectedTafsirLanguage = (
   tafsirListData: TafsirsResponse,
-  selectedTafsirId: number,
+  selectedTafsirIdOrSlug: number | string,
 ): string => {
-  const selectedTafsir = tafsirListData?.tafsirs.find((tafsir) => tafsir.id === selectedTafsirId);
+  const selectedTafsir = tafsirListData?.tafsirs.find(
+    (tafsir) =>
+      tafsir.slug === selectedTafsirIdOrSlug || tafsir.id === Number(selectedTafsirIdOrSlug),
+  );
   return selectedTafsir?.languageName;
 };
 

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -159,61 +159,65 @@ const TafsirBody = ({
     [initialTafsirData, selectedChapterId, selectedTafsirIdOrSlug, selectedVerseNumber],
   );
 
-  return (
-    <div>
-      <SurahAndAyahSelection
-        selectedChapterId={selectedChapterId}
-        selectedVerseNumber={selectedVerseNumber}
-        onChapterIdChange={(newChapterId) => {
-          logItemSelectionChange('tafsir_chapter_id', newChapterId);
-          fakeNavigate(
-            getVerseSelectedTafsirNavigationUrl(
-              Number(newChapterId),
-              Number(1),
-              selectedTafsirIdOrSlug,
-            ),
-          );
-          setSelectedChapterId(newChapterId.toString());
-          setSelectedVerseNumber('1'); // reset verse number to 1 every time chapter changes
-        }}
-        onVerseNumberChange={(newVerseNumber) => {
-          logItemSelectionChange('tafsir_verse_number', newVerseNumber);
-          setSelectedVerseNumber(newVerseNumber);
-          fakeNavigate(
-            getVerseSelectedTafsirNavigationUrl(
-              Number(selectedChapterId),
-              Number(newVerseNumber),
-              selectedTafsirIdOrSlug,
-            ),
-          );
-        }}
-      />
-      <LanguageAndTafsirSelection
-        selectedTafsirIdOrSlug={selectedTafsirIdOrSlug}
-        selectedLanguage={selectedLanguage}
-        onTafsirSelected={onTafsirSelected}
-        onSelectLanguage={(newLang) => {
-          logValueChange('tafsir_locale', selectedLanguage, newLang);
-          setSelectedLanguage(newLang);
-        }}
-        languageOptions={languageOptions}
-      />
-      <div
-        className={classNames(
-          styles.tafsirContainer,
-          styles[`tafsir-font-size-${quranReaderStyles.tafsirFontScale}`],
-        )}
-      >
-        {shouldUseInitialTafsirData ? (
-          renderTafsir(initialTafsirData)
-        ) : (
-          <DataFetcher
-            loading={TafsirSkeleton}
-            queryKey={tafsirContentQueryKey}
-            render={renderTafsir}
-          />
-        )}
-      </div>
+  const surahAndAyahSelection = (
+    <SurahAndAyahSelection
+      selectedChapterId={selectedChapterId}
+      selectedVerseNumber={selectedVerseNumber}
+      onChapterIdChange={(newChapterId) => {
+        logItemSelectionChange('tafsir_chapter_id', newChapterId);
+        fakeNavigate(
+          getVerseSelectedTafsirNavigationUrl(
+            Number(newChapterId),
+            Number(1),
+            selectedTafsirIdOrSlug,
+          ),
+        );
+        setSelectedChapterId(newChapterId.toString());
+        setSelectedVerseNumber('1'); // reset verse number to 1 every time chapter changes
+      }}
+      onVerseNumberChange={(newVerseNumber) => {
+        logItemSelectionChange('tafsir_verse_number', newVerseNumber);
+        setSelectedVerseNumber(newVerseNumber);
+        fakeNavigate(
+          getVerseSelectedTafsirNavigationUrl(
+            Number(selectedChapterId),
+            Number(newVerseNumber),
+            selectedTafsirIdOrSlug,
+          ),
+        );
+      }}
+    />
+  );
+
+  const languageAndTafsirSelection = (
+    <LanguageAndTafsirSelection
+      selectedTafsirIdOrSlug={selectedTafsirIdOrSlug}
+      selectedLanguage={selectedLanguage}
+      onTafsirSelected={onTafsirSelected}
+      onSelectLanguage={(newLang) => {
+        logValueChange('tafsir_locale', selectedLanguage, newLang);
+        setSelectedLanguage(newLang);
+      }}
+      languageOptions={languageOptions}
+    />
+  );
+
+  const body = (
+    <div
+      className={classNames(
+        styles.tafsirContainer,
+        styles[`tafsir-font-size-${quranReaderStyles.tafsirFontScale}`],
+      )}
+    >
+      {shouldUseInitialTafsirData ? (
+        renderTafsir(initialTafsirData)
+      ) : (
+        <DataFetcher
+          loading={TafsirSkeleton}
+          queryKey={tafsirContentQueryKey}
+          render={renderTafsir}
+        />
+      )}
     </div>
   );
 

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -151,11 +151,12 @@ const TafsirBody = ({
   // Whether we should use the initial tafsir data or fetch the data on the client side
   const shouldUseInitialTafsirData = useMemo(
     () =>
-      initialTafsirData &&
-      Object.keys(initialTafsirData.tafsir.verses).includes(
-        makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber)),
-      ) &&
-      selectedTafsirIdOrSlug === initialTafsirData?.tafsir?.resourceId,
+      (initialTafsirData &&
+        Object.keys(initialTafsirData.tafsir.verses).includes(
+          makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber)),
+        ) &&
+        selectedTafsirIdOrSlug === initialTafsirData?.tafsir?.slug) ||
+      Number(selectedTafsirIdOrSlug) === initialTafsirData?.tafsir?.resourceId,
     [initialTafsirData, selectedChapterId, selectedTafsirIdOrSlug, selectedVerseNumber],
   );
 

--- a/src/pages/[chapterId]/[verseId]/tafsirs.tsx
+++ b/src/pages/[chapterId]/[verseId]/tafsirs.tsx
@@ -59,7 +59,7 @@ const AyahTafsir: NextPage<AyahTafsirProp> = ({ hasError, chapter, tafsirData })
           initialChapterId={chapterId.toString()}
           initialVerseNumber={verseId.toString()}
           initialTafsirData={tafsirData}
-          initialTafsirId={router.query.tafsirId ? Number(router.query.tafsirId) : undefined}
+          initialTafsirIdOrSlug={router.query.tafsirId ? Number(router.query.tafsirId) : undefined}
         />
       </div>
     </>

--- a/src/redux/defaultSettings/defaultSettings.ts
+++ b/src/redux/defaultSettings/defaultSettings.ts
@@ -29,7 +29,7 @@ export interface DefaultSettings {
 }
 
 // Tafsir Ibn Kathir in English
-export const DEFAULT_TAFSIRS = [169];
+export const DEFAULT_TAFSIRS = ['en-tafisr-ibn-kathir'];
 
 export const DEFAULT_RECITER: Reciter = {
   id: 7,

--- a/src/redux/defaultSettings/locales/ar.ts
+++ b/src/redux/defaultSettings/locales/ar.ts
@@ -2,7 +2,7 @@ import DEFAULT_SETTINGS, { DefaultSettings } from '../defaultSettings';
 
 import { ReadingPreference } from 'types/QuranReader';
 
-const DEFAULT_TAFSIR = 90; // AlQurtubi
+const DEFAULT_TAFSIR = 'ar-tafseer-al-qurtubi"';
 
 export default {
   ...DEFAULT_SETTINGS,

--- a/src/redux/defaultSettings/locales/bn.ts
+++ b/src/redux/defaultSettings/locales/bn.ts
@@ -3,7 +3,7 @@ import DEFAULT_SETTINGS, { DefaultSettings } from '../defaultSettings';
 import { QuranFont } from 'types/QuranReader';
 
 const DEFAULT_TRANSLATION = 161; // Taisirul Quran
-const DEFAULT_TAFSIR = 165; // Tafsir Ahsanul Bayaan
+const DEFAULT_TAFSIR = 'bn-tafsir-ahsanul-bayaan'; // Tafsir Ahsanul Bayaan
 
 export default {
   ...DEFAULT_SETTINGS,

--- a/src/redux/defaultSettings/locales/ru.ts
+++ b/src/redux/defaultSettings/locales/ru.ts
@@ -1,7 +1,7 @@
 import DEFAULT_SETTINGS, { DefaultSettings } from '../defaultSettings';
 
 const DEFAULT_TRANSLATION = 45; // Elmir Kuliev
-const DEFAULT_TAFSIR = 170; // Russian Tafseer Al Saddi
+const DEFAULT_TAFSIR = 'ru-tafseer-al-saddi'; // Russian Tafseer Al Saddi
 
 export default {
   ...DEFAULT_SETTINGS,

--- a/src/redux/defaultSettings/locales/ur.ts
+++ b/src/redux/defaultSettings/locales/ur.ts
@@ -3,7 +3,7 @@ import DEFAULT_SETTINGS, { DefaultSettings } from '../defaultSettings';
 import { QuranFont } from 'types/QuranReader';
 
 const DEFAULT_TRANSLATION = 158; // Bayan Ul Quran
-const DEFAULT_TAFSIR = 159; // Bayan ul Quran
+const DEFAULT_TAFSIR = 'tafseer-ibn-e-kaseer-urdu'; // Bayan ul Quran
 
 export default {
   ...DEFAULT_SETTINGS,

--- a/src/redux/slices/QuranReader/tafsirs.ts
+++ b/src/redux/slices/QuranReader/tafsirs.ts
@@ -9,7 +9,7 @@ export const tafsirsSlice = createSlice({
   name: 'tafsirs',
   initialState: getTafsirsInitialState(),
   reducers: {
-    setSelectedTafsirs: (state, action: PayloadAction<{ tafsirs: number[]; locale: string }>) => ({
+    setSelectedTafsirs: (state, action: PayloadAction<{ tafsirs: string[]; locale: string }>) => ({
       ...state,
       // we need to before we compare because there is a corner case when the user changes the default tafsirs then re-selects them which results in the same array as the default one but reversed e.g. instead of [20, 131] it becomes [131, 20].
       isUsingDefaultTafsirs: areArraysEqual(

--- a/src/redux/types/TafsirsSettings.ts
+++ b/src/redux/types/TafsirsSettings.ts
@@ -1,5 +1,5 @@
 type TafsirsSettings = {
-  selectedTafsirs: number[];
+  selectedTafsirs: string[];
   isUsingDefaultTafsirs: boolean;
 };
 

--- a/src/utils/apiPaths.ts
+++ b/src/utils/apiPaths.ts
@@ -123,7 +123,7 @@ export const makeTafsirsUrl = (language: string): string =>
   makeUrl('/resources/tafsirs', { language });
 
 export const makeTafsirContentUrl = (
-  tafsirId: number,
+  tafsirId: number | string,
   verseKey: string,
   params: Record<string, unknown>,
 ) => makeUrl(`/tafsirs/${tafsirId}/by_ayah/${verseKey}`, params);

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -75,13 +75,13 @@ export const getVerseTafsirNavigationUrl = (
  *
  * @param {string | number} chapterId
  * @param {number} verseNumber
- * @param {number} tafsirId
+ * @param {number |string} tafsirId
  * @returns {string}
  */
 export const getVerseSelectedTafsirNavigationUrl = (
   chapterId: string | number,
   verseNumber: number,
-  tafsirId: number,
+  tafsirId: number | string,
 ): string => `/${chapterId}:${verseNumber}/tafsirs/${tafsirId}`;
 
 /**

--- a/types/ApiResponses.ts
+++ b/types/ApiResponses.ts
@@ -95,5 +95,6 @@ export interface TafsirContentResponse extends BaseResponse {
       languageName: string;
     };
     text: string;
+    slug?: string;
   };
 }


### PR DESCRIPTION
### Summary
This PR adds slugs for Tafsirs which is better for SEO and readability. For example `/1:2/tafsirs/ru-tafseer-al-saddi` would show the same content as `1:2/tafsirs/170`.