### PR TITLE
[Logging] unsupported logical css properties

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,6 +16,7 @@ import ThirdPartyScripts from 'src/components/ThirdPartyScripts/ThirdPartyScript
 import ReduxProvider from 'src/redux/Provider';
 import ThemeProvider from 'src/styles/ThemeProvider';
 import { API_HOST } from 'src/utils/api';
+import { checkForCSSLogicalUnsupported } from 'src/utils/css';
 import { getDir } from 'src/utils/locale';
 import { createSEOConfig } from 'src/utils/seo';
 
@@ -30,6 +31,7 @@ function MyApp({ Component, pageProps }): JSX.Element {
   // listen to in-app changes of the locale and update the HTML dir accordingly.
   useEffect(() => {
     document.documentElement.dir = getDir(locale);
+    checkForCSSLogicalUnsupported();
   }, [locale]);
   return (
     <>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,7 +16,7 @@ import ThirdPartyScripts from 'src/components/ThirdPartyScripts/ThirdPartyScript
 import ReduxProvider from 'src/redux/Provider';
 import ThemeProvider from 'src/styles/ThemeProvider';
 import { API_HOST } from 'src/utils/api';
-import { checkForCSSLogicalUnsupported } from 'src/utils/css';
+import { logUnsupportedLogicalCSS } from 'src/utils/css';
 import { getDir } from 'src/utils/locale';
 import { createSEOConfig } from 'src/utils/seo';
 
@@ -31,7 +31,7 @@ function MyApp({ Component, pageProps }): JSX.Element {
   // listen to in-app changes of the locale and update the HTML dir accordingly.
   useEffect(() => {
     document.documentElement.dir = getDir(locale);
-    checkForCSSLogicalUnsupported();
+    logUnsupportedLogicalCSS();
   }, [locale]);
   return (
     <>

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,7 +1,7 @@
 import { logEvent } from './eventLogger';
 
 /* eslint-disable import/prefer-default-export */
-export const checkForCSSLogicalUnsupported = () => {
+export const logUnsupportedLogicalCSS = () => {
   if (window.CSS && window.CSS.supports) {
     // log when css logical properties are not supported by testing the supportability of "padding-inline" logical property as a sample.
     if (!window.CSS.supports('padding-inline', '10px')) {

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,0 +1,11 @@
+import { logEvent } from './eventLogger';
+
+/* eslint-disable import/prefer-default-export */
+export const checkForCSSLogicalUnsupported = () => {
+  if (window.CSS && window.CSS.supports) {
+    // log when css logical properties are not supported by testing the supportability of "padding-inline" logical property as a sample.
+    if (!window.CSS.supports('padding-inline', '10px')) {
+      logEvent('logical_css_un_supported');
+    }
+  }
+};


### PR DESCRIPTION
### Summary
This PR adds logging when the user's browser doesn't support [CSS logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).