### PR TITLE
[Tafsir] Preserve the locale in the url

### DIFF
--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -83,6 +83,7 @@ const TafsirBody = ({
           Number(selectedVerseNumber),
           slug,
         ),
+        lang,
       );
       dispatch(
         setSelectedTafsirs({
@@ -172,6 +173,7 @@ const TafsirBody = ({
             Number(1),
             selectedTafsirIdOrSlug,
           ),
+          lang,
         );
         setSelectedChapterId(newChapterId.toString());
         setSelectedVerseNumber('1'); // reset verse number to 1 every time chapter changes
@@ -185,6 +187,7 @@ const TafsirBody = ({
             Number(newVerseNumber),
             selectedTafsirIdOrSlug,
           ),
+          lang,
         );
       }}
     />

--- a/src/components/dls/ContentModal/ContentModal.tsx
+++ b/src/components/dls/ContentModal/ContentModal.tsx
@@ -31,11 +31,11 @@ const ContentModal = ({
 
   useEffect(() => {
     if (!url) return null;
-    if (isOpen) fakeNavigate(url);
-    else fakeNavigate(router.asPath);
+    if (isOpen) fakeNavigate(url, router.locale);
+    else fakeNavigate(router.asPath, router.locale);
 
     return () => {
-      fakeNavigate(router.asPath);
+      fakeNavigate(router.asPath, router.locale);
     };
 
     // we only want to run this effect when `isOpen` changed, not when `url` changed

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -162,11 +162,12 @@ export const getQuranReflectVerseUrl = (verseKey: string) => {
 
 /**
  * Update the browser history with the new url.
- * withohut actually navigating into that url.
- * So it does not trigger re render or page visit on nextjs
+ * without actually navigating into that url.
+ * So it does not trigger re render or page visit on Next.js
  *
  * @param {string} url
+ * @param {string} locale
  */
-export const fakeNavigate = (url: string) => {
-  window.history.pushState({}, '', url);
+export const fakeNavigate = (url: string, locale: string) => {
+  window.history.pushState({}, '', `${locale === 'en' ? '' : `/${locale}`}${url}`);
 };


### PR DESCRIPTION
### Summary
This PR updates the `fakeNavigate` util to preserve the current locale when selecting a different Tafsir.