### PR TITLE
[Tafsir] fix exception when switching locale

### DIFF
--- a/src/components/QuranReader/TafsirView/LanguageAndTafsirSelection.tsx
+++ b/src/components/QuranReader/TafsirView/LanguageAndTafsirSelection.tsx
@@ -35,6 +35,13 @@ const LanguageAndTafsirSelection = ({
       )}
       queryKey={makeTafsirsUrl(lang)}
       render={(data: TafsirsResponse) => {
+        if (!data) {
+          return (
+            <Skeleton
+              className={classNames(styles.tafsirSkeletonItem, styles.tafsirSelectionSkeleton)}
+            />
+          );
+        }
         return (
           <div className={styles.tafsirSelectionContainer}>
             <Select


### PR DESCRIPTION
### Summary
This PR fixes an exception thrown when changing the locale from the Navbar while viewing a Tafsir via the url and not the Modal. e.g. when viewing `/2:1/tafsirs/tafseer-ibn-e-kaseer-urdu` and then switching the locale to Arabic.