### PR TITLE
fix: quranword is cut on safari

### DIFF
--- a/src/components/dls/Popover/Popover.module.scss
+++ b/src/components/dls/Popover/Popover.module.scss
@@ -7,6 +7,7 @@
 
 .trigger {
   all: unset;
+  display: inline-block;
 }
 
 .content {

--- a/src/components/dls/Popover/index.tsx
+++ b/src/components/dls/Popover/index.tsx
@@ -53,11 +53,8 @@ const Popover: React.FC<Props> = ({
       {...(typeof open !== 'undefined' && { open })}
       {...(onOpenChange && { onOpenChange })}
     >
-      <RadixPopover.Trigger
-        aria-label="Open popover"
-        className={classNames(styles.trigger, triggerStyles)}
-      >
-        {trigger}
+      <RadixPopover.Trigger aria-label="Open popover" asChild>
+        <span className={classNames(styles.trigger, triggerStyles)}>{trigger}</span>
       </RadixPopover.Trigger>
       <RadixPopover.Content
         sideOffset={2}

--- a/src/components/dls/Tooltip/Tooltip.module.scss
+++ b/src/components/dls/Tooltip/Tooltip.module.scss
@@ -1,5 +1,6 @@
 .trigger {
   all: unset;
+  display: inline-block;
 }
 
 .content {

--- a/src/components/dls/Tooltip/index.tsx
+++ b/src/components/dls/Tooltip/index.tsx
@@ -59,8 +59,8 @@ const Tooltip: React.FC<Props> = ({
     {...(typeof open !== 'undefined' && { open })}
     {...(onOpenChange && { onOpenChange })}
   >
-    <RadixTooltip.Trigger aria-label="Open tooltip" className={styles.trigger}>
-      {children}
+    <RadixTooltip.Trigger aria-label="Open tooltip" asChild>
+      <span className={styles.trigger}>{children}</span>
     </RadixTooltip.Trigger>
     <RadixTooltip.Content
       sideOffset={2}


### PR DESCRIPTION
Before
<img width="575" alt="image" src="https://user-images.githubusercontent.com/12745166/148638600-c536ae17-d8c2-4cf6-a4ab-1fde161a6acd.png">


After
<img width="572" alt="image" src="https://user-images.githubusercontent.com/12745166/148638586-13d825d4-7a38-44e8-9c59-e92df7ab0010.png">


Before
<img width="79" alt="image" src="https://user-images.githubusercontent.com/12745166/148638631-269bd7b7-0d9d-4447-860d-426288f5da8a.png">

After
<img width="60" alt="image" src="https://user-images.githubusercontent.com/12745166/148638636-b7c6a328-f8e6-4f08-8062-6637ac5b4271.png">
