### PR TITLE
fix: combobox search input icon not centered

### DIFF
--- a/src/components/dls/Forms/Combobox/Icons/SearchInputIcon.module.scss
+++ b/src/components/dls/Forms/Combobox/Icons/SearchInputIcon.module.scss
@@ -11,7 +11,8 @@
 }
 
 .icon svg {
-  display: inline-block;
+  display: flex;
+  align-items: center;
   width: var(--spacing-small);
   height: var(--spacing-small);
   overflow: hidden;


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/12745166/148639677-6d668fed-5708-404b-87e3-258332213b9e.png)


## After


![image](https://user-images.githubusercontent.com/12745166/148639680-9648e94f-0e56-47d0-a88f-83f1a1a91f66.png)
