### PR TITLE
[Query Params] Add translations

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslatioViewCellSkeleton.tsx
+++ b/src/components/QuranReader/TranslationView/TranslatioViewCellSkeleton.tsx
@@ -7,9 +7,9 @@ import skeletonStyles from './TranslationViewSkeleton.module.scss';
 import Button, { ButtonSize } from 'src/components/dls/Button/Button';
 import Skeleton from 'src/components/dls/Skeleton/Skeleton';
 import verseTextStyles from 'src/components/Verse/VerseText.module.scss';
+import useGetQueryParamOrReduxValue from 'src/hooks/useGetQueryParamOrReduxValue';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
-import { selectSelectedTranslations } from 'src/redux/slices/QuranReader/translations';
-import { areArraysEqual } from 'src/utils/array';
+import QueryParam from 'types/QueryParam';
 import { QuranFont } from 'types/QuranReader';
 
 const TRANSLATION_TEXT_SAMPLE =
@@ -18,7 +18,7 @@ const TRANSLATION_AUTHOR_SAMPLE = '— Dr. Mustafa Khattab, the Clear Quran';
 const VERSE_KEY_SAMPLE = '1:12';
 
 const TranslationViewCellSkeleton = () => {
-  const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
+  const selectedTranslations = useGetQueryParamOrReduxValue(QueryParam.Translations) as number[];
   const { quranFont, quranTextFontScale, translationFontScale } = useSelector(
     selectQuranReaderStyles,
     shallowEqual,

--- a/src/components/QuranReader/hooks/useSyncQueryParams.ts
+++ b/src/components/QuranReader/hooks/useSyncQueryParams.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/router';
+import { useSelector } from 'react-redux';
+
+import {
+  selectIsUsingDefaultTranslations,
+  selectSelectedTranslations,
+} from 'src/redux/slices/QuranReader/translations';
+import { areArraysEqual } from 'src/utils/array';
+import QueryParam from 'types/QueryParam';
+
+const useSyncQueryParams = () => {
+  const router = useRouter();
+  const isUsingDefaultTranslations = useSelector(selectIsUsingDefaultTranslations);
+  const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
+
+  useEffect(() => {
+    if (isUsingDefaultTranslations) {
+      // when the user reset the default settings, we should remove the value from the url
+      if (router.query[QueryParam.Translations]) {
+        if (router.query[QueryParam.Translations] === selectedTranslations.join(',')) {
+          delete router.query[QueryParam.Translations];
+          router.push(router, undefined, { shallow: true });
+        }
+      }
+    } else if (!selectedTranslations.length) {
+      // if the user un-selects all translations but there is still translations in the url, we remove it
+      if (router.query[QueryParam.Translations]) {
+        delete router.query[QueryParam.Translations];
+        router.push(router, undefined, { shallow: true });
+      }
+    } else if (!router.query[QueryParam.Translations]) {
+      router.query[QueryParam.Translations] = selectedTranslations.join(',');
+      router.push(router, undefined, { shallow: true });
+    }
+
+    // else if (selectedTranslations.length) {
+    //   const queryParamValue = selectedTranslations.join(',');
+    //   // if there is a difference between the current query and the new value, we should update the url
+    //   if (router.query[QueryParam.Translations] !== queryParamValue) {
+    //     router.query[QueryParam.Translations] = queryParamValue;
+    //     router.push(router, undefined, { shallow: true });
+    //   }
+    // } else if (router.query[QueryParam.Translations]) {
+    //   // if the user un-selected all translations but there is still translations in the url, we remove it
+    //   delete router.query[QueryParam.Translations];
+    //   router.push(router, undefined, { shallow: true });
+    // }
+  }, [isUsingDefaultTranslations, router, selectedTranslations]);
+};
+
+export default useSyncQueryParams;

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -12,6 +12,7 @@ import useSWRInfinite from 'swr/infinite';
 import { getPageLimit, getRequestKey, verseFetcher } from './api';
 import ContextMenu from './ContextMenu';
 import DebuggingObserverWindow from './DebuggingObserverWindow';
+import useSyncQueryParams from './hooks/useSyncQueryParams';
 import Loader from './Loader';
 import Loading from './Loading';
 import Notes from './Notes/Notes';
@@ -24,6 +25,7 @@ import SidebarNavigation from './SidebarNavigation/SidebarNavigation';
 import TranslationViewSkeleton from './TranslationView/TranslationViewSkeleton';
 
 import Spinner from 'src/components/dls/Spinner/Spinner';
+import useGetQueryParamOrReduxValue from 'src/hooks/useGetQueryParamOrReduxValue';
 import useGlobalIntersectionObserver from 'src/hooks/useGlobalIntersectionObserver';
 import Error from 'src/pages/_error';
 import { selectIsUsingDefaultReciter, selectReciter } from 'src/redux/slices/AudioPlayer/state';
@@ -37,12 +39,9 @@ import { setLastReadVerse } from 'src/redux/slices/QuranReader/readingTracker';
 import { selectIsSidebarNavigationVisible } from 'src/redux/slices/QuranReader/sidebarNavigation';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectIsUsingDefaultTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
-import {
-  selectIsUsingDefaultTranslations,
-  selectSelectedTranslations,
-} from 'src/redux/slices/QuranReader/translations';
-import { areArraysEqual } from 'src/utils/array';
+import { selectIsUsingDefaultTranslations } from 'src/redux/slices/QuranReader/translations';
 import { VersesResponse } from 'types/ApiResponses';
+import QueryParam from 'types/QueryParam';
 import { QuranFont, QuranReaderDataType, ReadingPreference } from 'types/QuranReader';
 
 const EndOfScrollingControls = dynamic(() => import('./EndOfScrollingControls'), {
@@ -67,7 +66,7 @@ const QuranReader = ({
   const isSelectedTafsirData = quranReaderDataType === QuranReaderDataType.SelectedTafsir;
   const isSideBarVisible = useSelector(selectNotes, shallowEqual).isVisible;
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
-  const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
+  const selectedTranslations = useGetQueryParamOrReduxValue(QueryParam.Translations) as number[];
   const isUsingDefaultTranslations = useSelector(selectIsUsingDefaultTranslations);
   const isUsingDefaultTafsirs = useSelector(selectIsUsingDefaultTafsirs);
   const isUsingDefaultWordByWordLocale = useSelector(selectIsUsingDefaultWordByWordLocale);
@@ -75,6 +74,7 @@ const QuranReader = ({
   const reciter = useSelector(selectReciter, shallowEqual);
   const isUsingDefaultReciter = useSelector(selectIsUsingDefaultReciter);
   const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
+  useSyncQueryParams();
   const { data, size, setSize, isValidating } = useSWRInfinite(
     (index) =>
       getRequestKey({

--- a/src/hooks/useGetQueryParamOrReduxValue.ts
+++ b/src/hooks/useGetQueryParamOrReduxValue.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+
+import { useRouter } from 'next/router';
+import { useSelector } from 'react-redux';
+
+import { RootState } from 'src/redux/RootState';
+import { selectSelectedTranslations } from 'src/redux/slices/QuranReader/translations';
+import { areArraysEqual } from 'src/utils/array';
+import { isValidTranslationsQueryParamValue } from 'src/utils/queryParamValidator';
+import QueryParam from 'types/QueryParam';
+
+enum ValueType {
+  String = 'String',
+  ArrayOfNumbers = 'ArrayOfNumbers',
+  ArrayOfStrings = 'ArrayOfStrings',
+}
+
+const QUERY_PARAMS_DATA = {
+  [QueryParam.Translations]: {
+    reduxSelector: selectSelectedTranslations,
+    reduxEqualityFunction: areArraysEqual,
+    valueType: ValueType.ArrayOfNumbers,
+  },
+} as Record<
+  QueryParam,
+  {
+    reduxSelector: (state: RootState) => unknown;
+    valueType: ValueType;
+    reduxEqualityFunction?: (left: unknown, right: unknown) => boolean;
+  }
+>;
+
+/**
+ * A hook that searches the query params of the url for specific values,
+ * parses them if found and if not, falls back to the Redux value.
+ *
+ * @param {QueryParam} queryParam
+ * @returns {unknown}
+ */
+const useGetQueryParamOrReduxValue = (queryParam: QueryParam): unknown => {
+  const { query, isReady } = useRouter();
+  let useSelectorArguments = [QUERY_PARAMS_DATA[queryParam].reduxSelector];
+  if (QUERY_PARAMS_DATA[queryParam].reduxEqualityFunction) {
+    useSelectorArguments = [
+      QUERY_PARAMS_DATA[queryParam].reduxSelector,
+      // @ts-ignore
+      QUERY_PARAMS_DATA[queryParam].reduxEqualityFunction,
+    ];
+  }
+  // @ts-ignore
+  const selectedValue = useSelector(...useSelectorArguments);
+  const [value, setValue] = useState(selectedValue);
+  useEffect(() => {
+    // if the param exists in the url
+    if (isReady && query[queryParam]) {
+      const paramStringValue = String(query[queryParam]);
+      let isValidValue = true;
+      if (queryParam === QueryParam.Translations) {
+        isValidValue = isValidTranslationsQueryParamValue(paramStringValue);
+      }
+      if (isValidValue) {
+        // return an array of numbers instead of a string
+        if (QUERY_PARAMS_DATA[queryParam].valueType === ValueType.ArrayOfNumbers) {
+          setValue(paramStringValue.split(',').map((stringValue) => Number(stringValue)));
+        } else {
+          setValue(query[queryParam]);
+        }
+      }
+    } else {
+      setValue(selectedValue);
+    }
+  }, [isReady, query, queryParam, selectedValue]);
+  return value;
+};
+
+export default useGetQueryParamOrReduxValue;

--- a/src/utils/queryParamValidator.test.ts
+++ b/src/utils/queryParamValidator.test.ts
@@ -1,0 +1,26 @@
+import { isValidTranslationsQueryParamValue } from './queryParamValidator';
+
+it('Returns false when empty', () => {
+  expect(isValidTranslationsQueryParamValue('')).toBe(false);
+});
+it('Returns true when 1 valid translation id exists', () => {
+  expect(isValidTranslationsQueryParamValue('124')).toBe(true);
+});
+it('Returns false when 1 invalid translation id exists', () => {
+  expect(isValidTranslationsQueryParamValue('sdfsdfdf')).toBe(false);
+});
+it('Returns false when 1 invalid translation id and 1 empty id exist', () => {
+  expect(isValidTranslationsQueryParamValue('sdfsdf,')).toBe(false);
+});
+it('Returns false when 1 valid id and 1 empty id exist', () => {
+  expect(isValidTranslationsQueryParamValue('123,')).toBe(false);
+});
+it('Returns false when 2 valid ids and 1 empty id exist', () => {
+  expect(isValidTranslationsQueryParamValue('151,54,')).toBe(false);
+});
+it('Returns true when 2 valid translation id exist', () => {
+  expect(isValidTranslationsQueryParamValue('123,444')).toBe(true);
+});
+it('Returns false when one of many ids is not valid', () => {
+  expect(isValidTranslationsQueryParamValue('123,sdfsdf,1234')).toBe(false);
+});

--- a/src/utils/queryParamValidator.ts
+++ b/src/utils/queryParamValidator.ts
@@ -1,0 +1,24 @@
+/* eslint-disable import/prefer-default-export */
+
+export const isValidTranslationsQueryParamValue = (value: string): boolean => {
+  // if it's empty string, we shouldn't consider it as a valid translation
+  if (!value) {
+    return false;
+  }
+  const translationIds = value.split(',');
+  let isValid = true;
+  for (let index = 0; index < translationIds.length; index += 1) {
+    // if the value is empty
+    if (!translationIds[index]) {
+      isValid = false;
+      break;
+    }
+    const translationId = Number(translationIds[index]);
+    // if the translation Id is empty or is not a number
+    if (!translationId && Number.isNaN(translationId)) {
+      isValid = false;
+      break;
+    }
+  }
+  return isValid;
+};

--- a/types/QueryParam.ts
+++ b/types/QueryParam.ts
@@ -1,0 +1,5 @@
+enum QueryParam {
+  Translations = 'translations',
+}
+
+export default QueryParam;


### PR DESCRIPTION
### Summary
This PR adds the ability to parse the `translations` query param in the URL and apply it inside the QuranReader. It also adds the ability to sync between the selected translations settings and the `translations` query param.