### PR TITLE
Remove unused Tarteel search response fields no longer sent by api

### DIFF
--- a/types/Tarteel/SearchResult.ts
+++ b/types/Tarteel/SearchResult.ts
@@ -1,11 +1,8 @@
 interface SearchResult {
   queryText: string;
   matches?: {
-    arabicAyah: string;
-    arabicSurahName: string;
     ayahNum: number;
     surahNum: number;
-    translationSurahName: string;
   }[];
 }
 


### PR DESCRIPTION
### Summary
In the Tarteel search backend we had some deprecated fields included in the search result matches. We have now fully removed those fields from the response. Those fields were already unused on quran.com, but the type definition needs to be updated.

### Test Plan
Inspected the code to understand whether any of these fields were being used. Will test with the updated backend response before merging. Opening now for early review.