### PR TITLE
[Query Params] WBW query params

### DIFF
--- a/src/components/QuranReader/hooks/useSyncReduxAndQueryParams.ts
+++ b/src/components/QuranReader/hooks/useSyncReduxAndQueryParams.ts
@@ -5,6 +5,10 @@ import { shallowEqual, useSelector } from 'react-redux';
 
 import { selectIsUsingDefaultReciter, selectReciterId } from 'src/redux/slices/AudioPlayer/state';
 import {
+  selectIsUsingDefaultWordByWordLocale,
+  selectWordByWordLocale,
+} from 'src/redux/slices/QuranReader/readingPreferences';
+import {
   selectIsUsingDefaultTranslations,
   selectSelectedTranslations,
 } from 'src/redux/slices/QuranReader/translations';
@@ -15,8 +19,10 @@ const useSyncReduxAndQueryParams = () => {
   const router = useRouter();
   const isUsingDefaultTranslations = useSelector(selectIsUsingDefaultTranslations);
   const isUsingDefaultReciter = useSelector(selectIsUsingDefaultReciter);
+  const isUsingDefaultWordByWordLocale = useSelector(selectIsUsingDefaultWordByWordLocale);
   const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
   const selectedReciterId = useSelector(selectReciterId, shallowEqual);
+  const selectedWordByWordLocale = useSelector(selectWordByWordLocale, shallowEqual);
 
   useEffect(() => {
     if (router.isReady) {
@@ -59,6 +65,24 @@ const useSyncReduxAndQueryParams = () => {
       }
     }
   }, [isUsingDefaultReciter, router, selectedReciterId]);
+
+  useEffect(() => {
+    if (router.isReady) {
+      if (isUsingDefaultWordByWordLocale) {
+        // when the user resets the default settings, we should remove the value from the url
+        if (
+          router.query[QueryParam.WBW_LOCALE] &&
+          router.query[QueryParam.WBW_LOCALE] === selectedWordByWordLocale
+        ) {
+          delete router.query[QueryParam.WBW_LOCALE];
+          router.push(router, undefined, { shallow: true });
+        }
+      } else if (!router.query[QueryParam.WBW_LOCALE]) {
+        router.query[QueryParam.WBW_LOCALE] = selectedWordByWordLocale;
+        router.push(router, undefined, { shallow: true });
+      }
+    }
+  }, [isUsingDefaultWordByWordLocale, router, selectedWordByWordLocale]);
 };
 
 export default useSyncReduxAndQueryParams;

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -33,7 +33,6 @@ import { selectNotes } from 'src/redux/slices/QuranReader/notes';
 import {
   selectIsUsingDefaultWordByWordLocale,
   selectReadingPreference,
-  selectWordByWordLocale,
 } from 'src/redux/slices/QuranReader/readingPreferences';
 import { setLastReadVerse } from 'src/redux/slices/QuranReader/readingTracker';
 import { selectIsSidebarNavigationVisible } from 'src/redux/slices/QuranReader/sidebarNavigation';
@@ -71,7 +70,7 @@ const QuranReader = ({
   const isUsingDefaultTranslations = useSelector(selectIsUsingDefaultTranslations);
   const isUsingDefaultTafsirs = useSelector(selectIsUsingDefaultTafsirs);
   const isUsingDefaultWordByWordLocale = useSelector(selectIsUsingDefaultWordByWordLocale);
-  const wordByWordLocale = useSelector(selectWordByWordLocale);
+  const wordByWordLocale = useGetQueryParamOrReduxValue(QueryParam.WBW_LOCALE) as string;
   const isUsingDefaultReciter = useSelector(selectIsUsingDefaultReciter);
   const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
   useSyncReduxAndQueryParams();

--- a/src/hooks/useGetQueryParamOrReduxValue.ts
+++ b/src/hooks/useGetQueryParamOrReduxValue.ts
@@ -5,6 +5,7 @@ import { useSelector, shallowEqual } from 'react-redux';
 
 import { RootState } from 'src/redux/RootState';
 import { selectReciterId } from 'src/redux/slices/AudioPlayer/state';
+import { selectWordByWordLocale } from 'src/redux/slices/QuranReader/readingPreferences';
 import { selectSelectedTranslations } from 'src/redux/slices/QuranReader/translations';
 import { areArraysEqual } from 'src/utils/array';
 import {
@@ -30,6 +31,11 @@ const QUERY_PARAMS_DATA = {
     reduxSelector: selectReciterId,
     reduxEqualityFunction: shallowEqual,
     valueType: ValueType.Number,
+  },
+  [QueryParam.WBW_LOCALE]: {
+    reduxSelector: selectWordByWordLocale,
+    reduxEqualityFunction: shallowEqual,
+    valueType: ValueType.String,
   },
 } as Record<
   QueryParam,

--- a/types/QueryParam.ts
+++ b/types/QueryParam.ts
@@ -1,6 +1,7 @@
 enum QueryParam {
   Translations = 'translations',
   Reciter = 'reciter',
+  WBW_LOCALE = 'wbw_locale',
 }
 
 export default QueryParam;


### PR DESCRIPTION
This PR adds the ability to parse the word by word locale query param (`wbw_locale`) in the URL and apply it inside the QuranReader. It also adds the ability to sync between the selected word by word locale settings and the query param.