### PR TITLE
Handle when no translations found

### DIFF
--- a/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
@@ -68,6 +68,9 @@ const TranslationSelectionBody = () => {
 
   const renderTranslationGroup = useCallback(
     (language, translations) => {
+      if (!translations) {
+        return <></>;
+      }
       return (
         <div className={styles.group} key={language}>
           <div className={styles.language}>{language}</div>


### PR DESCRIPTION
### Summary
This PR handles the case when the search query in the settings drawer's translation section doesn't match any existing translations.