### PR TITLE
New reciter api

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -81,11 +81,11 @@ export const getAvailableLanguages = async (language: string): Promise<Languages
 
 /**
  * Get list of available reciters.
- *
+ * @param {string} locale  the locale.
  * @returns {Promise<RecitersResponse>}
  */
-export const getAvailableReciters = async (): Promise<RecitersResponse> =>
-  fetcher(makeRecitersUrl());
+export const getAvailableReciters = async (locale: string): Promise<RecitersResponse> =>
+  fetcher(makeRecitersUrl(locale));
 
 /**
  * Get audio file for a specific reciter and chapter.

--- a/src/api.ts
+++ b/src/api.ts
@@ -81,7 +81,9 @@ export const getAvailableLanguages = async (language: string): Promise<Languages
 
 /**
  * Get list of available reciters.
+ *
  * @param {string} locale  the locale.
+ *
  * @returns {Promise<RecitersResponse>}
  */
 export const getAvailableReciters = async (locale: string): Promise<RecitersResponse> =>

--- a/src/components/AudioPlayer/Buttons/SelectReciterMenu.tsx
+++ b/src/components/AudioPlayer/Buttons/SelectReciterMenu.tsx
@@ -43,7 +43,7 @@ const SelectReciterMenu = ({ onBack }) => {
     [selectedReciter, lang, dispatch, onBack],
   );
 
-  const reciters = <DataFetcher queryKey={makeRecitersUrl()} render={renderReciter} />;
+  const reciters = <DataFetcher queryKey={makeRecitersUrl(lang)} render={renderReciter} />;
 
   return (
     <>

--- a/src/components/DeveloperUtility/ReciterAdjustment.tsx
+++ b/src/components/DeveloperUtility/ReciterAdjustment.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import React from 'react';
 
+import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, shallowEqual, useSelector } from 'react-redux';
 import useSWRImmutable from 'swr/immutable';
 
@@ -10,13 +11,12 @@ import { getAvailableReciters } from 'src/api';
 import { selectReciter, setReciter } from 'src/redux/slices/AudioPlayer/state';
 import { makeRecitersUrl } from 'src/utils/apiPaths';
 import Reciter from 'types/Reciter';
-import useTranslation from 'next-translate/useTranslation';
 
 const ReciterAdjustment: React.FC = () => {
   const dispatch = useDispatch();
-    const { lang } = useTranslation();
+  const { lang } = useTranslation();
 
-    const { data, error } = useSWRImmutable(makeRecitersUrl(lang), () =>
+  const { data, error } = useSWRImmutable(makeRecitersUrl(lang), () =>
     getAvailableReciters(lang).then((res) =>
       res.status === 500 ? Promise.reject(error) : Promise.resolve(res.reciters),
     ),

--- a/src/components/DeveloperUtility/ReciterAdjustment.tsx
+++ b/src/components/DeveloperUtility/ReciterAdjustment.tsx
@@ -10,11 +10,14 @@ import { getAvailableReciters } from 'src/api';
 import { selectReciter, setReciter } from 'src/redux/slices/AudioPlayer/state';
 import { makeRecitersUrl } from 'src/utils/apiPaths';
 import Reciter from 'types/Reciter';
+import useTranslation from 'next-translate/useTranslation';
 
 const ReciterAdjustment: React.FC = () => {
   const dispatch = useDispatch();
-  const { data, error } = useSWRImmutable(makeRecitersUrl(), () =>
-    getAvailableReciters().then((res) =>
+    const { lang } = useTranslation();
+
+    const { data, error } = useSWRImmutable(makeRecitersUrl(lang), () =>
+    getAvailableReciters(lang).then((res) =>
       res.status === 500 ? Promise.reject(error) : Promise.resolve(res.reciters),
     ),
   );

--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
@@ -18,7 +18,7 @@ import Reciter from 'types/Reciter';
 
 const filterReciters = (reciters, searchQuery: string): Reciter[] => {
   const fuse = new Fuse(reciters, {
-    keys: ['name', 'languageName', 'authorName'],
+    keys: ['name', 'languageName', 'translatedName.name', 'qirat.name', 'style.name' ],
     threshold: 0.3,
   });
 
@@ -57,7 +57,7 @@ const SettingsReciter = () => {
         />
       </div>
       <DataFetcher
-        queryKey={makeRecitersUrl()}
+        queryKey={makeRecitersUrl(lang)}
         render={(data: RecitersResponse) => {
           const filteredReciters = searchQuery
             ? filterReciters(data.reciters, searchQuery)
@@ -82,7 +82,7 @@ const SettingsReciter = () => {
                         onSelectedReciterChange(e.target.value, data.reciters);
                       }}
                     />
-                    <span>{reciter.name}</span>
+                    <span lang={reciter.translatedName.languageName}>{reciter.translatedName.name}</span>
                     <span className={styles.recitationStyle}>{reciter.style.name}</span>
                   </label>
                 ))}

--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
@@ -18,7 +18,7 @@ import Reciter from 'types/Reciter';
 
 const filterReciters = (reciters, searchQuery: string): Reciter[] => {
   const fuse = new Fuse(reciters, {
-    keys: ['name', 'languageName', 'translatedName.name', 'qirat.name', 'style.name' ],
+    keys: ['name', 'languageName', 'translatedName.name', 'qirat.name', 'style.name'],
     threshold: 0.3,
   });
 
@@ -82,7 +82,9 @@ const SettingsReciter = () => {
                         onSelectedReciterChange(e.target.value, data.reciters);
                       }}
                     />
-                    <span lang={reciter.translatedName.languageName}>{reciter.translatedName.name}</span>
+                    <span lang={reciter.translatedName.languageName}>
+                      {reciter.translatedName.name}
+                    </span>
                     <span className={styles.recitationStyle}>{reciter.style.name}</span>
                   </label>
                 ))}

--- a/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
@@ -29,7 +29,7 @@ import AvailableTranslation from 'types/AvailableTranslation';
 
 const filterTranslations = (translations, searchQuery: string): AvailableTranslation[] => {
   const fuse = new Fuse(translations, {
-    keys: ['name', 'languageName', 'authorName'],
+    keys: ['name', 'languageName', 'authorName', 'translatedName.name'],
     threshold: 0.3,
   });
 
@@ -85,7 +85,7 @@ const TranslationSelectionBody = () => {
                   checked={selectedTranslations.includes(translation.id)}
                   onChange={onTranslationsChange}
                 />
-                <label htmlFor={translation.id.toString()}>{translation.authorName}</label>
+                <label htmlFor={translation.id.toString()} lang={translation.translatedName.languageName}>{translation.translatedName.name}</label>
               </div>
             ))}
         </div>

--- a/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
@@ -85,7 +85,12 @@ const TranslationSelectionBody = () => {
                   checked={selectedTranslations.includes(translation.id)}
                   onChange={onTranslationsChange}
                 />
-                <label htmlFor={translation.id.toString()} lang={translation.translatedName.languageName}>{translation.translatedName.name}</label>
+                <label
+                  htmlFor={translation.id.toString()}
+                  lang={translation.translatedName.languageName}
+                >
+                  {translation.translatedName.name}
+                </label>
               </div>
             ))}
         </div>

--- a/src/components/Radio/ReciterStationList.tsx
+++ b/src/components/Radio/ReciterStationList.tsx
@@ -1,3 +1,4 @@
+import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import PauseIcon from '../../../public/icons/pause.svg';
@@ -16,7 +17,6 @@ import { getRandomChapterId } from 'src/utils/chapter';
 import { logEvent } from 'src/utils/eventLogger';
 import { RecitersResponse } from 'types/ApiResponses';
 import Reciter from 'types/Reciter';
-import useTranslation from 'next-translate/useTranslation';
 
 // TODO:
 // - these images url should come from backend.
@@ -37,7 +37,7 @@ const reciterPictures = {
 
 const ReciterStationList = () => {
   const dispatch = useDispatch();
-  const {lang} = useTranslation();
+  const { lang } = useTranslation();
   const stationState = useSelector(selectRadioStation, shallowEqual);
   const isAudioPlaying = useSelector(selectIsPlaying);
 

--- a/src/components/Radio/ReciterStationList.tsx
+++ b/src/components/Radio/ReciterStationList.tsx
@@ -16,6 +16,7 @@ import { getRandomChapterId } from 'src/utils/chapter';
 import { logEvent } from 'src/utils/eventLogger';
 import { RecitersResponse } from 'types/ApiResponses';
 import Reciter from 'types/Reciter';
+import useTranslation from 'next-translate/useTranslation';
 
 // TODO:
 // - these images url should come from backend.
@@ -36,6 +37,7 @@ const reciterPictures = {
 
 const ReciterStationList = () => {
   const dispatch = useDispatch();
+  const {lang} = useTranslation();
   const stationState = useSelector(selectRadioStation, shallowEqual);
   const isAudioPlaying = useSelector(selectIsPlaying);
 
@@ -67,7 +69,7 @@ const ReciterStationList = () => {
 
   return (
     <DataFetcher
-      queryKey={makeRecitersUrl()}
+      queryKey={makeRecitersUrl(lang)}
       render={(data: RecitersResponse) => {
         if (!data) return null;
         return (

--- a/src/utils/apiPaths.ts
+++ b/src/utils/apiPaths.ts
@@ -67,18 +67,20 @@ export const makeLanguagesUrl = (language: string): string =>
 
 /**
  * Compose the url for reciters API.
+ *
  * @param {string} locale the user's language code.
  * @returns {string}
  */
-export const makeRecitersUrl = (locale: string): string => makeUrl('/audio/reciters', {locale});
+export const makeRecitersUrl = (locale: string): string => makeUrl('/audio/reciters', { locale });
 
 /**
  * Compose the url for the audio file for of a surah.
  *
+ * @param {number} reciterId id of reciter
  * @param {number} chapter the surah number.
  * @param {boolean} segments include segments info
- * @returns {string}
  *
+ * @returns {string}
  */
 export const makeChapterAudioDataUrl = (reciterId: number, chapter: number, segments: boolean) =>
   makeUrl(`/audio/reciters/${reciterId}/audio_files`, { chapter, segments });

--- a/src/utils/apiPaths.ts
+++ b/src/utils/apiPaths.ts
@@ -67,13 +67,21 @@ export const makeLanguagesUrl = (language: string): string =>
 
 /**
  * Compose the url for reciters API.
- *
+ * @param {string} locale the user's language code.
  * @returns {string}
  */
-export const makeRecitersUrl = (): string => makeUrl('/audio/reciters');
+export const makeRecitersUrl = (locale: string): string => makeUrl('/audio/reciters', {locale});
 
+/**
+ * Compose the url for the audio file for of a surah.
+ *
+ * @param {number} chapter the surah number.
+ * @param {boolean} segments include segments info
+ * @returns {string}
+ *
+ */
 export const makeChapterAudioDataUrl = (reciterId: number, chapter: number, segments: boolean) =>
-  makeUrl(`/audio/reciters/${reciterId}`, { chapter, segments });
+  makeUrl(`/audio/reciters/${reciterId}/audio_files`, { chapter, segments });
 
 export const makeAudioTimestampsUrl = (reciterId: number, verseKey: string) =>
   makeUrl(`/audio/reciters/${reciterId}/timestamp?verse_key=${verseKey}`);

--- a/src/utils/apiPaths.ts
+++ b/src/utils/apiPaths.ts
@@ -74,7 +74,7 @@ export const makeLanguagesUrl = (language: string): string =>
 export const makeRecitersUrl = (locale: string): string => makeUrl('/audio/reciters', { locale });
 
 /**
- * Compose the url for the audio file for of a surah.
+ * Compose the url of the audio file of a surah.
  *
  * @param {number} reciterId id of reciter
  * @param {number} chapter the surah number.
@@ -82,8 +82,11 @@ export const makeRecitersUrl = (locale: string): string => makeUrl('/audio/recit
  *
  * @returns {string}
  */
-export const makeChapterAudioDataUrl = (reciterId: number, chapter: number, segments: boolean) =>
-  makeUrl(`/audio/reciters/${reciterId}/audio_files`, { chapter, segments });
+export const makeChapterAudioDataUrl = (
+  reciterId: number,
+  chapter: number,
+  segments: boolean,
+): string => makeUrl(`/audio/reciters/${reciterId}/audio_files`, { chapter, segments });
 
 export const makeAudioTimestampsUrl = (reciterId: number, verseKey: string) =>
   makeUrl(`/audio/reciters/${reciterId}/timestamp?verse_key=${verseKey}`);


### PR DESCRIPTION
### Summary
- Fix reciter api 
- Search translation and recitation using localized names as well
- Show localized names, instead of default English names

### Test Plan
- Change the site locale to Urdu or Arabic
- Open the settings, go to reciter or translations 
- You should see localised names and should be able to search using localised names as well 