### PR TITLE
Add PlainVerseText

### DIFF
--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -18,7 +18,7 @@ import styles from './TafsirView.module.scss';
 import { fetcher } from 'src/api';
 import DataFetcher from 'src/components/DataFetcher';
 import Separator from 'src/components/dls/Separator/Separator';
-import VerseText from 'src/components/Verse/VerseText';
+import VerseText from 'src/components/Verse/PlainVerseText';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import QuranReaderStyles from 'src/redux/types/QuranReaderStyles';

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -18,7 +18,7 @@ import styles from './TafsirView.module.scss';
 import { fetcher } from 'src/api';
 import DataFetcher from 'src/components/DataFetcher';
 import Separator from 'src/components/dls/Separator/Separator';
-import VerseText from 'src/components/Verse/PlainVerseText';
+import PlainVerseText from 'src/components/Verse/PlainVerseText';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import QuranReaderStyles from 'src/redux/types/QuranReaderStyles';
@@ -138,7 +138,7 @@ const TafsirBody = ({
           <TafsirGroupMessage from={firstVerseKey} to={lastVerseKey} />
         )}
         <div className={styles.verseTextContainer}>
-          <VerseText words={words} />
+          <PlainVerseText words={words} />
         </div>
         <div className={styles.separatorContainer}>
           <Separator />

--- a/src/components/Verse/PlainVerseText.tsx
+++ b/src/components/Verse/PlainVerseText.tsx
@@ -20,10 +20,9 @@ type Props = {
 };
 
 /**
- * A component to show the verse text without the extra functionalities for specific
- * scenarios e.g. ayah highlighting when audio is playing or showing a tooltip when
+ * A component to only show the verse text without extra functionalities such as ayah
+ * highlighting when audio is playing or showing a tooltip when
  * hovering over a verse or showing the word by word translation/transliteration.
- * This component was initially designed for the Tafsir view.
  *
  * @param {Props} param0
  * @returns {JSX.Element}

--- a/src/components/Verse/PlainVerseText.tsx
+++ b/src/components/Verse/PlainVerseText.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import classNames from 'classnames';
+import { shallowEqual, useSelector } from 'react-redux';
+
+import GlyphWord from '../dls/QuranWord/GlyphWord';
+import TajweedWord from '../dls/QuranWord/TajweedWordImage';
+import TextWord from '../dls/QuranWord/TextWord';
+
+import styles from './VerseText.module.scss';
+
+import { selectLoadedFontFaces } from 'src/redux/slices/QuranReader/font-faces';
+import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
+import { isQCFFont } from 'src/utils/fontFaceHelper';
+import { QuranFont } from 'types/QuranReader';
+import Word from 'types/Word';
+
+type Props = {
+  words: Word[];
+};
+
+/**
+ * A component to show the verse text without the extra functionalities for specific
+ * scenarios e.g. ayah highlighting when audio is playing or showing a tooltip when
+ * hovering over a verse or showing the word by word translation/transliteration.
+ * This component was initially designed for the Tafsir view.
+ *
+ * @param {Props} param0
+ * @returns {JSX.Element}
+ */
+const PlainVerseText: React.FC<Props> = ({ words }: Props): JSX.Element => {
+  const loadedFonts = useSelector(selectLoadedFontFaces);
+  const { quranFont, quranTextFontScale } = useSelector(selectQuranReaderStyles, shallowEqual);
+  const isQcfFont = isQCFFont(quranFont);
+  const isFontLoaded =
+    !isQcfFont || loadedFonts.includes(`p${words[0].pageNumber}-${quranFont.replace('code_', '')}`);
+  return (
+    <div
+      className={classNames(styles.verseTextContainer, styles.tafsirOrTranslationMode, {
+        [styles[`${quranFont}-font-size-${quranTextFontScale}`]]: quranFont !== QuranFont.Tajweed,
+      })}
+    >
+      <div className={classNames(styles.verseText, styles.verseTextWrap)}>
+        {words?.map((word) => {
+          if (isQcfFont) {
+            return (
+              <GlyphWord
+                key={word.location}
+                font={quranFont}
+                qpcUthmaniHafs={word.qpcUthmaniHafs}
+                pageNumber={word.pageNumber}
+                textCodeV1={word.codeV1}
+                textCodeV2={word.codeV2}
+                isFontLoaded={isFontLoaded}
+              />
+            );
+          }
+          if (quranFont === QuranFont.Tajweed) {
+            return <TajweedWord key={word.location} path={word.text} alt={word.textUthmani} />;
+          }
+          return (
+            <TextWord
+              key={word.location}
+              font={quranFont}
+              text={word.text}
+              charType={word.charTypeName}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PlainVerseText;


### PR DESCRIPTION
### Summary
This PR adds a component that only shows the verse text without the extra functionalities for specific scenarios e.g. ayah highlighting when audio is playing or showing a tooltip when hovering over a verse or showing the word by word translation/transliteration.