### PR TITLE
Fix BackIcon color

### DIFF
--- a/public/icons/west.svg
+++ b/public/icons/west.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 19L10.41 17.59L5.83 13H22V11H5.83L10.42 6.41L9 5L2 12L9 19Z" fill="#323232"/>
+<path d="M9 19L10.41 17.59L5.83 13H22V11H5.83L10.42 6.41L9 5L2 12L9 19Z" fill="var(--color-text-default)"/>
 </svg>


### PR DESCRIPTION
### Summary

Fix `BackIcon (west.svg)` color

### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/58295120/151369115-ec473c3b-7840-476b-beb2-34c7a1dff53e.png) | ![image](https://user-images.githubusercontent.com/58295120/151369150-3d58f4f2-baac-4304-92f9-72344edd6938.png) |