### PR TITLE
fix: back icon color

### DIFF
--- a/public/icons/west.svg
+++ b/public/icons/west.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9 19L10.41 17.59L5.83 13H22V11H5.83L10.42 6.41L9 5L2 12L9 19Z" fill="#323232"/>
+<path d="M9 19L10.41 17.59L5.83 13H22V11H5.83L10.42 6.41L9 5L2 12L9 19Z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/12745166/151503268-b1cedb3c-1fe0-42be-8747-e3f6c13cfe4f.png)


After
![image](https://user-images.githubusercontent.com/12745166/151503206-b7b2c29c-3d83-448b-8a1e-6ac48f24bca3.png)

