### PR TITLE
use DLS radio group in reciter settings

### DIFF
--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.module.scss
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.module.scss
@@ -3,9 +3,10 @@
   display: flex;
   align-items: center;
   font-size: var(--font-size-large);
-  & > input {
-    margin-inline-end: var(--spacing-small);
-  }
+}
+
+.reciterLabel {
+  padding-inline-start: var(--spacing-small);
 }
 
 $recitation-padding: calc(0.5 * var(--spacing-xxsmall));

--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
@@ -70,40 +70,32 @@ const SettingsReciter = () => {
           const filteredReciters = searchQuery
             ? filterReciters(data.reciters, searchQuery)
             : data.reciters;
-          return (
-            <RadioGroup
-              value={selectedReciter.id.toString()}
-              orientation={RadioGroupOrientation.Vertical}
-              label="reciter"
-              onChange={(newId) => onSelectedReciterChange(newId, data.reciters)}
-              items={filteredReciters
-                .sort((a, b) => (a.name > b.name ? 1 : -1))
-                .map((reciter) => ({
-                  value: reciter.id.toString(),
-                  id: reciter.id.toString(),
-                  label:
-                    reciter.style.name !== DEFAULT_RECITATION_STYLE
-                      ? `${reciter.translatedName.name}/${reciter.style.name}`
-                      : reciter.translatedName.name,
-                }))}
-              renderItem={(item) => {
-                const [reciterName, reciterStyle] = item.label.split('/');
 
-                return (
-                  <div className={styles.reciter} key={item.id}>
-                    <RadioGroup.Item value={item.value} id={item.id}>
-                      <RadioGroup.Indicator />
-                    </RadioGroup.Item>
-                    <label htmlFor={item.id} className={styles.reciterLabel}>
-                      {reciterName}
-                      {reciterStyle && (
-                        <span className={styles.recitationStyle}>{reciterStyle}</span>
-                      )}
-                    </label>
-                  </div>
-                );
-              }}
-            />
+          return (
+            <RadioGroup.Root
+              label="reciter"
+              orientation={RadioGroupOrientation.Vertical}
+              value={selectedReciter.id.toString()}
+              onChange={(newId) => onSelectedReciterChange(newId, data.reciters)}
+            >
+              {filteredReciters
+                .sort((a, b) => (a.name > b.name ? 1 : -1))
+                .map((reciter) => {
+                  const reciterId = reciter.id.toString();
+                  return (
+                    <div className={styles.reciter} key={reciterId}>
+                      <RadioGroup.Item value={reciterId} id={reciterId} />
+
+                      <label htmlFor={reciterId} className={styles.reciterLabel}>
+                        {reciter.translatedName.name}
+                        {reciter.style.name !== DEFAULT_RECITATION_STYLE && (
+                          <span className={styles.recitationStyle}>{reciter.style.name}</span>
+                        )}
+                      </label>
+                    </div>
+                  );
+                })}
+            </RadioGroup.Root>
           );
         }}
       />

--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
@@ -11,6 +11,7 @@ import styles from './ReciterSelectionBody.module.scss';
 
 import DataFetcher from 'src/components/DataFetcher';
 import Input from 'src/components/dls/Forms/Input';
+import RadioGroup, { RadioGroupOrientation } from 'src/components/dls/Forms/RadioGroup/RadioGroup';
 import { selectReciter, setReciterAndPauseAudio } from 'src/redux/slices/AudioPlayer/state';
 import { makeAvailableRecitersUrl } from 'src/utils/apiPaths';
 import { logEmptySearchResults, logItemSelectionChange } from 'src/utils/eventLogger';
@@ -70,34 +71,39 @@ const SettingsReciter = () => {
             ? filterReciters(data.reciters, searchQuery)
             : data.reciters;
           return (
-            <div>
-              {filteredReciters
+            <RadioGroup
+              value={selectedReciter.id.toString()}
+              orientation={RadioGroupOrientation.Vertical}
+              label="reciter"
+              onChange={(newId) => onSelectedReciterChange(newId, data.reciters)}
+              items={filteredReciters
                 .sort((a, b) => (a.name > b.name ? 1 : -1))
-                .map((reciter) => (
-                  <label
-                    className={styles.reciter}
-                    htmlFor={reciter.id.toString()}
-                    key={reciter.id}
-                  >
-                    <input
-                      id={reciter.id.toString()}
-                      type="radio"
-                      name="reciter"
-                      value={reciter.id}
-                      checked={reciter.id === selectedReciter.id}
-                      onChange={(e) => {
-                        onSelectedReciterChange(e.target.value, data.reciters);
-                      }}
-                    />
-                    <span lang={reciter.translatedName.languageName}>
-                      {reciter.translatedName.name}
-                    </span>
-                    {reciter.style.name !== DEFAULT_RECITATION_STYLE && (
-                      <span className={styles.recitationStyle}>{reciter.style.name}</span>
-                    )}
-                  </label>
-                ))}
-            </div>
+                .map((reciter) => ({
+                  value: reciter.id.toString(),
+                  id: reciter.id.toString(),
+                  label:
+                    reciter.style.name !== DEFAULT_RECITATION_STYLE
+                      ? `${reciter.translatedName.name}/${reciter.style.name}`
+                      : reciter.translatedName.name,
+                }))}
+              renderItem={(item) => {
+                const [reciterName, reciterStyle] = item.label.split('/');
+
+                return (
+                  <div className={styles.reciter} key={item.id}>
+                    <RadioGroup.Item value={item.value} id={item.id}>
+                      <RadioGroup.Indicator />
+                    </RadioGroup.Item>
+                    <label htmlFor={item.id} className={styles.reciterLabel}>
+                      {reciterName}
+                      {reciterStyle && (
+                        <span className={styles.recitationStyle}>{reciterStyle}</span>
+                      )}
+                    </label>
+                  </div>
+                );
+              }}
+            />
           );
         }}
       />

--- a/src/components/dls/Forms/RadioGroup/Item.module.scss
+++ b/src/components/dls/Forms/RadioGroup/Item.module.scss
@@ -1,0 +1,52 @@
+.indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  &:after {
+    content: "";
+    display: block;
+    width: var(--spacing-xsmall);
+    height: var(--spacing-xsmall);
+    border-radius: var(--border-radius-circle);
+    background-color: black;
+  }
+}
+
+.indicator[data-state="checked"][data-disabled] {
+  &:after {
+    background-color: var(--color-secondary-medium);
+  }
+}
+
+.radioItem {
+  all: unset;
+  background-color: var(--color-primary-faded);
+  width: var(--spacing-medium);
+  height: var(--spacing-medium);
+  border-radius: var(--border-radius-circle);
+  border: 1px solid var(--color-secondary-medium);
+}
+
+.radioItem:not([data-disabled]) {
+  &:hover {
+    cursor: pointer;
+    border: 1px solid var(--color-primary-medium);
+  }
+}
+
+.radioItem[data-state="checked"] {
+  border: 1px solid var(--color-primary-medium);
+}
+
+.radioItem[data-state="checked"][data-disabled] {
+  border: 1px solid var(--color-secondary-medium);
+}
+
+.radioItem[data-focus-visible-added] {
+  &:focus {
+    box-shadow: var(--shadow-small);
+  }
+}

--- a/src/components/dls/Forms/RadioGroup/Item.tsx
+++ b/src/components/dls/Forms/RadioGroup/Item.tsx
@@ -1,0 +1,16 @@
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import classNames from 'classnames';
+
+import styles from './Item.module.scss';
+
+interface Props extends RadioGroupPrimitive.RadioGroupItemProps {
+  indicatorClassName?: string;
+}
+
+const Item = ({ className, indicatorClassName, ...props }: Props) => (
+  <RadioGroupPrimitive.Item className={classNames(styles.radioItem, className)} {...props}>
+    <RadioGroupPrimitive.Indicator className={classNames(styles.indicator, indicatorClassName)} />
+  </RadioGroupPrimitive.Item>
+);
+
+export default Item;

--- a/src/components/dls/Forms/RadioGroup/RadioGroup.module.scss
+++ b/src/components/dls/Forms/RadioGroup/RadioGroup.module.scss
@@ -1,38 +1,3 @@
-.container {
-  margin-block-start: var(--spacing-micro);
-  margin-inline-end: var(--spacing-micro);
-  margin-block-end: var(--spacing-micro);
-  margin-inline-start: var(--spacing-micro);
-}
-.container[data-orientation="horizontal"] {
-  align-items: center;
-  justify-content: space-between;
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  position: relative;
-  &:after {
-    content: "";
-    display: block;
-    width: var(--spacing-xsmall);
-    height: var(--spacing-xsmall);
-    border-radius: var(--border-radius-circle);
-    background-color: black;
-  }
-}
-.indicator[data-state="checked"][data-disabled] {
-  &:after {
-    background-color: var(--color-secondary-medium);
-  }
-}
-
 .radioItemContainer {
   display: flex;
   align-items: center;
@@ -40,32 +5,6 @@
   margin-block-end: var(--spacing-micro);
   margin-inline-start: 0;
   margin-inline-end: 0;
-}
-
-.radioItem {
-  all: unset;
-  background-color: var(--color-primary-faded);
-  width: var(--spacing-medium);
-  height: var(--spacing-medium);
-  border-radius: var(--border-radius-circle);
-  border: 1px solid var(--color-secondary-medium);
-}
-.radioItem:not([data-disabled]) {
-  &:hover {
-    cursor: pointer;
-    border: 1px solid var(--color-primary-medium);
-  }
-}
-.radioItem[data-state="checked"] {
-  border: 1px solid var(--color-primary-medium);
-}
-.radioItem[data-state="checked"][data-disabled] {
-  border: 1px solid var(--color-secondary-medium);
-}
-.radioItem[data-focus-visible-added] {
-  &:focus {
-    box-shadow: var(--shadow-small);
-  }
 }
 
 .label {

--- a/src/components/dls/Forms/RadioGroup/RadioGroup.tsx
+++ b/src/components/dls/Forms/RadioGroup/RadioGroup.tsx
@@ -32,7 +32,7 @@ interface Props {
   required?: boolean;
   loop?: boolean;
   orientation?: RadioGroupOrientation;
-  renderItem: (item: RadioItem) => React.ReactNode;
+  renderItem?: (item: RadioItem) => React.ReactNode;
 }
 
 const RadioGroup: React.FC<Props> & {

--- a/src/components/dls/Forms/RadioGroup/RadioGroup.tsx
+++ b/src/components/dls/Forms/RadioGroup/RadioGroup.tsx
@@ -32,9 +32,13 @@ interface Props {
   required?: boolean;
   loop?: boolean;
   orientation?: RadioGroupOrientation;
+  renderItem: (item: RadioItem) => React.ReactNode;
 }
 
-const RadioGroup: React.FC<Props> = ({
+const RadioGroup: React.FC<Props> & {
+  Item: (props: RadioGroupPrimitive.RadioGroupItemProps) => React.ReactElement;
+  Indicator: (props: RadioGroupPrimitive.RadioIndicatorProps) => React.ReactElement;
+} = ({
   items,
   label,
   onChange,
@@ -44,6 +48,7 @@ const RadioGroup: React.FC<Props> = ({
   required,
   disabled = false,
   orientation = RadioGroupOrientation.Vertical,
+  renderItem,
 }) => {
   const direction = useDirection();
 
@@ -60,6 +65,8 @@ const RadioGroup: React.FC<Props> = ({
       {...(required && { required })}
     >
       {items.map((item) => {
+        if (renderItem) return renderItem(item);
+
         const isDisabled = disabled === true || item.disabled === true;
         return (
           <div className={styles.radioItemContainer} key={item.id}>
@@ -84,5 +91,15 @@ const RadioGroup: React.FC<Props> = ({
     </RadioGroupPrimitive.Root>
   );
 };
+
+// eslint-disable-next-line react/no-multi-comp
+RadioGroup.Item = ({ className, ...props }) => (
+  <RadioGroupPrimitive.Item className={classNames(styles.radioItem, className)} {...props} />
+);
+
+// eslint-disable-next-line react/no-multi-comp
+RadioGroup.Indicator = ({ className, ...props }) => (
+  <RadioGroupPrimitive.Indicator className={classNames(styles.indicator, className)} {...props} />
+);
 
 export default RadioGroup;

--- a/src/components/dls/Forms/RadioGroup/RadioGroup.tsx
+++ b/src/components/dls/Forms/RadioGroup/RadioGroup.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 
-import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import classNames from 'classnames';
 
+import Item from './Item';
 import styles from './RadioGroup.module.scss';
-
-import useDirection from 'src/hooks/useDirection';
-import { Direction } from 'src/utils/locale';
+import Root, { Props as RootProps } from './Root';
 
 export interface RadioItem {
   value: string;
@@ -16,69 +14,25 @@ export interface RadioItem {
   required?: boolean;
 }
 
-export enum RadioGroupOrientation {
-  Horizontal = 'horizontal',
-  Vertical = 'vertical',
-}
-
-interface Props {
+interface Props extends RootProps {
   items: RadioItem[];
-  label: string;
-  defaultValue?: string;
-  onChange?: (value: string) => void;
   disabled?: boolean;
-  value?: string;
-  name?: string;
-  required?: boolean;
-  loop?: boolean;
-  orientation?: RadioGroupOrientation;
-  renderItem?: (item: RadioItem) => React.ReactNode;
 }
 
-const RadioGroup: React.FC<Props> & {
-  Item: (props: RadioGroupPrimitive.RadioGroupItemProps) => React.ReactElement;
-  Indicator: (props: RadioGroupPrimitive.RadioIndicatorProps) => React.ReactElement;
-} = ({
-  items,
-  label,
-  onChange,
-  defaultValue,
-  value,
-  name,
-  required,
-  disabled = false,
-  orientation = RadioGroupOrientation.Vertical,
-  renderItem,
-}) => {
-  const direction = useDirection();
-
+const RadioGroup = ({ items, disabled = false, ...props }: Props) => {
   return (
-    <RadioGroupPrimitive.Root
-      className={styles.container}
-      dir={direction as Direction}
-      aria-label={label}
-      orientation={orientation}
-      {...(onChange && { onValueChange: onChange })}
-      {...(defaultValue && { defaultValue })}
-      {...(value && { value })}
-      {...(name && { name })}
-      {...(required && { required })}
-    >
+    <Root {...props}>
       {items.map((item) => {
-        if (renderItem) return renderItem(item);
-
         const isDisabled = disabled === true || item.disabled === true;
         return (
           <div className={styles.radioItemContainer} key={item.id}>
-            <RadioGroupPrimitive.Item
+            <Item
               value={item.value}
               id={item.id}
-              className={styles.radioItem}
               disabled={isDisabled}
               required={item.required || false}
-            >
-              <RadioGroupPrimitive.Indicator className={styles.indicator} />
-            </RadioGroupPrimitive.Item>
+            />
+
             <label
               htmlFor={item.id}
               className={classNames(styles.label, { [styles.disabled]: isDisabled })}
@@ -88,18 +42,14 @@ const RadioGroup: React.FC<Props> & {
           </div>
         );
       })}
-    </RadioGroupPrimitive.Root>
+    </Root>
   );
 };
 
-// eslint-disable-next-line react/no-multi-comp
-RadioGroup.Item = ({ className, ...props }) => (
-  <RadioGroupPrimitive.Item className={classNames(styles.radioItem, className)} {...props} />
-);
+RadioGroup.Root = Root;
+RadioGroup.Item = Item;
 
-// eslint-disable-next-line react/no-multi-comp
-RadioGroup.Indicator = ({ className, ...props }) => (
-  <RadioGroupPrimitive.Indicator className={classNames(styles.indicator, className)} {...props} />
-);
+// export `RadioGroupOrientation` type from here so that files that are using it don't break
+export { RadioRootOrientation as RadioGroupOrientation } from './Root';
 
 export default RadioGroup;

--- a/src/components/dls/Forms/RadioGroup/Root.module.scss
+++ b/src/components/dls/Forms/RadioGroup/Root.module.scss
@@ -1,0 +1,13 @@
+.container {
+  margin-block-start: var(--spacing-micro);
+  margin-inline-end: var(--spacing-micro);
+  margin-block-end: var(--spacing-micro);
+  margin-inline-start: var(--spacing-micro);
+}
+
+.container[data-orientation="horizontal"] {
+  align-items: center;
+  justify-content: space-between;
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/src/components/dls/Forms/RadioGroup/Root.tsx
+++ b/src/components/dls/Forms/RadioGroup/Root.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import classNames from 'classnames';
+
+import styles from './Root.module.scss';
+
+import useDirection from 'src/hooks/useDirection';
+import { Direction } from 'src/utils/locale';
+
+export enum RadioRootOrientation {
+  Horizontal = 'horizontal',
+  Vertical = 'vertical',
+}
+
+export interface Props {
+  orientation?: RadioRootOrientation;
+  label: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  value?: string;
+  name?: string;
+  required?: boolean;
+  className?: string;
+}
+
+const Root: React.FC<Props> = ({
+  className,
+  label,
+  orientation = RadioRootOrientation.Vertical,
+  onChange,
+  defaultValue,
+  value,
+  name,
+  required,
+  children,
+}) => {
+  const direction = useDirection();
+
+  return (
+    <RadioGroupPrimitive.Root
+      className={classNames(styles.container, className)}
+      dir={direction as Direction}
+      aria-label={label}
+      orientation={orientation}
+      {...(onChange && { onValueChange: onChange })}
+      {...(defaultValue && { defaultValue })}
+      {...(value && { value })}
+      {...(name && { name })}
+      {...(required && { required })}
+    >
+      {children}
+    </RadioGroupPrimitive.Root>
+  );
+};
+
+export default Root;


### PR DESCRIPTION
### Summary
- use DLS radio group in reciter selection settings
- accept `renderItem` prop in `RadioGroup`
- add `Item` & `Indicator` components in `RadioGroup` to allow further customization

### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
| <img width="258" alt="image" src="https://user-images.githubusercontent.com/58295120/151602040-23f3b828-ad10-4d23-80de-fb492cd02914.png"> | <img width="254" alt="image" src="https://user-images.githubusercontent.com/58295120/151602080-5d654880-d71a-4cc7-847e-e7d63dc3a346.png"> |