### PR TITLE
Open reading view verse menu on long press on mobile

### DIFF
--- a/src/components/QuranReader/ReadingView/WordPopover/WordPopover.module.scss
+++ b/src/components/QuranReader/ReadingView/WordPopover/WordPopover.module.scss
@@ -1,4 +1,5 @@
 @use "src/styles/theme";
+@use "src/styles/breakpoints";
 
 $black: #000;
 $white: #fff;
@@ -22,5 +23,13 @@ $white: #fff;
     @include theme.dark {
       fill: $white;
     }
+  }
+}
+
+.trigger {
+  @include breakpoints.smallerThanTablet {
+    // disable word selecting when on mobile so that we can show the popover on long tap.
+    -webkit-touch-callout: none;
+    user-select: none;
   }
 }

--- a/src/components/QuranReader/ReadingView/WordPopover/index.tsx
+++ b/src/components/QuranReader/ReadingView/WordPopover/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { useDispatch } from 'react-redux';
 
@@ -7,6 +7,7 @@ import ReadingViewWordActionsMenu from '../WordActionsMenu';
 import styles from './WordPopover.module.scss';
 
 import Popover, { ContentSide } from 'src/components/dls/Popover';
+import useLongPress from 'src/hooks/useLongPress';
 import {
   setReadingViewSelectedVerseKey,
   setReadingViewHoveredVerseKey,
@@ -32,6 +33,10 @@ const ReadingViewWordPopover: React.FC<Props> = ({ word, children }) => {
     [dispatch, word.verseKey],
   );
 
+  const onLongPress = useCallback(() => {
+    onOpenChange(true);
+  }, [onOpenChange]);
+  const [onStart, onEnd] = useLongPress(onLongPress, 1000);
   const onHoverChange = (isHovering: boolean) => {
     dispatch(setReadingViewHoveredVerseKey(isHovering ? word.verseKey : null));
   };
@@ -52,6 +57,8 @@ const ReadingViewWordPopover: React.FC<Props> = ({ word, children }) => {
           onMouseLeave={() => {
             onHoverChange(false);
           }}
+          onTouchStart={onStart}
+          onTouchEnd={onEnd}
         >
           {children}
         </div>
@@ -62,6 +69,7 @@ const ReadingViewWordPopover: React.FC<Props> = ({ word, children }) => {
       contentStyles={styles.content}
       open={isTooltipOpened}
       onOpenChange={onOpenChange}
+      triggerStyles={styles.trigger}
     >
       <ReadingViewWordActionsMenu word={word} onActionTriggered={onActionTriggered} />
     </Popover>

--- a/src/components/QuranReader/ReadingView/WordPopover/index.tsx
+++ b/src/components/QuranReader/ReadingView/WordPopover/index.tsx
@@ -36,7 +36,7 @@ const ReadingViewWordPopover: React.FC<Props> = ({ word, children }) => {
   const onLongPress = useCallback(() => {
     onOpenChange(true);
   }, [onOpenChange]);
-  const [onStart, onEnd] = useLongPress(onLongPress, 1000);
+  const [onStart, onEnd] = useLongPress(onLongPress);
   const onHoverChange = (isHovering: boolean) => {
     dispatch(setReadingViewHoveredVerseKey(isHovering ? word.verseKey : null));
   };

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,53 @@
+import { useCallback, useRef } from 'react';
+
+const DEFAULT_DURATION = 300;
+
+/**
+ * A hook that listens to long press action on mobile devices.
+ * inspired by {@link https://stackoverflow.com/questions/48048957/react-long-press-event}
+ *
+ * @param {()=> void} callback
+ * @param {number} duration
+ * @returns {[() => void, () => void, () => void]}
+ */
+const useLongPress = (
+  // callback that is invoked at the specified duration or `onEndLongPress`
+  callback: () => void,
+  // long press duration in milliseconds
+  duration: number = DEFAULT_DURATION,
+): [() => void, () => void, () => void] => {
+  // used to persist the timer state
+  // non zero values means the value has never been fired before
+  const timerRef = useRef<number>(0);
+
+  // clear timed callback
+  const endTimer = () => {
+    clearTimeout(timerRef.current || 0);
+    timerRef.current = 0;
+  };
+
+  // init timer
+  const onStartLongPress = useCallback(() => {
+    // stop any previously set timers
+    endTimer();
+
+    // set new timeout
+    timerRef.current = window.setTimeout(() => {
+      callback();
+      endTimer();
+    }, duration);
+  }, [callback, duration]);
+
+  // determine to end timer early and invoke the callback or do nothing
+  const onEndLongPress = useCallback(() => {
+    // run the callback fn the timer hasn't gone off yet (non zero)
+    if (timerRef.current) {
+      endTimer();
+      callback();
+    }
+  }, [callback]);
+
+  return [onStartLongPress, onEndLongPress, endTimer];
+};
+
+export default useLongPress;


### PR DESCRIPTION
### Summary
This PR makes it possible to open the verse actions menu for the reading view on mobile when the user long presses a word.