### PR TITLE
Fix: Hghlight currently selected theme on footer theme switcher

### DIFF
--- a/src/components/dls/Footer/FooterThemeSwitcher.tsx
+++ b/src/components/dls/Footer/FooterThemeSwitcher.tsx
@@ -12,7 +12,7 @@ import { selectTheme, setTheme } from 'src/redux/slices/theme';
 import ThemeType from 'src/redux/types/ThemeType';
 
 const FooterThemeSwitcher = () => {
-  const { lang, t } = useTranslation('common');
+  const { t } = useTranslation('common');
   const dispatch = useDispatch();
 
   const theme = useSelector(selectTheme, shallowEqual);
@@ -42,7 +42,7 @@ const FooterThemeSwitcher = () => {
     >
       {themes.map((option) => (
         <PopoverMenu.Item
-          isSelected={option.value === lang}
+          isSelected={option.value === theme.type}
           shouldCloseMenuAfterClick
           key={option.value}
           onClick={() => dispatch({ type: setTheme.type, payload: option.value })}


### PR DESCRIPTION
### Summary

This PR resolves #1165 by highlighting the active theme on the footer theme switcher

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="760" alt="Screen Shot 2022-01-29 at 7 44 02 PM" src="https://user-images.githubusercontent.com/39024901/151669808-207c5bc7-879d-49f4-b73e-c37e1e2743c8.png"> | <img width="938" alt="Screen Shot 2022-01-29 at 7 51 31 PM" src="https://user-images.githubusercontent.com/39024901/151669826-da83a999-99d0-4e58-a6d9-1cd5f3143f4e.png">|