### PR TITLE
Fix: Send Mushaf ID to Tafseers API

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,7 @@
 import { camelizeKeys } from 'humps';
 
+import { getQuranReaderStylesInitialState } from './redux/defaultSettings/util';
+import { getDefaultWordFields, getMushafId } from './utils/api';
 import {
   makeAdvancedCopyUrl,
   makeTafsirsUrl,
@@ -17,6 +19,7 @@ import {
   makeFootnoteUrl,
   makeChapterUrl,
   makeReciterUrl,
+  makeTafsirContentUrl,
 } from './utils/apiPaths';
 
 import { SearchRequest, AdvancedCopyRequest } from 'types/ApiRequests';
@@ -34,6 +37,7 @@ import {
   FootnoteResponse,
   ChapterResponse,
   ReciterResponse,
+  TafsirContentResponse,
 } from 'types/ApiResponses';
 import AudioData from 'types/AudioData';
 
@@ -260,6 +264,17 @@ export const getChapterIdBySlug = async (slug: string, locale: string): Promise<
   } catch (error) {
     return false;
   }
+};
+
+export const getTafsirContent = (tafsirIdOrSlug: string, verseKey: string, locale: string) => {
+  const quranStyle = getQuranReaderStylesInitialState(locale);
+  return fetcher<TafsirContentResponse>(
+    makeTafsirContentUrl(tafsirIdOrSlug as string, verseKey, {
+      words: true,
+      ...getDefaultWordFields(),
+      ...getMushafId(quranStyle.quranFont, quranStyle.mushafLines),
+    }),
+  );
 };
 
 export const getImageCDNPath = (path: string) => `https://static.qurancdn.com/images/${path}`;

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -22,7 +22,7 @@ import PlainVerseText from 'src/components/Verse/PlainVerseText';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import QuranReaderStyles from 'src/redux/types/QuranReaderStyles';
-import { getDefaultWordFields } from 'src/utils/api';
+import { getDefaultWordFields, getMushafId } from 'src/utils/api';
 import { makeTafsirContentUrl, makeTafsirsUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import {
@@ -35,6 +35,7 @@ import { getLanguageDataById } from 'src/utils/locale';
 import { fakeNavigate, getVerseSelectedTafsirNavigationUrl } from 'src/utils/navigation';
 import { getFirstAndLastVerseKeys, getVerseWords, makeVerseKey } from 'src/utils/verse';
 import { TafsirContentResponse, TafsirsResponse } from 'types/ApiResponses';
+import { QuranFont } from 'types/QuranReader';
 import Tafsir from 'types/Tafsir';
 import Verse from 'types/Verse';
 
@@ -159,18 +160,26 @@ const TafsirBody = ({
   const tafsirContentQueryKey = makeTafsirContentUrl(selectedTafsirIdOrSlug, selectedVerseKey, {
     words: true,
     ...getDefaultWordFields(quranReaderStyles.quranFont),
+    ...getMushafId(quranReaderStyles.quranFont),
   });
 
   // Whether we should use the initial tafsir data or fetch the data on the client side
   const shouldUseInitialTafsirData = useMemo(
     () =>
       (initialTafsirData &&
+        quranReaderStyles.quranFont === QuranFont.QPCHafs &&
         Object.keys(initialTafsirData.tafsir.verses).includes(
           makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber)),
         ) &&
         selectedTafsirIdOrSlug === initialTafsirData?.tafsir?.slug) ||
       Number(selectedTafsirIdOrSlug) === initialTafsirData?.tafsir?.resourceId,
-    [initialTafsirData, selectedChapterId, selectedTafsirIdOrSlug, selectedVerseNumber],
+    [
+      initialTafsirData,
+      quranReaderStyles.quranFont,
+      selectedChapterId,
+      selectedTafsirIdOrSlug,
+      selectedVerseNumber,
+    ],
   );
 
   const surahAndAyahSelection = (

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -19,6 +19,7 @@ import { fetcher } from 'src/api';
 import DataFetcher from 'src/components/DataFetcher';
 import Separator from 'src/components/dls/Separator/Separator';
 import PlainVerseText from 'src/components/Verse/PlainVerseText';
+import { getQuranReaderStylesInitialState } from 'src/redux/defaultSettings/util';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import QuranReaderStyles from 'src/redux/types/QuranReaderStyles';
@@ -35,7 +36,6 @@ import { getLanguageDataById } from 'src/utils/locale';
 import { fakeNavigate, getVerseSelectedTafsirNavigationUrl } from 'src/utils/navigation';
 import { getFirstAndLastVerseKeys, getVerseWords, makeVerseKey } from 'src/utils/verse';
 import { TafsirContentResponse, TafsirsResponse } from 'types/ApiResponses';
-import { QuranFont } from 'types/QuranReader';
 import Tafsir from 'types/Tafsir';
 import Verse from 'types/Verse';
 
@@ -160,14 +160,14 @@ const TafsirBody = ({
   const tafsirContentQueryKey = makeTafsirContentUrl(selectedTafsirIdOrSlug, selectedVerseKey, {
     words: true,
     ...getDefaultWordFields(quranReaderStyles.quranFont),
-    ...getMushafId(quranReaderStyles.quranFont),
+    ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
   });
 
   // Whether we should use the initial tafsir data or fetch the data on the client side
   const shouldUseInitialTafsirData = useMemo(
     () =>
       (initialTafsirData &&
-        quranReaderStyles.quranFont === QuranFont.QPCHafs &&
+        quranReaderStyles.quranFont === getQuranReaderStylesInitialState(lang).quranFont &&
         Object.keys(initialTafsirData.tafsir.verses).includes(
           makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber)),
         ) &&
@@ -179,6 +179,7 @@ const TafsirBody = ({
       selectedChapterId,
       selectedTafsirIdOrSlug,
       selectedVerseNumber,
+      lang,
     ],
   );
 

--- a/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
+++ b/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
@@ -5,12 +5,10 @@ import useTranslation from 'next-translate/useTranslation';
 
 import styles from '../[verseId]/tafsirs.module.scss';
 
-import { fetcher } from 'src/api';
+import { getTafsirContent } from 'src/api';
 import NextSeoWrapper from 'src/components/NextSeoWrapper';
 import TafsirBody from 'src/components/QuranReader/TafsirView/TafsirBody';
 import Error from 'src/pages/_error';
-import { getDefaultWordFields } from 'src/utils/api';
-import { makeTafsirContentUrl } from 'src/utils/apiPaths';
 import { getChapterData } from 'src/utils/chapter';
 import { toLocalizedNumber } from 'src/utils/locale';
 import { scrollWindowToTop } from 'src/utils/navigation';
@@ -83,13 +81,7 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
   }
   const [chapterNumber, verseNumber] = getVerseAndChapterNumbersFromKey(verseKey);
   try {
-    const tafsirData = await fetcher<TafsirContentResponse>(
-      makeTafsirContentUrl(tafsirIdOrSlug as string, verseKey, {
-        words: true,
-        ...getDefaultWordFields(),
-      }),
-    );
-
+    const tafsirData = await getTafsirContent(tafsirIdOrSlug as string, verseKey, locale);
     return {
       props: {
         chapterId: chapterNumber,


### PR DESCRIPTION
### Summary

This PR resolves #1066. On tafsirs modal / page when the user has selected tajweed Quran font tafsirs were not getting rendered since `Mushaf ID` was not sent to the tafsirs API. 

I have also added a second condition to `shouldUseInitialTafsirData` variable where it needs to be on default font to be true. This is because when rendering the tafsir with `initialTafsirData` means that we are using data `getStaticProps` which is from SSR and this will not work if user has changed their font preference from the default since we are persisting the preference data on the browser's local storage.

### Screenshots

| Before | After |
| ------ | ------ |
| ![Tafsir-Surah-Al-Fatihah-1-Quran-com](https://user-images.githubusercontent.com/39024901/151719290-740738b5-ade3-41ab-a7bc-44aa6d22d023.png) |  ![Tafsir-Surah-Ali-Imran-1-Quran-com](https://user-images.githubusercontent.com/39024901/151719348-7beeab73-9d54-4949-be2d-a7fa0d734dfd.png) |