### PR TITLE
fix: reciter image aspect ratio

### DIFF
--- a/src/components/Reciter/ReciterInfo.module.scss
+++ b/src/components/Reciter/ReciterInfo.module.scss
@@ -15,6 +15,8 @@
   position: absolute;
   height: 100%;
   width: 100%;
+  aspect-ratio: 1/1;
+  object-fit: cover;
 }
 
 .reciterBio {


### PR DESCRIPTION
Before
<img width="173" alt="image" src="https://user-images.githubusercontent.com/12745166/151941153-1d153aec-55b8-4bd3-bf15-0d376654060e.png">


After
<img width="251" alt="image" src="https://user-images.githubusercontent.com/12745166/151941099-89ed7969-d79a-4cb2-b3dc-dd3d730dfd2b.png">
