### PR TITLE
fix: radio station name not found on pages other than "home"

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -2,7 +2,7 @@
   "locales": ["en", "ar", "bn", "fa", "fr", "id", "it", "nl", "pt", "ru", "sq", "th", "tr", "ur", "zh", "ms"],
   "defaultLocale": "en",
   "pages": {
-    "*": ["common", "error"],
+    "*": ["common", "error", "radio"],
     "/": ["home", "quick-links", "radio"],
     "/[chapterId]": ["quran-reader", "chapter", "surah-info"],
     "/[chapterId]/[verseId]": ["quran-reader"],


### PR DESCRIPTION
Fixing this issue basically 😁
<img width="1361" alt="image" src="https://user-images.githubusercontent.com/12745166/152639466-f8d2e377-a60c-4f98-a275-f0dd979ea3ef.png">
