### PR TITLE
replace Noto Urdu with Mehr nastaleeq

### DIFF
--- a/src/components/Fonts/FontPreLoader.tsx
+++ b/src/components/Fonts/FontPreLoader.tsx
@@ -10,7 +10,7 @@ const LOCALE_PRELOADED_FONTS = {
   [DEFAULT_LOCALE]: [{ type: 'font/woff2', location: 'lang/ProximaVara/ProximaVara.woff2' }],
   ar: [{ type: 'font/woff2', location: 'lang/arabic/NotoNaskhArabic-Regular.woff2' }],
   bn: [{ type: 'font/ttf', location: 'lang/bengali/NotoSerifBengali-Regular.woff2' }],
-  ur: [{ type: 'font/woff2', location: 'lang/urdu/notonastaliqurdu.woff2' }],
+  ur: [{ type: 'font/woff2', location: 'lang/urdu/MehrNastaliqWeb.woff2' }],
 } as Record<string, { type: string; location: string }[]>;
 
 interface Props {

--- a/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
@@ -30,12 +30,12 @@ $translation-line-height: 1.5;
 }
 
 .urdu {
-  font-family: "NotoNastaliqUrdu", "Noto Nastaliq Urdu", "Noto Nastaliq Arabic",
-    "Helvetica Neue", Helvetica, Arial !important; // important is needed to over-ride the language specific font-family
+  font-family: "MehrNastaliq", "Mehr Nastaliq Web", "Helvetica Neue", Helvetica,
+    Arial, serif !important; // important is needed to over-ride the language specific font-family
 }
 
 .kurdish {
-  font-family: "DroidArabicNaskh", "Noto Nastaliq Arabic", "Noto Nastaliq Urdu" !important; // important is needed to over-ride the language specific font-family
+  font-family: "DroidArabicNaskh", "Noto Nastaliq Arabic", "MehrNastaliq" !important; // important is needed to over-ride the language specific font-family
 }
 
 .divehi {

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -64,11 +64,12 @@ $font-cdn: "https://static.qurancdn.com/fonts";
   font-display: swap;
 }
 
-// Noto Nastaliq Urdu https://fonts.googleapis.com/css2?family=Noto+Nastaliq+Urdu:wght@400&display=swap
 @font-face {
-  font-family: "NotoNastaliqUrdu";
-  src: local("Noto Nastaliq Urdu"), local("Nafees Regular"),
-    url("#{$font-cdn}/lang/urdu/notonastaliqurdu.woff2");
+  font-family: "MehrNastaliq";
+  src: local("Mehr Nastaliq Web"),
+    url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.woff2"),
+    url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.woff") format("woff"),
+    url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -24,8 +24,8 @@ body {
   :lang(urdu),
   .ur,
   .urdu {
-    font-family: "NotoNastaliqUrdu", "Noto Nastaliq Urdu",
-      "Noto Nastaliq Arabic", "ProximaVara", "Helvetica Neue", Helvetica, Arial;
+    font-family: "MehrNastaliq", "Mehr Nastaliq Web", "Helvetica Neue",
+      Helvetica, Arial, serif;
   }
 
   :lang(ar),


### PR DESCRIPTION
### Summary

Both noto and Mehr look the same, but Mehr has fixed "line-height" issues and has tashkeel rendering support.

### Screenshots
Mehr on top, bottom text is Noto. You can see lot of text cut off in Noto.
![808d29fb9bd048d5baf3d69f62f911e0](https://user-images.githubusercontent.com/701567/152673543-ff02c633-8fe1-4ab8-8d68-1d9a21a1b9e8.jpeg)
