### PR TITLE
Fix ReadingView popover's zIndex issue

### DIFF
--- a/src/components/QuranReader/ReadingView/WordActionsMenu/index.tsx
+++ b/src/components/QuranReader/ReadingView/WordActionsMenu/index.tsx
@@ -5,6 +5,7 @@ import ShareVerseButton from '../../TranslationView/ShareVerseButton';
 
 import styles from './WordActionsMenu.module.scss';
 
+import useSetPortalledZIndex from 'src/components/QuranReader/hooks/useSetPortalledZIndex';
 import OverflowVerseActionsMenu from 'src/components/Verse/OverflowVerseActionsMenu';
 import PlayVerseAudioButton from 'src/components/Verse/PlayVerseAudioButton';
 import Word from 'types/Word';
@@ -14,9 +15,17 @@ type Props = {
   onActionTriggered?: () => void;
 };
 
+const DATA_POPOVER_PORTALLED = 'data-popover-menu-portalled';
+
 const ReadingViewWordActionsMenu: React.FC<Props> = ({ word, onActionTriggered }) => {
+  useSetPortalledZIndex(DATA_POPOVER_PORTALLED);
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      {...{
+        [DATA_POPOVER_PORTALLED]: true,
+      }}
+    >
       <ShareVerseButton
         verseKey={word.verseKey}
         isTranslationView={false}

--- a/src/components/QuranReader/hooks/useSetPortalledZIndex.ts
+++ b/src/components/QuranReader/hooks/useSetPortalledZIndex.ts
@@ -1,0 +1,29 @@
+import useBrowserLayoutEffect from 'src/hooks/useBrowserLayoutEffect';
+
+/**
+ * A hook that will run when enabled that will manually set the zIndex of the parent of
+ * a portalled Radix component (e.g. a modal or popover menu) to 1 so that it doesn't
+ * stack on top of a modal since the default behavior of Radix is to set a really high
+ *  value of the zIndex of the container of the portalled component which causes it to
+ * be on always on top of our custom Modal.
+ *
+ * @param {string} querySelectorKey
+ * @param {boolean} isEnabled
+ */
+const useSetPortalledZIndex = (querySelectorKey: string, isEnabled = true) => {
+  useBrowserLayoutEffect(() => {
+    if (isEnabled) {
+      // eslint-disable-next-line i18next/no-literal-string
+      const portalledElement = window.document.querySelector(`[${querySelectorKey}="true"]`);
+      if (portalledElement) {
+        // we need to react a few elements up the tree to get to the container that we want to override its zIndex
+        const radixPortalElement = portalledElement.closest('[data-radix-portal]') as HTMLElement;
+        if (radixPortalElement) {
+          radixPortalElement.style.zIndex = '1';
+        }
+      }
+    }
+  }, [isEnabled, querySelectorKey]);
+};
+
+export default useSetPortalledZIndex;

--- a/src/components/Verse/OverflowVerseActionsMenuBody.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenuBody.tsx
@@ -21,6 +21,7 @@ import VerseActionRepeatAudio from './VerseActionRepeatAudio';
 
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import { ToastStatus, useToast } from 'src/components/dls/Toast/Toast';
+import useSetPortalledZIndex from 'src/components/QuranReader/hooks/useSetPortalledZIndex';
 import useBrowserLayoutEffect from 'src/hooks/useBrowserLayoutEffect';
 import { selectBookmarks, toggleVerseBookmark } from 'src/redux/slices/QuranReader/bookmarks';
 import { logButtonClick } from 'src/utils/eventLogger';
@@ -51,6 +52,7 @@ const OverflowVerseActionsMenuBody: React.FC<Props> = ({
   const [isShared, setIsShared] = useState(false);
   const router = useRouter();
   const toast = useToast();
+  useSetPortalledZIndex(DATA_POPOVER_PORTALLED, isPortalled);
 
   /**
    * A hook that will run once to check if the body is portalled or not and if it is,


### PR DESCRIPTION
### Summary
This PR fixes the ReadingView popover's zIndex issue that was cause the verse actions popover menu to stack on top or Tafsir/Advanced copy modals.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="492" alt="Screen Shot 2022-02-11 at 21 44 06" src="https://user-images.githubusercontent.com/15169499/153613857-042eee2b-75f5-436d-b5af-d75b12f6febf.png">|<img width="493" alt="Screen Shot 2022-02-11 at 21 44 14" src="https://user-images.githubusercontent.com/15169499/153613863-304833bd-f770-4bdd-adae-cfaf018f45b4.png">|