### PR TITLE
fix: debounce search query on main search bar

### DIFF
--- a/src/components/CommandBar/CommandBarBody/index.tsx
+++ b/src/components/CommandBar/CommandBarBody/index.tsx
@@ -7,6 +7,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import IconSearch from '../../../../public/icons/search.svg';
+import useDebounce from '../../../hooks/useDebounce';
 import CommandsList, { Command } from '../CommandsList';
 
 import styles from './CommandBarBody.module.scss';
@@ -49,11 +50,16 @@ const NAVIGATE_TO = [
   },
 ];
 
+const DEBOUNCING_PERIOD_MS = 500;
+
 const CommandBarBody: React.FC = () => {
   const { t, lang } = useTranslation('common');
   const recentNavigations = useSelector(selectRecentNavigations, areArraysEqual);
   const isVoiceSearchFlowStarted = useSelector(selectIsCommandBarVoiceFlowStarted, shallowEqual);
   const [searchQuery, setSearchQuery] = useState<string>(null);
+
+  const debouncedSearchQuery = useDebounce<string>(searchQuery, DEBOUNCING_PERIOD_MS);
+
   /**
    * Handle when the search query is changed.
    *
@@ -182,7 +188,9 @@ const CommandBarBody: React.FC = () => {
           <VoiceSearchBodyContainer isCommandBar />
         ) : (
           <DataFetcher
-            queryKey={searchQuery ? makeSearchResultsUrl({ query: searchQuery }) : null}
+            queryKey={
+              debouncedSearchQuery ? makeSearchResultsUrl({ query: debouncedSearchQuery }) : null
+            }
             render={dataFetcherRender}
           />
         )}


### PR DESCRIPTION
### Summary
This PR addresses the bug #1248 where search queries aren't being de-bounced, resulting in N number of search queries. 

### Test Plan
Visit beta.quran.com to search for any juz or surah from the main search bar while having the network tab opened. 

### Screenshots

| Before | After |
| ------ | ------ |
| ![before](https://user-images.githubusercontent.com/7938533/153974687-7f3b75e5-a925-45ed-8b45-4cd6a506bc79.gif) | ![after](https://user-images.githubusercontent.com/7938533/153974692-b768a24c-8087-4e0b-acd3-87df3447635a.gif) |

closes #1248 