### PR TITLE
add asset version to invalidate them.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -288,5 +288,3 @@ export const getTafsirContent = (tafsirIdOrSlug: string, verseKey: string, local
     }),
   );
 };
-
-export const getImageCDNPath = (path: string) => `https://static.qurancdn.com/images/${path}`;

--- a/src/components/Fonts/FontPreLoader.tsx
+++ b/src/components/Fonts/FontPreLoader.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 import Head from 'next/head';
 
-import { FONT_CDN } from 'src/utils/fontFaceHelper';
+import { makeCDNUrl } from 'src/utils/cdn';
 
 const DEFAULT_LOCALE = 'en';
 
 const LOCALE_PRELOADED_FONTS = {
-  [DEFAULT_LOCALE]: [{ type: 'font/woff2', location: 'lang/ProximaVara/ProximaVara.woff2' }],
-  ar: [{ type: 'font/woff2', location: 'lang/arabic/NotoNaskhArabic-Regular.woff2' }],
-  bn: [{ type: 'font/ttf', location: 'lang/bengali/NotoSerifBengali-Regular.woff2' }],
-  ur: [{ type: 'font/woff2', location: 'lang/urdu/MehrNastaliqWeb.woff2' }],
+  [DEFAULT_LOCALE]: [{ type: 'font/woff2', location: 'fonts/lang/ProximaVara/ProximaVara.woff2' }],
+  ar: [{ type: 'font/woff2', location: 'fonts/lang/arabic/NotoNaskhArabic-Regular.woff2' }],
+  bn: [{ type: 'font/ttf', location: 'fonts/lang/bengali/NotoSerifBengali-Regular.woff2' }],
+  ur: [{ type: 'font/woff2', location: 'fonts/lang/urdu/MehrNastaliqWeb.woff2' }],
 } as Record<string, { type: string; location: string }[]>;
 
 interface Props {
@@ -28,7 +28,7 @@ const FontPreLoader: React.FC<Props> = ({ locale }) => {
           rel="preload"
           as="font"
           type={fontDetails.type}
-          href={`${FONT_CDN}/${fontDetails.location}`}
+          href={makeCDNUrl(fontDetails.location)}
           crossOrigin="anonymous"
         />
       ))}

--- a/src/components/Radio/ReciterStationList.tsx
+++ b/src/components/Radio/ReciterStationList.tsx
@@ -11,6 +11,7 @@ import { StationState, StationType } from './types';
 
 import { playFrom, selectIsPlaying } from 'src/redux/slices/AudioPlayer/state';
 import { selectRadioStation, setRadioStationState } from 'src/redux/slices/radio';
+
 import { makeCDNUrl } from 'src/utils/cdn';
 import { getRandomChapterId } from 'src/utils/chapter';
 import { logEvent } from 'src/utils/eventLogger';

--- a/src/components/Radio/ReciterStationList.tsx
+++ b/src/components/Radio/ReciterStationList.tsx
@@ -9,9 +9,9 @@ import Card, { CardSize } from '../dls/Card/Card';
 import styles from './ReciterStationList.module.scss';
 import { StationState, StationType } from './types';
 
-import { getImageCDNPath } from 'src/api';
 import { playFrom, selectIsPlaying } from 'src/redux/slices/AudioPlayer/state';
 import { selectRadioStation, setRadioStationState } from 'src/redux/slices/radio';
+import { makeCDNUrl } from 'src/utils/cdn';
 import { getRandomChapterId } from 'src/utils/chapter';
 import { logEvent } from 'src/utils/eventLogger';
 import Reciter from 'types/Reciter';
@@ -65,7 +65,7 @@ const ReciterStationList = ({ reciters }: ReciterStationListProps) => {
         return (
           <Card
             actionIcon={actionIcon}
-            imgSrc={getImageCDNPath(reciter.profilePicture)}
+            imgSrc={makeCDNUrl(reciter.profilePicture)}
             key={reciter.id}
             onImgClick={onClick}
             title={reciter.name}

--- a/src/components/Radio/ReciterStationList.tsx
+++ b/src/components/Radio/ReciterStationList.tsx
@@ -11,7 +11,6 @@ import { StationState, StationType } from './types';
 
 import { playFrom, selectIsPlaying } from 'src/redux/slices/AudioPlayer/state';
 import { selectRadioStation, setRadioStationState } from 'src/redux/slices/radio';
-
 import { makeCDNUrl } from 'src/utils/cdn';
 import { getRandomChapterId } from 'src/utils/chapter';
 import { logEvent } from 'src/utils/eventLogger';

--- a/src/components/Reciter/ReciterInfo.tsx
+++ b/src/components/Reciter/ReciterInfo.tsx
@@ -10,7 +10,7 @@ import { playReciterStation } from '../Radio/ReciterStationList';
 
 import styles from './ReciterInfo.module.scss';
 
-import { getImageCDNPath } from 'src/utils/api';
+import { makeCDNUrl } from 'src/utils/cdn';
 import { logEvent } from 'src/utils/eventLogger';
 import Reciter from 'types/Reciter';
 
@@ -39,7 +39,7 @@ const ReciterInfo = ({ selectedReciter }: ReciterInfoProps) => {
       <div className={styles.reciterImageContainer}>
         <img
           className={styles.reciterImage}
-          src={getImageCDNPath(selectedReciter?.profilePicture)}
+          src={makeCDNUrl(selectedReciter?.profilePicture)}
           alt={selectedReciter?.name}
         />
       </div>

--- a/src/components/Reciter/RecitersList.tsx
+++ b/src/components/Reciter/RecitersList.tsx
@@ -2,8 +2,8 @@ import Card, { CardSize } from '../dls/Card/Card';
 
 import styles from './RecitersList.module.scss';
 
-import { getImageCDNPath } from 'src/api';
 import Link from 'src/components/dls/Link/Link';
+import { makeCDNUrl } from 'src/utils/cdn';
 import { getReciterNavigationUrl } from 'src/utils/navigation';
 import Reciter from 'types/Reciter';
 
@@ -18,7 +18,7 @@ const RecitersList = ({ reciters }: RecitersListProps) => {
         return (
           <Link key={reciter.id} href={getReciterNavigationUrl(reciter.id.toString())}>
             <Card
-              imgSrc={getImageCDNPath(reciter.profilePicture)}
+              imgSrc={makeCDNUrl(reciter.profilePicture)}
               key={reciter.id}
               title={reciter.name}
               description={reciter.style.name}

--- a/src/components/dls/QuranWord/TajweedWordImage.tsx
+++ b/src/components/dls/QuranWord/TajweedWordImage.tsx
@@ -26,7 +26,7 @@ const TajweedWord: React.FC<Props> = ({ path, alt }) => {
   const { quranTextFontScale } = useSelector(selectQuranReaderStyles);
   return (
     <span className={classNames(styles.imageContainer, FONT_SIZE_CLASS_MAP[quranTextFontScale])}>
-      <img src={`${makeCDNUrl(path)}`} alt={alt} />
+      <img src={`${makeCDNUrl(`images/${path}`)}`} alt={alt} />
     </span>
   );
 };

--- a/src/components/dls/QuranWord/TajweedWordImage.tsx
+++ b/src/components/dls/QuranWord/TajweedWordImage.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 import styles from './TajweedWordImage.module.scss';
 
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
+import { makeCDNUrl } from 'src/utils/cdn';
 
 interface Props {
   path: string;
@@ -21,13 +22,11 @@ const FONT_SIZE_CLASS_MAP = {
   5: styles.xl,
 };
 
-const IMAGE_BASE_PATH = 'https://static.qurancdn.com/images';
-
 const TajweedWord: React.FC<Props> = ({ path, alt }) => {
   const { quranTextFontScale } = useSelector(selectQuranReaderStyles);
   return (
     <span className={classNames(styles.imageContainer, FONT_SIZE_CLASS_MAP[quranTextFontScale])}>
-      <img src={`${IMAGE_BASE_PATH}/${path}`} alt={alt} />
+      <img src={`${makeCDNUrl(path)}`} alt={alt} />
     </span>
   );
 };

--- a/src/pages/reciters/[reciterId]/[chapterId].tsx
+++ b/src/pages/reciters/[reciterId]/[chapterId].tsx
@@ -23,7 +23,7 @@ import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import Spinner from 'src/components/dls/Spinner/Spinner';
 import { ToastStatus, useToast } from 'src/components/dls/Toast/Toast';
 import { playFrom, selectAudioData, selectIsPlaying } from 'src/redux/slices/AudioPlayer/state';
-import { getImageCDNPath } from 'src/utils/api';
+import { makeCDNUrl } from 'src/utils/cdn';
 import { getChapterData } from 'src/utils/chapter';
 import { logButtonClick } from 'src/utils/eventLogger';
 import { getSurahNavigationUrl } from 'src/utils/navigation';
@@ -91,7 +91,7 @@ const RecitationPage = ({ selectedReciter, selectedChapter }: ShareRecitationPag
         <img
           className={styles.reciterImage}
           alt={selectedReciter.name}
-          src={getImageCDNPath(selectedReciter.profilePicture)}
+          src={makeCDNUrl(selectedReciter.profilePicture)}
         />
         <div>
           <div className={styles.chapterName}>

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,4 +1,5 @@
 $font-cdn: "https://static.qurancdn.com/fonts";
+$asset-version: "1";
 
 // TODO: figure out a way to generate font faces on the fly. We're creating lot of font faces that browsers might not need.
 
@@ -6,38 +7,33 @@ $font-cdn: "https://static.qurancdn.com/fonts";
 @font-face {
   font-family: "IndoPak";
   src: local("AlQuran IndoPak by QuranWBW"),
-    url("#{$font-cdn}/quran/hafs/nastaleeq/indopak/indopak-nastaleeq-waqf-lazim-v4.woff2"),
-    url("#{$font-cdn}/quran/hafs/nastaleeq/indopak/indopak-nastaleeq-waqf-lazim-v4.woff")
-      format("woff"),
-    url("#{$font-cdn}/quran/hafs/nastaleeq/indopak/indopak-nastaleeq-waqf-lazim-v4.ttf")
-      format("truetype");
+  url("#{$font-cdn}/quran/hafs/nastaleeq/indopak/indopak-nastaleeq-waqf-lazim-v4.woff2?v=#{$asset-version}") format("woff2"),
+  url("#{$font-cdn}/quran/hafs/nastaleeq/indopak/indopak-nastaleeq-waqf-lazim-v4.woff?v=#{$asset-version}") format("woff"),
+  url("#{$font-cdn}/quran/hafs/nastaleeq/indopak/indopak-nastaleeq-waqf-lazim-v4.ttf?v=#{$asset-version}") format("truetype");
 }
 
 // TODO: we're not rendering text_uthmani anymore, do we need this font face?
 @font-face {
   font-family: "meQuran";
   src: local("me_quran2"),
-    url("#{$font-cdn}/quran/hafs/me_quran/me_quran-2.woff2"),
-    url("#{$font-cdn}/quran/hafs/me_quran/me_quran-2.woff2") format("truetype");
+  url("#{$font-cdn}/quran/hafs/me_quran/me_quran-2.woff2?v=#{$asset-version}") format("woff2"),
+  url("#{$font-cdn}/quran/hafs/me_quran/me_quran-2.woff2?v=#{$asset-version}") format("truetype");
 }
 
 @font-face {
   font-family: "UthmanicHafs";
   src: local("KFGQPC HAFS Uthmanic Script"),
-    url("#{$font-cdn}/quran/hafs/uthmanic_hafs/UthmanicHafs1Ver18.woff2"),
-    url("#{$font-cdn}/quran/hafs/uthmanic_hafs/UthmanicHafs1Ver18.ttf")
-      format("truetype");
+  url("#{$font-cdn}/quran/hafs/uthmanic_hafs/UthmanicHafs1Ver18.woff2?v=#{$asset-version}") format("woff2"),
+  url("#{$font-cdn}/quran/hafs/uthmanic_hafs/UthmanicHafs1Ver18.ttf?v=#{$asset-version}") format("truetype");
 }
 
 // TODO: regenerate this font and add font-family name
 @font-face {
   font-family: "surahnames";
-  src: url("#{$font-cdn}/quran/surah-names/v1/sura_names.woff2");
-  src: url("#{$font-cdn}/quran/surah-names/v1/surah-names.eot#iefix")
-      format("embedded-opentype"),
-    url("#{$font-cdn}/quran/surah-names/v1/sura_names.ttf") format("truetype"),
-    url("#{$font-cdn}/quran/quran/surah-names/v1/sura_names.woff")
-      format("woff");
+  src: url("#{$font-cdn}/quran/surah-names/v1/sura_names.woff2?v=#{$asset-version}");
+  src: url("#{$font-cdn}/quran/surah-names/v1/surah-names.eot?v=#{$asset-version}") format("embedded-opentype"),
+  url("#{$font-cdn}/quran/surah-names/v1/sura_names.ttf?v=#{$asset-version}") format("truetype"),
+  url("#{$font-cdn}/quran/quran/surah-names/v1/sura_names.woff?v=#{$asset-version}") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -47,18 +43,18 @@ $font-cdn: "https://static.qurancdn.com/fonts";
 @font-face {
   font-family: "divehi";
   src: local("Dhivehi Akuru"),
-    url("#{$font-cdn}/lang/dhivehi/dhivehi/DhivehiAkuru.woff2"),
-    url("#{$font-cdn}/lang/dhivehi/dhivehi/DhivehiAkuru.woff") format("woff"),
-    url("#{$font-cdn}/lang/dhivehi/dhivehi/DhivehiAkuru.otf") format("opentype");
+  url("#{$font-cdn}/lang/dhivehi/dhivehi/DhivehiAkuru.woff2?v=#{$asset-version}"),
+  url("#{$font-cdn}/lang/dhivehi/dhivehi/DhivehiAkuru.woff?v=#{$asset-version}") format("woff"),
+  url("#{$font-cdn}/lang/dhivehi/dhivehi/DhivehiAkuru.otf?v=#{$asset-version}") format("opentype");
   font-display: swap;
 }
 
 @font-face {
   font-family: "NotoNastaliq";
-  src: local("Noto Naskh Arabic"), local("Nafees Regular"),
-    url("#{$font-cdn}/lang/arabic/NotoNaskhArabic-Regular.woff2"),
-    url("#{$font-cdn}/lang/arabic/NotoNaskhArabic-Regular.ttf")
-      format("truetype");
+  src: local("Noto Naskh Arabic"),
+  local("Nafees Regular"),
+  url("#{$font-cdn}/lang/arabic/NotoNaskhArabic-Regular.woff2?v=#{$asset-version}"),
+  url("#{$font-cdn}/lang/arabic/NotoNaskhArabic-Regular.ttf?v=#{$asset-version}") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -67,9 +63,9 @@ $font-cdn: "https://static.qurancdn.com/fonts";
 @font-face {
   font-family: "MehrNastaliq";
   src: local("Mehr Nastaliq Web"),
-    url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.woff2"),
-    url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.woff") format("woff"),
-    url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.ttf") format("truetype");
+  url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.woff2?v=#{$asset-version}"),
+  url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.woff?v=#{$asset-version}") format("woff"),
+  url("#{$font-cdn}/lang/urdu/MehrNastaliqWeb.ttf?v=#{$asset-version}") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -78,14 +74,14 @@ $font-cdn: "https://static.qurancdn.com/fonts";
 @font-face {
   font-family: "NotoSerifBengali";
   src: local("Noto Serif Bengali"),
-    url("#{$font-cdn}/bengali/NotoSerifBengali-Regular.woff2");
+  url("#{$font-cdn}/bengali/NotoSerifBengali-Regular.woff2?v=#{$asset-version}");
 }
 
 @font-face {
   font-family: "DroidArabicNaskh";
   src: local("Droid Arabic Naskh"),
-    url("#{$font-cdn}/lang/kurdish/droid-naskh-regular.woff2"),
-    url("#{$font-cdn}/lang/kurdish/droid-naskh-regular.ttf") format("truetype");
+  url("#{$font-cdn}/lang/kurdish/droid-naskh-regular.woff2?v=#{$asset-version}"),
+  url("#{$font-cdn}/lang/kurdish/droid-naskh-regular.ttf?v=#{$asset-version}") format("truetype");
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -95,7 +91,7 @@ $font-cdn: "https://static.qurancdn.com/fonts";
 @font-face {
   font-family: "ProximaVara";
   src: local("Proxima Vara"),
-    url("#{$font-cdn}/lang/ProximaVara/ProximaVara.woff2");
+  url("#{$font-cdn}/lang/ProximaVara/ProximaVara.woff2?v=#{$asset-version}");
   font-weight: 100 900;
   /* default 400 */
   font-stretch: 50% 100%;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -72,5 +72,3 @@ export const getMushafId = (
   }
   return { mushaf };
 };
-
-export const getImageCDNPath = (path: string) => `https://static.qurancdn.com/images/${path}`;

--- a/src/utils/cdn.ts
+++ b/src/utils/cdn.ts
@@ -1,0 +1,13 @@
+export const CDN_HOST = 'https://static.qurancdn.com';
+export const CDN_ASSETS_VERSION = '1';
+
+/**
+ * Generate versioned URL of static asset
+ *
+ * @param {string} path the path of static asset
+ * @returns {string}
+ */
+
+export const makeCDNUrl = (path: string) => {
+  return `${CDN_HOST}/${path}?v=${CDN_ASSETS_VERSION}`;
+};

--- a/src/utils/fontFaceHelper.ts
+++ b/src/utils/fontFaceHelper.ts
@@ -36,14 +36,14 @@ export const getV1OrV2FontFaceSource = (isV1: boolean, pageNumber: number): stri
   const pageName = String(pageNumber).padStart(3, '0');
 
   if (isV1) {
-    const woff2 = makeCDNUrl(`/quran/hafs/v1/woff2/p${pageNumber}.woff2`);
-    const woff = makeCDNUrl(`/quran/hafs/v1/woff/p${pageNumber}.woff`);
-    const ttf = makeCDNUrl(`/quran/hafs/v1/ttf/p${pageNumber}.ttf`);
+    const woff2 = makeCDNUrl(`fonts/quran/hafs/v1/woff2/p${pageNumber}.woff2`);
+    const woff = makeCDNUrl(`fonts/quran/hafs/v1/woff/p${pageNumber}.woff`);
+    const ttf = makeCDNUrl(`fonts/quran/hafs/v1/ttf/p${pageNumber}.ttf`);
     return `local(QCF_P${pageName}), url('${woff2}') format('woff2'), url('${woff}') format('woff'), url('${ttf}') format('truetype')`;
   }
 
-  const woff2 = makeCDNUrl(`/quran/hafs/v2/woff2/p${pageNumber}.woff2`);
-  const woff = makeCDNUrl(`/quran/hafs/v2/woff/p${pageNumber}.woff`);
+  const woff2 = makeCDNUrl(`fonts/quran/hafs/v2/woff2/p${pageNumber}.woff2`);
+  const woff = makeCDNUrl(`fonts/quran/hafs/v2/woff/p${pageNumber}.woff`);
 
   return `local(QCF2${pageName}), url('${woff2}') format('woff2'), url('${woff}') format('woff')`;
 };

--- a/src/utils/fontFaceHelper.ts
+++ b/src/utils/fontFaceHelper.ts
@@ -1,11 +1,11 @@
 import range from 'lodash/range';
 
+import { makeCDNUrl } from './cdn';
+
 import { MushafLines, QuranFont } from 'types/QuranReader';
 import Verse from 'types/Verse';
 
 const QCFFontCodes = [QuranFont.MadaniV1, QuranFont.MadaniV2];
-export const FONT_CDN = 'https://static.qurancdn.com/fonts';
-
 export const isQCFFont = (font: QuranFont) => QCFFontCodes.includes(font);
 
 /**
@@ -36,9 +36,16 @@ export const getV1OrV2FontFaceSource = (isV1: boolean, pageNumber: number): stri
   const pageName = String(pageNumber).padStart(3, '0');
 
   if (isV1) {
-    return `local(QCF_P${pageName}), url('${FONT_CDN}/quran/hafs/v1/woff2/p${pageNumber}.woff2') format('woff2'), url('${FONT_CDN}/quran/hafs/v1/woff/p${pageNumber}.woff') format('woff'), url('${FONT_CDN}/quran/hafs/v1/ttf/p${pageNumber}.ttf') format('truetype')`;
+    const woff2 = makeCDNUrl(`/quran/hafs/v1/woff2/p${pageNumber}.woff2`);
+    const woff = makeCDNUrl(`/quran/hafs/v1/woff/p${pageNumber}.woff`);
+    const ttf = makeCDNUrl(`/quran/hafs/v1/ttf/p${pageNumber}.ttf`);
+    return `local(QCF_P${pageName}), url('${woff2}') format('woff2'), url('${woff}') format('woff'), url('${ttf}') format('truetype')`;
   }
-  return `local(QCF2${pageName}), url('${FONT_CDN}/quran/hafs/v2/woff2/p${pageNumber}.woff2') format('woff2'), url('${FONT_CDN}/quran/hafs/v2/woff/p${pageNumber}.woff') format('woff')`;
+
+  const woff2 = makeCDNUrl(`/quran/hafs/v2/woff2/p${pageNumber}.woff2`);
+  const woff = makeCDNUrl(`/quran/hafs/v2/woff/p${pageNumber}.woff`);
+
+  return `local(QCF2${pageName}), url('${woff2}') format('woff2'), url('${woff}') format('woff')`;
 };
 
 /**


### PR DESCRIPTION
### Summary
Fixed page 1 of v1 font https://github.com/quran/quran.com-api/issues/516 but there is no way to invalidate cached fonts in browsers. 

Added assets version that'll invalidate the cached content. For now, invalidation is at the global level, we should invalidate only assets that are changed, will do in successive PR.