### PR TITLE
Fix flipped previous page button on RTL locales

### DIFF
--- a/src/components/QuranReader/ReadingView/PageNavigationButtons/index.tsx
+++ b/src/components/QuranReader/ReadingView/PageNavigationButtons/index.tsx
@@ -33,6 +33,7 @@ const PageNavigationButtons: React.FC<Props> = ({ scrollToNextPage, scrollToPrev
         size={ButtonSize.Small}
         className={styles.prevButton}
         onClick={scrollToPreviousPage}
+        shouldFlipOnRTL={false}
         tooltip={
           <>
             {t('prev-page')} <KeyboardInput invertColors keyboardKey="⬆" />


### PR DESCRIPTION
### Summary
This PR fixes flipped previous page issue on RTL locales e.g. `/ar/2` in the reading view.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="77" alt="Screen Shot 2022-02-17 at 17 19 30" src="https://user-images.githubusercontent.com/15169499/154459987-43712179-a6c2-4c56-bee4-e4bccbe01e49.png">|<img width="68" alt="Screen Shot 2022-02-17 at 17 42 29" src="https://user-images.githubusercontent.com/15169499/154459992-cdf27e7c-504d-4177-a725-9900e9b0d68f.png">|