### PR TITLE
Increase viewport for QuranReader

### DIFF
--- a/src/components/QuranReader/ReadingView/index.tsx
+++ b/src/components/QuranReader/ReadingView/index.tsx
@@ -42,6 +42,8 @@ type ReadingViewProps = {
   resourceId: number | string; // can be the chapter, verse, tafsir, hizb, juz, rub or page's ID.
 };
 
+const INCREASE_VIEWPORT_BY_PIXELS = 1200;
+
 const ReadingView = ({
   quranReaderStyles,
   quranReaderDataType,
@@ -161,7 +163,7 @@ const ReadingView = ({
         <Virtuoso
           ref={virtuosoRef}
           useWindowScroll
-          increaseViewportBy={300}
+          increaseViewportBy={INCREASE_VIEWPORT_BY_PIXELS}
           className={styles.virtuosoScroller}
           initialItemCount={1} // needed for SSR.
           totalCount={pagesCount}

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -32,6 +32,8 @@ const EndOfScrollingControls = dynamic(() => import('../EndOfScrollingControls')
   loading: () => <Spinner />,
 });
 
+const INCREASE_VIEWPORT_BY_PIXELS = 1000;
+
 const TranslationView = ({
   quranReaderStyles,
   quranReaderDataType,
@@ -97,7 +99,7 @@ const TranslationView = ({
           ref={virtuosoRef}
           useWindowScroll
           totalCount={numberOfPages}
-          increaseViewportBy={300}
+          increaseViewportBy={INCREASE_VIEWPORT_BY_PIXELS}
           initialItemCount={1} // needed for SSR.
           itemContent={itemContentRenderer}
           components={{


### PR DESCRIPTION
### Summary
This PR artificially increases the viewport of both `ReadingView` and `TranslationView` so that we pre-fetch more pages in order not to let the user see the skeletons as frequent.