### PR TITLE
Hide Sitemaps Link on Home Page because of 404

### DIFF
--- a/src/components/dls/Footer/BottomSection.tsx
+++ b/src/components/dls/Footer/BottomSection.tsx
@@ -24,7 +24,7 @@ const BottomSection = () => {
     <div className={styles.bottomSectionContainer}>
       <div>
         <div className={styles.bottomLinks}>
-          <Link href="/sitemap" prefetch={false}>
+          <Link href="/sitemap" prefetch={false} isHidden>
             {t('sitemap')}
           </Link>
           <Link href="/privacy" prefetch={false}>

--- a/src/components/dls/Link/Link.module.scss
+++ b/src/components/dls/Link/Link.module.scss
@@ -2,6 +2,9 @@
   text-decoration: none;
   color: inherit;
 }
+.hidden {
+  display: none;
+}
 // variants
 .highlight {
   color: var(--color-text-link);

--- a/src/components/dls/Link/Link.tsx
+++ b/src/components/dls/Link/Link.tsx
@@ -23,6 +23,7 @@ type LinkProps = {
   passHref?: boolean;
   isShallow?: boolean;
   prefetch?: boolean;
+  isHidden?: boolean;
 };
 
 const Link: React.FC<LinkProps> = ({
@@ -36,6 +37,7 @@ const Link: React.FC<LinkProps> = ({
   passHref,
   isShallow = false,
   prefetch = true,
+  isHidden = false,
 }) => (
   <Wrapper
     shouldWrap={!download}
@@ -60,6 +62,7 @@ const Link: React.FC<LinkProps> = ({
         [styles.primary]: variant === LinkVariant.Primary,
         [styles.secondary]: variant === LinkVariant.Secondary,
         [styles.blend]: variant === LinkVariant.Blend,
+        [styles.hidden]: isHidden,
       })}
       {...(onClick && { onClick })}
     >


### PR DESCRIPTION
### Summary
The link tag of 'Sitemaps' has been hid from UI until sitemaps.xml is ready. The users have complained that they tried clicking on it and it leads them to a 404 page. 