### PR TITLE
Fix clicking on verse indicator audio issue

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -4,12 +4,6 @@ import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
-import {
-  verseFontChanged,
-  verseTranslationChanged,
-  verseTranslationFontChanged,
-} from '../utils/memoization';
-
 import BookmarkIcon from './BookmarkIcon';
 import QuranReflectButton from './QuranReflectButton';
 import ShareVerseButton from './ShareVerseButton';
@@ -17,6 +11,11 @@ import TranslationText from './TranslationText';
 import styles from './TranslationViewCell.module.scss';
 
 import Separator from 'src/components/dls/Separator/Separator';
+import {
+  verseFontChanged,
+  verseTranslationChanged,
+  verseTranslationFontChanged,
+} from 'src/components/QuranReader/utils/memoization';
 import OverflowVerseActionsMenu from 'src/components/Verse/OverflowVerseActionsMenu';
 import PlayVerseAudioButton from 'src/components/Verse/PlayVerseAudioButton';
 import VerseLink from 'src/components/Verse/VerseLink';

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -124,9 +124,12 @@ const QuranWord = ({
     }
   }, [audioData, word, wordClickFunctionality]);
 
+  const shouldHandleWordClicking =
+    readingPreference === ReadingPreference.Translation && word.charTypeName !== CharType.End;
+
   return (
     <div
-      {...(readingPreference === ReadingPreference.Translation && { onClick, onKeyPress: onClick })}
+      {...(shouldHandleWordClicking && { onClick, onKeyPress: onClick })}
       role="button"
       tabIndex={0}
       {...{


### PR DESCRIPTION
### Summary
This PR fixes the issue of trying to request the audio file of the end of verse's indicator (verse number) on click in the translation view.

| Screenshots |
| ------ |
|<img width="362" alt="Screen Shot 2022-02-22 at 16 35 12" src="https://user-images.githubusercontent.com/15169499/155105523-11ededa6-67a9-4ca9-9eff-bd35e746cd66.png">|