### PR TITLE
Fix startingVerse undefined ref

### DIFF
--- a/src/components/QuranReader/ReadingView/index.tsx
+++ b/src/components/QuranReader/ReadingView/index.tsx
@@ -91,6 +91,10 @@ const ReadingView = ({
     quranReaderStyles,
     verses,
     pagesVersesRange,
+    isUsingDefaultFont,
+    quranReaderStyles.quranFont,
+    quranReaderStyles.mushafLines,
+    isLoading,
   );
 
   const scrollToPreviousPage = useCallback(() => {


### PR DESCRIPTION
### Summary
This PR fixes the issue when `startingVerse` exists in the url, `undefined` e.g. `/id/9?startingVerse=1`

| Screenshots |
| ----- |
|<img width="736" alt="Screen Shot 2022-02-24 at 16 48 31" src="https://user-images.githubusercontent.com/15169499/155500124-16a0c176-8727-4c05-9ed9-c4c4899fd1d7.png">|