### PR TITLE
increase popover menu touch area

### DIFF
--- a/src/components/dls/PopoverMenu/PopoverMenu.module.scss
+++ b/src/components/dls/PopoverMenu/PopoverMenu.module.scss
@@ -82,7 +82,7 @@ $separator-size: 1px;
   color: var(--color-text-default);
   display: flex;
   align-items: center;
-  padding-block: var(--spacing-xxsmall);
+  padding-block: var(--spacing-xsmall);
   padding-inline-start: var(--spacing-medium);
   padding-inline-end: var(--spacing-medium);
   position: relative;


### PR DESCRIPTION
Based on feedback from yusuf, increasing the touch area for popovermenu

Before
<img width="320" alt="image" src="https://user-images.githubusercontent.com/12745166/155824968-27160af5-e269-4d14-8528-5c531cc7ed4e.png">


After
<img width="351" alt="image" src="https://user-images.githubusercontent.com/12745166/155824961-10caea87-8bf8-498d-b5fd-62601efb012e.png">
