### PR TITLE
hide repetitive translation author information

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationText/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/index.tsx
@@ -19,7 +19,7 @@ import Footnote from 'types/Footnote';
 interface Props {
   translationFontScale: number;
   text: string;
-  resourceName: string;
+  resourceName?: string;
   languageId: number;
 }
 
@@ -165,15 +165,17 @@ const TranslationText: React.FC<Props> = ({
         />
       )}
       {subFootnote && <FootnoteText footnote={subFootnote} onCloseClicked={resetSubFootnote} />}
-      <p
-        className={classNames(
-          styles.translationName,
-          styles[langData.direction],
-          styles[langData.font],
-        )}
-      >
-        — {resourceName}
-      </p>
+      {resourceName && (
+        <p
+          className={classNames(
+            styles.translationName,
+            styles[langData.direction],
+            styles[langData.font],
+          )}
+        >
+          — {resourceName}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -100,7 +100,7 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
                   translationFontScale={quranReaderStyles.translationFontScale}
                   text={translation.text}
                   languageId={translation.languageId}
-                  resourceName={translation.resourceName}
+                  resourceName={verse.translations?.length > 1 ? translation.resourceName : null}
                 />
               </div>
             ))}


### PR DESCRIPTION
Based on the feedback from our designer (yusuf). We want to hide repetitive information (translation author and book name)

Proposal: When there's only 1 translation selected, hide the author name & book name. 
Because for people who only use default translation (1 translation), he's probably on casual reading mode, (not deep reading mode).
So resource name, might be less relevant. 

## Before
<img width="513" alt="image" src="https://user-images.githubusercontent.com/12745166/155825234-48798b1f-1382-4e6b-a4e2-fad15d1abc9b.png">

## After
<img width="354" alt="image" src="https://user-images.githubusercontent.com/12745166/155825250-57855311-0b4e-49a6-979c-d6e06b2ba0aa.png">
