### PR TITLE
Fix 16-line Indopak Mushaf wrong page

### DIFF
--- a/src/pages/page/[pageId].tsx
+++ b/src/pages/page/[pageId].tsx
@@ -69,6 +69,7 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
     const pageVersesResponse = await getPageVerses(pageId, locale, {
       perPage: 'all',
       mushaf: defaultMushafId,
+      filterPageWords: true,
       ...getDefaultWordFields(getQuranReaderStylesInitialState(locale).quranFont),
     });
     const pagesLookupResponse = await getPagesLookup({


### PR DESCRIPTION
### Summary
This PR fixes the issue of wrong page number and verses for 16-line Indopak Mushaf. e.g. [page 30](https://next.quran.com/id/page/30).

### Screenshots

| Before | After |
| ------ | ------ |
|![BEFORE](https://user-images.githubusercontent.com/15169499/155874650-1fac1156-26a1-4016-8300-d7fe3ae59dbb.png)|![AFTER](https://user-images.githubusercontent.com/15169499/155874647-db5910e5-acc8-4b80-b953-f4de84b5b1e3.png)|