### PR TITLE
Close AdvancedCopy Modal on Esc key pressed

### DIFF
--- a/src/components/Verse/VerseActionAdvancedCopy/index.tsx
+++ b/src/components/Verse/VerseActionAdvancedCopy/index.tsx
@@ -64,6 +64,7 @@ const VerseActionAdvancedCopy = ({
         header={<p className={styles.header}>{t('advanced-copy')}</p>}
         hasCloseButton
         onClose={onModalClose}
+        onEscapeKeyDown={onModalClose}
         contentClassName={styles.contentWrapper}
       >
         <VerseAdvancedCopy verse={verse}>


### PR DESCRIPTION
### Summary
This PR adds the ability to close the Advanced Copy modal when Esc key is pressed to make it consistent with other modals.