### PR TITLE
on mobile, dismiss keyboard when user click "return"

### DIFF
--- a/src/components/Navbar/SearchDrawer/Header/index.tsx
+++ b/src/components/Navbar/SearchDrawer/Header/index.tsx
@@ -31,6 +31,12 @@ const Header: React.FC<Props> = ({
   const { t } = useTranslation('common');
   // we detect whether the user is inputting a right-to-left text or not so we can change the layout accordingly
   const isRTLInput = useElementComputedPropertyValue(inputRef, 'direction') === 'rtl';
+
+  const onKeyboardReturnPressed = (e) => {
+    e.preventDefault();
+    inputRef.current.blur();
+  };
+
   return (
     <>
       {isVoiceFlowStarted ? (
@@ -47,12 +53,7 @@ const Header: React.FC<Props> = ({
               [styles.searchInputContainerRTL]: isRTLInput,
             })}
           >
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                inputRef.current.blur();
-              }}
-            >
+            <form onSubmit={onKeyboardReturnPressed}>
               <input
                 className={styles.searchInput}
                 type="text"

--- a/src/components/Navbar/SearchDrawer/Header/index.tsx
+++ b/src/components/Navbar/SearchDrawer/Header/index.tsx
@@ -47,18 +47,23 @@ const Header: React.FC<Props> = ({
               [styles.searchInputContainerRTL]: isRTLInput,
             })}
           >
-            <input
-              className={styles.searchInput}
-              inputMode="search"
-              enterKeyHint="search"
-              type="text"
-              ref={inputRef}
-              dir="auto"
-              placeholder={t('search.title')}
-              onChange={onSearchQueryChange}
-              value={searchQuery}
-              disabled={isSearching}
-            />
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                inputRef.current.blur();
+              }}
+            >
+              <input
+                className={styles.searchInput}
+                type="text"
+                ref={inputRef}
+                dir="auto"
+                placeholder={t('search.title')}
+                onChange={onSearchQueryChange}
+                value={searchQuery}
+                disabled={isSearching}
+              />
+            </form>
             <TarteelVoiceSearchTrigger
               onClick={() => {
                 logButtonClick('search_drawer_voice_search_start_flow');


### PR DESCRIPTION
Before
- clicking "search" on mobile keyboard does not close the keyboard

After
- clicking "search" on mobile close the keyboard

Based on yusuf's feedback