### PR TITLE
Make page number relative to vh

### DIFF
--- a/src/components/QuranReader/ReadingView/PageFooter.module.scss
+++ b/src/components/QuranReader/ReadingView/PageFooter.module.scss
@@ -1,5 +1,3 @@
-@use "src/styles/breakpoints";
-
 .pageText {
   text-align: center;
   padding-block-start: var(--spacing-xxsmall);


### PR DESCRIPTION
### Summary
This PR makes the font size of the page number in the Reading View relative to the viewport's height to match that of the Quranic text. 

### Screenshots (large screens)

| Before | After |
| ------ | ------ |
|<img width="446" alt="Screen Shot 2022-03-01 at 19 29 35" src="https://user-images.githubusercontent.com/15169499/156172128-2fbe663a-ae87-413b-b400-b785dff0eda9.png">|<img width="432" alt="Screen Shot 2022-03-01 at 19 29 53" src="https://user-images.githubusercontent.com/15169499/156172144-881f9577-650d-485d-ba4c-da3ff5722f13.png">|