### PR TITLE
fix: remove startVerse query param when switching mode

### DIFF
--- a/src/components/QuranReader/ReadingPreferenceSwitcher.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import omit from 'lodash/omit';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 import { useDispatch, useSelector } from 'react-redux';
@@ -38,7 +37,8 @@ const ReadingPreferenceSwitcher = () => {
     logValueChange('reading_preference', readingPreference, view);
 
     // drop `startingVerse` from query params
-    const newQueryParams = omit(router.query, ['startingVerse']);
+    const newQueryParams = { ...router.query };
+    delete newQueryParams.startingVerse;
     const newUrlObject = {
       pathname: router.pathname,
       query: newQueryParams,


### PR DESCRIPTION
to solve the problem
- when user have startingVerse=68 param, 
- he scroll up
- and then switch from translation -> reading mode. It scroll to verse 68 on reading mode
- removing this param, fixed the behavior -> doesn't scroll anymore
