### PR TITLE
Update fonts path

### DIFF
--- a/src/components/Fonts/FontPreLoader.tsx
+++ b/src/components/Fonts/FontPreLoader.tsx
@@ -5,10 +5,10 @@ import Head from 'next/head';
 const DEFAULT_LOCALE = 'en';
 
 const LOCALE_PRELOADED_FONTS = {
-  [DEFAULT_LOCALE]: [{ type: 'font/woff2', location: 'fonts/lang/ProximaVara/ProximaVara.woff2' }],
-  ar: [{ type: 'font/woff2', location: 'fonts/lang/arabic/NotoNaskhArabic-Regular.woff2' }],
-  bn: [{ type: 'font/ttf', location: 'fonts/lang/bengali/NotoSerifBengali-Regular.woff2' }],
-  ur: [{ type: 'font/woff2', location: 'fonts/lang/urdu/MehrNastaliqWeb.woff2' }],
+  [DEFAULT_LOCALE]: [{ type: 'font/woff2', location: '/fonts/lang/ProximaVara/ProximaVara.woff2' }],
+  ar: [{ type: 'font/woff2', location: '/fonts/lang/arabic/NotoNaskhArabic-Regular.woff2' }],
+  bn: [{ type: 'font/ttf', location: '/fonts/lang/bengali/NotoSerifBengali-Regular.woff2' }],
+  ur: [{ type: 'font/woff2', location: '/fonts/lang/urdu/MehrNastaliqWeb.woff2' }],
 } as Record<string, { type: string; location: string }[]>;
 
 interface Props {

--- a/src/utils/fontFaceHelper.ts
+++ b/src/utils/fontFaceHelper.ts
@@ -34,14 +34,14 @@ export const getV1OrV2FontFaceSource = (isV1: boolean, pageNumber: number): stri
   const pageName = String(pageNumber).padStart(3, '0');
 
   if (isV1) {
-    const woff2 = `fonts/quran/hafs/v1/woff2/p${pageNumber}.woff2`;
-    const woff = `fonts/quran/hafs/v1/woff/p${pageNumber}.woff`;
-    const ttf = `fonts/quran/hafs/v1/ttf/p${pageNumber}.ttf`;
+    const woff2 = `/fonts/quran/hafs/v1/woff2/p${pageNumber}.woff2`;
+    const woff = `/fonts/quran/hafs/v1/woff/p${pageNumber}.woff`;
+    const ttf = `/fonts/quran/hafs/v1/ttf/p${pageNumber}.ttf`;
     return `local(QCF_P${pageName}), url('${woff2}') format('woff2'), url('${woff}') format('woff'), url('${ttf}') format('truetype')`;
   }
 
-  const woff2 = `fonts/quran/hafs/v2/woff2/p${pageNumber}.woff2`;
-  const woff = `fonts/quran/hafs/v2/woff/p${pageNumber}.woff`;
+  const woff2 = `/fonts/quran/hafs/v2/woff2/p${pageNumber}.woff2`;
+  const woff = `/fonts/quran/hafs/v2/woff/p${pageNumber}.woff`;
 
   return `local(QCF2${pageName}), url('${woff2}') format('woff2'), url('${woff}') format('woff')`;
 };


### PR DESCRIPTION
### Summary
this PR updates the fonts path to make it absolute instead of relative so that we can always import from `/public/fonts` directory. e.g when visiting https://next.quran.com/2/2.


### Screenshots

| Screenshots |
| ------ |
|<img width="585" alt="Screen Shot 2022-03-03 at 09 34 36" src="https://user-images.githubusercontent.com/15169499/156485898-b609bb92-b131-4f39-91b6-cbdf4fc0ea36.png">|
|<img width="554" alt="Screen Shot 2022-03-03 at 09 34 43" src="https://user-images.githubusercontent.com/15169499/156485907-a678cf14-880b-4eaf-bcc8-065ae53161f6.png">|