### PR TITLE
Fix router exception for a chapterId with leading "00"

### DIFF
--- a/src/hooks/useChapterId.ts
+++ b/src/hooks/useChapterId.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 
 import { getChapterIdBySlug } from 'src/api';
 import { getChapterIdsForJuz, getChapterIdsForPage } from 'src/utils/chapter';
+import { formatStringNumber } from 'src/utils/number';
 import { isValidChapterId, isValidVerseKey } from 'src/utils/validator';
 import { getChapterNumberFromKey } from 'src/utils/verse';
 
@@ -30,7 +31,7 @@ const useChapterIdsByUrlPath = (lang: string): string[] => {
         const chapterIdOrVerseKeyOrSlug = chapterId as string;
         // if it's a chapter id
         if (isValidChapterId(chapterIdOrVerseKeyOrSlug)) {
-          setChapterIds([chapterIdOrVerseKeyOrSlug]);
+          setChapterIds([formatStringNumber(chapterIdOrVerseKeyOrSlug)]);
         } else if (isValidVerseKey(chapterIdOrVerseKeyOrSlug)) {
           // if it's a verse key e.g 5:1
           setChapterIds([getChapterNumberFromKey(chapterIdOrVerseKeyOrSlug).toString()]);
@@ -46,10 +47,10 @@ const useChapterIdsByUrlPath = (lang: string): string[] => {
           }
         }
       } else if (pageId) {
-        const chapterIdsForPage = await getChapterIdsForPage(pageId as string);
+        const chapterIdsForPage = await getChapterIdsForPage(formatStringNumber(pageId as string));
         setChapterIds(chapterIdsForPage);
       } else if (juzId) {
-        setChapterIds(await getChapterIdsForJuz(juzId as string));
+        setChapterIds(await getChapterIdsForJuz(formatStringNumber(juzId as string)));
       }
     })();
   }, [pageId, juzId, lang, chapterId]);

--- a/src/pages/[chapterId]/index.tsx
+++ b/src/pages/[chapterId]/index.tsx
@@ -18,6 +18,7 @@ import {
   getSurahNavigationUrl,
   getVerseNavigationUrl,
 } from 'src/utils/navigation';
+import { formatStringNumber } from 'src/utils/number';
 import {
   REVALIDATION_PERIOD_ON_ERROR_SECONDS,
   ONE_WEEK_REVALIDATION_PERIOD_SECONDS,
@@ -184,7 +185,7 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
         },
       };
     }
-    const versesResponse = await getChapterVerses(chapterId, locale, apiParams);
+    const versesResponse = await getChapterVerses(formatStringNumber(chapterId), locale, apiParams);
     const metaData = { numberOfVerses };
     versesResponse.metaData = metaData;
     versesResponse.pagesLookup = pagesLookupResponse;

--- a/src/pages/juz/[juzId]/index.tsx
+++ b/src/pages/juz/[juzId]/index.tsx
@@ -12,6 +12,7 @@ import { getQuranReaderStylesInitialState } from 'src/redux/defaultSettings/util
 import { getDefaultWordFields, getMushafId } from 'src/utils/api';
 import { getLanguageAlternates, toLocalizedNumber } from 'src/utils/locale';
 import { getCanonicalUrl, getJuzNavigationUrl } from 'src/utils/navigation';
+import { formatStringNumber } from 'src/utils/number';
 import { getPageOrJuzMetaDescription } from 'src/utils/seo';
 import {
   REVALIDATION_PERIOD_ON_ERROR_SECONDS,
@@ -55,13 +56,15 @@ const JuzPage: NextPage<JuzPageProps> = ({ hasError, juzVerses }) => {
 
 // eslint-disable-next-line react-func/max-lines-per-function
 export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
-  const juzId = String(params.juzId);
+  let juzId = String(params.juzId);
   // we need to validate the chapterId and verseId first to save calling BE since we haven't set the valid paths inside getStaticPaths to avoid pre-rendering them at build time.
   if (!isValidJuzId(juzId)) {
     return {
       notFound: true,
     };
   }
+  juzId = formatStringNumber(juzId);
+
   const defaultMushafId = getMushafId(
     getQuranReaderStylesInitialState(locale).quranFont,
     getQuranReaderStylesInitialState(locale).mushafLines,

--- a/src/utils/chapter.ts
+++ b/src/utils/chapter.ts
@@ -2,6 +2,8 @@
 /* eslint-disable global-require */
 import random from 'lodash/random';
 
+import { formatStringNumber } from './number';
+
 import Chapter from 'types/Chapter';
 
 const DEFAULT_LANGUAGE = 'en';
@@ -42,7 +44,8 @@ export const getAllChaptersData = (lang: string = DEFAULT_LANGUAGE): Record<stri
  */
 export const getChapterData = (id: string, lang: string = DEFAULT_LANGUAGE): Chapter => {
   const chapters = getAllChaptersData(lang);
-  return chapters[id];
+  const chapterNumberString = formatStringNumber(id);
+  return chapters[chapterNumberString];
 };
 
 /**

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * This function returns a number string after making sure
+ * it's in the valid format. e.g.
+ * 1   -> 1
+ * 001 -> 1
+ *
+ * @param {string} number
+ * @returns {string}
+ */
+export const formatStringNumber = (number: string) => String(Number(number));

--- a/src/utils/verse.ts
+++ b/src/utils/verse.ts
@@ -4,6 +4,7 @@ import { random } from 'lodash';
 import range from 'lodash/range';
 
 import { getAllChaptersData, getChapterData, getRandomChapterId } from './chapter';
+import { formatStringNumber } from './number';
 
 import Verse from 'types/Verse';
 import Word from 'types/Word';
@@ -18,8 +19,11 @@ const COLON_SPLITTER = ':';
  */
 export const generateChapterVersesKeys = (chapterId: string): string[] => {
   const data = getAllChaptersData();
+  const chapterNumberString = formatStringNumber(chapterId);
 
-  return range(data[chapterId].versesCount).map((verseId) => `${chapterId}:${verseId + 1}`);
+  return range(data[chapterNumberString].versesCount).map(
+    (verseId) => `${chapterNumberString}:${verseId + 1}`,
+  );
 };
 
 /**


### PR DESCRIPTION
### Summary
This PR fixes an exceptions that gets throws when the url contains a number for page, juz, chapter ids that has a leading "001" since "001" is considered as a valid number due to `Number.isNaN` returning `false`.  Examples of affected routes:

```
/surah/001/info
/001
/001/001
/001/1
/juz/001
/page/001
/chapter_info/001
/surah-info/001
/001:5
```

| Screenshots |
| ------ |
|<img width="923" alt="Screen Shot 2022-03-03 at 08 52 25" src="https://user-images.githubusercontent.com/15169499/156490643-193f9fb0-a68c-4a79-ba7c-fda2d3197d80.png">|