### PR TITLE
Fix 16-line Indopak wrong page nav buttons

### DIFF
--- a/src/components/QuranReader/EndOfScrollingControls/PageControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/PageControls.tsx
@@ -17,7 +17,13 @@ interface Props {
 
 const PageControls: React.FC<Props> = ({ lastVerse }) => {
   const { t } = useTranslation('quran-reader');
-  const { pageNumber } = lastVerse;
+  /**
+   * We need to access the last word of the the last verse instead
+   * since the pageNumber of the last verse in the case of the 16-line
+   * Mushaf can point to the next page instead of the current one when
+   * the verse spans across 2 pages e.g. /ur/page/30 (verse 16).
+   */
+  const { pageNumber } = lastVerse.words[lastVerse.words.length - 1];
   const { quranFont, mushafLines } = useSelector(selectQuranReaderStyles);
   const page = Number(pageNumber);
   return (


### PR DESCRIPTION
### Summary
This PR fixes an issue of wrong  next and previous page numbers that are referred to from the navigation buttons at the bottom of the page when the last verse of the page spans across 2 pages for 16-line Indopak Mushaf. e.g. `/ur/page/30`.

| Screenshots |
| ------ |
|<img width="834" alt="Screen Shot 2022-03-03 at 12 54 42" src="https://user-images.githubusercontent.com/15169499/156504964-934c85f7-6502-40fa-a6e8-de5cc169dbd1.png">|
|<img width="816" alt="Screen Shot 2022-03-03 at 12 54 48" src="https://user-images.githubusercontent.com/15169499/156504971-b59727b9-342b-4311-a9ff-d388babe72b1.png">|