### PR TITLE
fix: settings drawer hidden when audio auto scroll

### DIFF
--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -116,3 +116,7 @@
 .hiddenButtonHeaderContentContainer {
   align-items: flex-end;
 }
+
+.navbarInvisible {
+  transform: translate3d(0, 0 + constants.$navbar-height, 0);
+}

--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -83,7 +83,7 @@ const Drawer: React.FC<Props> = ({
   hideCloseButton = false,
   closeOnNavigation = true,
 }) => {
-  const { isVisible } = useSelector(selectNavbar, shallowEqual);
+  const { isVisible: isNavbarVisible } = useSelector(selectNavbar, shallowEqual);
   const drawerRef = useRef(null);
   const dispatch = useDispatch();
   const navbar = useSelector(selectNavbar, shallowEqual);
@@ -130,7 +130,7 @@ const Drawer: React.FC<Props> = ({
   return (
     <div
       className={classNames(styles.container, {
-        [styles.navbarInvisible]: !isVisible,
+        [styles.navbarInvisible]: !isNavbarVisible,
         [styles.containerOpen]: isOpen,
         [styles.left]: side === DrawerSide.Left,
         [styles.right]: side === DrawerSide.Right,

--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -83,6 +83,7 @@ const Drawer: React.FC<Props> = ({
   hideCloseButton = false,
   closeOnNavigation = true,
 }) => {
+  const { isVisible } = useSelector(selectNavbar, shallowEqual);
   const drawerRef = useRef(null);
   const dispatch = useDispatch();
   const navbar = useSelector(selectNavbar, shallowEqual);
@@ -129,6 +130,7 @@ const Drawer: React.FC<Props> = ({
   return (
     <div
       className={classNames(styles.container, {
+        [styles.navbarInvisible]: !isVisible,
         [styles.containerOpen]: isOpen,
         [styles.left]: side === DrawerSide.Left,
         [styles.right]: side === DrawerSide.Right,


### PR DESCRIPTION
How to test
* go to next.quran.com
* go to al baqarah
* play audio
* open settings drawer
* wait until the page auto scroll
* the "close" icon will be hidden.

Now try on this PR preview