### PR TITLE
Fix 16-line Indopak wrong initial verses

### DIFF
--- a/src/components/QuranReader/ReadingView/PageContainer.tsx
+++ b/src/components/QuranReader/ReadingView/PageContainer.tsx
@@ -42,9 +42,9 @@ const getPageVersesRange = (
 /**
  * Get the verses returned from the initialData of the first page.
  * This function will filter out all the words that don't
- * belong to the first page to in-case we have have verses
+ * belong to the first page in-case we have some verses
  * that contain words that don't belong to the first page
- * for 16-line Indopak Mushaf e.g. /ur/haji/25 or ur/2/211-216
+ * (applies to 16-line Indopak Mushaf e.g. /ur/haji/25 or /ur/2/211-216)
  *
  * @param {number} pageNumber
  * @param {Verse[]} initialVerses

--- a/src/components/QuranReader/ReadingView/PageContainer.tsx
+++ b/src/components/QuranReader/ReadingView/PageContainer.tsx
@@ -40,6 +40,23 @@ const getPageVersesRange = (
 };
 
 /**
+ * Get the verses returned from the initialData of the first page.
+ * This function will filter out all the words that don't
+ * belong to the first page to in-case we have have verses
+ * that contain words that don't belong to the first page
+ * for 16-line Indopak Mushaf e.g. /ur/haji/25 or ur/2/211-216
+ *
+ * @param {number} pageNumber
+ * @param {Verse[]} initialVerses
+ * @returns {Verse[]}
+ */
+const getInitialVerses = (pageNumber: number, initialVerses: Verse[]): Verse[] =>
+  initialVerses.map((verse) => ({
+    ...verse,
+    words: verse.words.filter((word) => word.pageNumber === pageNumber),
+  }));
+
+/**
  * A component that will fetch the verses of the current mushaf page
  * and will render a skeleton while it's loading.
  *
@@ -61,6 +78,10 @@ const PageContainer: React.FC<Props> = ({
     () => getPageNumberByPageIndex(pageIndex, pagesVersesRange),
     [pageIndex, pagesVersesRange],
   );
+  const initialVerses = useMemo(
+    () => (pageIndex === 0 ? getInitialVerses(pageNumber, initialData.verses) : initialData.verses),
+    [initialData.verses, pageIndex, pageNumber],
+  );
   const isUsingDefaultReciter = useSelector(selectIsUsingDefaultReciter);
   const isUsingDefaultWordByWordLocale = useSelector(selectIsUsingDefaultWordByWordLocale);
   const shouldUseInitialData =
@@ -79,7 +100,7 @@ const PageContainer: React.FC<Props> = ({
     }),
     verseFetcher,
     {
-      fallbackData: shouldUseInitialData ? initialData.verses : null,
+      fallbackData: shouldUseInitialData ? initialVerses : null,
       revalidateOnMount: !shouldUseInitialData,
     },
   );


### PR DESCRIPTION
### Summary
This PR fixes Reading View's 16-line Indopak Mushaf initial verses issue where the initial verses contain all the words of the verses of the first page while sometimes the first page in the actual Mushaf doesn't contain the entire verse but only part of it.

### Screenshots

| Before | After | Path |
| ------ | ------ | ------ |
|<img width="480" alt="Screen Shot 2022-03-03 at 19 54 28" src="https://user-images.githubusercontent.com/15169499/156570679-cdc5cdcc-b6f2-428f-9fb8-8406b534d100.png">|<img width="527" alt="Screen Shot 2022-03-03 at 19 54 07" src="https://user-images.githubusercontent.com/15169499/156570660-1d1d8a66-e586-43d5-b671-d7de9360d391.png">|https://quran.com/bn/haji/25|
|<img width="510" alt="Screen Shot 2022-03-03 at 19 56 58" src="https://user-images.githubusercontent.com/15169499/156570686-5b8de1d4-5e78-435d-8590-829ab251aabd.png">|<img width="502" alt="Screen Shot 2022-03-03 at 19 57 54" src="https://user-images.githubusercontent.com/15169499/156570689-bc73a2b7-c381-4120-9b1b-8a111ecc24b9.png">|https://quran.com/ur/2/211-216|