### PR TITLE
fix: unnecassary api call when opening overflow verse actions

### DIFF
--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -51,6 +51,7 @@ type TafsirBodyProps = {
   initialTafsirData?: TafsirContentResponse;
   initialTafsirIdOrSlug?: number | string;
   scrollToTop: () => void;
+  shouldRender?: boolean;
   render: (renderProps: {
     surahAndAyahSelection: JSX.Element;
     languageAndTafsirSelection: JSX.Element;
@@ -65,6 +66,7 @@ const TafsirBody = ({
   initialTafsirIdOrSlug,
   render,
   scrollToTop,
+  shouldRender,
 }: TafsirBodyProps) => {
   const dispatch = useDispatch();
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
@@ -112,7 +114,10 @@ const TafsirBody = ({
     [dispatch, lang, selectedChapterId, selectedVerseNumber],
   );
 
-  const { data: tafsirSelectionList } = useSWR<TafsirsResponse>(makeTafsirsUrl(lang), fetcher);
+  const { data: tafsirSelectionList } = useSWR<TafsirsResponse>(
+    shouldRender ? makeTafsirsUrl(lang) : null,
+    fetcher,
+  );
 
   // selectedLanguage is based on selectedTafir's language
   // but we need to fetch the data from the API first to know what is the lanaguage of `selectedTafsirIdOrSlug`

--- a/src/components/QuranReader/TafsirView/TafsirVerseAction.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirVerseAction.tsx
@@ -68,6 +68,7 @@ const TafsirVerseAction = ({
       </PopoverMenu.Item>
 
       <TafsirBody
+        shouldRender={isContentModalOpen}
         initialChapterId={chapterId.toString()}
         initialVerseNumber={verseNumber.toString()}
         scrollToTop={() => {

--- a/src/pages/[chapterId]/[verseId]/tafsirs.tsx
+++ b/src/pages/[chapterId]/[verseId]/tafsirs.tsx
@@ -61,6 +61,7 @@ const AyahTafsir: NextPage<AyahTafsirProp> = ({ hasError, chapter, tafsirData })
       />
       <div className={styles.tafsirContainer}>
         <TafsirBody
+          shouldRender
           initialChapterId={chapter.chapter.id.toString()}
           initialVerseNumber={verseId.toString()}
           initialTafsirData={tafsirData}

--- a/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
+++ b/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
@@ -53,6 +53,7 @@ const SelectedTafsirOfAyah: NextPage<AyahTafsirProp> = ({
       />
       <div className={styles.tafsirContainer}>
         <TafsirBody
+          shouldRender
           scrollToTop={scrollWindowToTop}
           initialChapterId={chapterId}
           initialVerseNumber={verseNumber.toString()}


### PR DESCRIPTION
`useSWR` was always called when opening overflow verse actions menu. Even when don't click "Tafsir" yet. This PR fixed the issue