### PR TITLE
Remove url handler from ContentModal

### DIFF
--- a/src/components/QuranReader/TafsirView/TafsirVerseAction.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirVerseAction.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
 import TafsirIcon from '../../../../public/icons/book-open.svg';
@@ -10,7 +11,7 @@ import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentMo
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import { selectSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import { logButtonClick, logEvent } from 'src/utils/eventLogger';
-import { getVerseSelectedTafsirNavigationUrl } from 'src/utils/navigation';
+import { fakeNavigate, getVerseSelectedTafsirNavigationUrl } from 'src/utils/navigation';
 
 const TafsirBody = dynamic(() => import('./TafsirBody'), { ssr: false });
 const ContentModal = dynamic(() => import('src/components/dls/ContentModal/ContentModal'), {
@@ -33,8 +34,9 @@ const TafsirVerseAction = ({
   onActionTriggered,
 }: TafsirVerseActionProps) => {
   const [isContentModalOpen, setIsContentModalOpen] = useState(false);
-  const { t } = useTranslation();
+  const { t, lang } = useTranslation();
   const tafsirs = useSelector(selectSelectedTafsirs);
+  const router = useRouter();
 
   const contentModalRef = useRef<ContentModalHandles>();
 
@@ -45,6 +47,7 @@ const TafsirVerseAction = ({
       logEvent('reading_view_tafsir_modal_close');
     }
     setIsContentModalOpen(false);
+    fakeNavigate(router.asPath, router.locale);
     if (onActionTriggered) {
       setTimeout(() => {
         // we set a really short timeout to close the popover after the modal has been closed to allow enough time for the fadeout css effect to apply.
@@ -62,6 +65,10 @@ const TafsirVerseAction = ({
             `${isTranslationView ? 'translation_view' : 'reading_view'}_verse_actions_menu_tafsir`,
           );
           setIsContentModalOpen(true);
+          fakeNavigate(
+            getVerseSelectedTafsirNavigationUrl(chapterId, verseNumber, tafsirs[0]),
+            lang,
+          );
         }}
       >
         {t('quran-reader:tafsirs')}
@@ -78,7 +85,6 @@ const TafsirVerseAction = ({
           return (
             <ContentModal
               innerRef={contentModalRef}
-              url={getVerseSelectedTafsirNavigationUrl(chapterId, verseNumber, tafsirs[0])}
               isOpen={isContentModalOpen}
               hasCloseButton
               onClose={onModalClose}

--- a/src/components/QuranReader/TranslationView/QuranReflectButton.tsx
+++ b/src/components/QuranReader/TranslationView/QuranReflectButton.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from 'react';
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 
 import ChatIcon from '../../../../public/icons/chat.svg';
 
@@ -12,8 +13,9 @@ import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/d
 import ContentModal from 'src/components/dls/ContentModal/ContentModal';
 import { logButtonClick } from 'src/utils/eventLogger';
 import {
+  fakeNavigate,
   getQuranReflectVerseUrl,
-  getVerseSelectedReflectionNavigationUrl,
+  // getVerseSelectedReflectionNavigationUrl,
 } from 'src/utils/navigation';
 import { navigateToExternalUrl } from 'src/utils/url';
 import { getVerseAndChapterNumbersFromKey } from 'src/utils/verse';
@@ -32,6 +34,7 @@ const QuranReflectButton = ({
   onActionTriggered,
 }: QuranReflectButtonProps) => {
   const { t } = useTranslation('common');
+  const router = useRouter();
   const [isContentModalOpen, setIsContentModalOpen] = useState(false);
 
   const onButtonClicked = () => {
@@ -39,12 +42,14 @@ const QuranReflectButton = ({
     logButtonClick(`${isTranslationView ? 'translation_view' : 'reading_view'}_reflect`);
     navigateToExternalUrl(getQuranReflectVerseUrl(verseKey));
     // setIsContentModalOpen(true); // temporarily disable inline reflection feature
+    // fakeNavigate(getVerseSelectedReflectionNavigationUrl(verseKey));
   };
 
   const contentModalRef = useRef(null);
 
   const onModalClose = () => {
     setIsContentModalOpen(false);
+    fakeNavigate(router.asPath, router.locale);
     if (onActionTriggered) {
       onActionTriggered();
     }
@@ -78,7 +83,6 @@ const QuranReflectButton = ({
         render={({ surahAndAyahSelection, body }) => (
           <ContentModal
             innerRef={contentModalRef}
-            url={getVerseSelectedReflectionNavigationUrl(verseKey)}
             isOpen={isContentModalOpen}
             hasCloseButton
             onClose={onModalClose}

--- a/src/components/QuranReader/TranslationView/QuranReflectButton.tsx
+++ b/src/components/QuranReader/TranslationView/QuranReflectButton.tsx
@@ -12,11 +12,7 @@ import styles from './TranslationViewCell.module.scss';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import ContentModal from 'src/components/dls/ContentModal/ContentModal';
 import { logButtonClick } from 'src/utils/eventLogger';
-import {
-  fakeNavigate,
-  getQuranReflectVerseUrl,
-  // getVerseSelectedReflectionNavigationUrl,
-} from 'src/utils/navigation';
+import { fakeNavigate, getQuranReflectVerseUrl } from 'src/utils/navigation';
 import { navigateToExternalUrl } from 'src/utils/url';
 import { getVerseAndChapterNumbersFromKey } from 'src/utils/verse';
 

--- a/src/components/dls/ContentModal/ContentModal.tsx
+++ b/src/components/dls/ContentModal/ContentModal.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef, useImperativeHandle, ForwardedRef } from 'react';
+import { useRef, useImperativeHandle, ForwardedRef } from 'react';
 
 import * as Dialog from '@radix-ui/react-dialog';
 import classNames from 'classnames';
-import { useRouter } from 'next/router';
 
 import CloseIcon from '../../../../public/icons/close.svg';
 import Button, { ButtonShape, ButtonVariant } from '../Button/Button';
@@ -10,7 +9,6 @@ import Button, { ButtonShape, ButtonVariant } from '../Button/Button';
 import styles from './ContentModal.module.scss';
 
 import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentModalHandles';
-import { fakeNavigate } from 'src/utils/navigation';
 
 type ContentModalProps = {
   isOpen?: boolean;
@@ -18,7 +16,6 @@ type ContentModalProps = {
   onEscapeKeyDown?: () => void;
   children: React.ReactNode;
   hasCloseButton?: boolean;
-  url?: string;
   header?: React.ReactNode;
   innerRef?: ForwardedRef<ContentModalHandles>;
   contentClassName?: string;
@@ -31,13 +28,10 @@ const ContentModal = ({
   onEscapeKeyDown,
   hasCloseButton,
   children,
-  url,
   header,
   innerRef,
   contentClassName,
 }: ContentModalProps) => {
-  const router = useRouter();
-
   const overlayRef = useRef<HTMLDivElement>();
 
   useImperativeHandle(innerRef, () => ({
@@ -45,20 +39,6 @@ const ContentModal = ({
       if (overlayRef.current) overlayRef.current.scrollTop = 0;
     },
   }));
-
-  useEffect(() => {
-    if (!url) return null;
-    if (isOpen) fakeNavigate(url, router.locale);
-    else fakeNavigate(router.asPath, router.locale);
-
-    return () => {
-      fakeNavigate(router.asPath, router.locale);
-    };
-
-    // we only want to run this effect when `isOpen` changed, not when `url` changed
-    // this is important because sometime the url props is changed, but we don't want to trigger `fakeNavigate` again.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
 
   return (
     <Dialog.Root open={isOpen}>


### PR DESCRIPTION
When opening contentModal, the `fakeNavigate` function is called multiple times. Because the function is tied to react lifecycle via useEffect. This adds unnecessary complexity. 

`fakeNavigate` function should be triggered inside `onClick`, not on `render`.

Removing this handler from contentModal to avoid other complexity in the future

---

Here's a few problem that's already found 

It's called multiple times (more than what we need) when opening tafsir,
<img width="720" alt="image" src="https://user-images.githubusercontent.com/12745166/158124084-0bd0bbe8-ca7d-48dc-b206-10678ca84fc6.png">


When it's called often enough, it breaks safari.
<img width="855" alt="image" src="https://user-images.githubusercontent.com/12745166/158123361-da7b53ec-d7aa-4c66-86dc-f27daabd1bf9.png">
