### PR TITLE
[SEO] Support reciter chapter slugs

### DIFF
--- a/src/pages/reciters/[reciterId]/[chapterId].tsx
+++ b/src/pages/reciters/[reciterId]/[chapterId].tsx
@@ -29,6 +29,7 @@ import { getChapterData } from 'src/utils/chapter';
 import { logButtonClick } from 'src/utils/eventLogger';
 import { getSurahNavigationUrl } from 'src/utils/navigation';
 import { getCurrentPath } from 'src/utils/url';
+import { isValidChapterId } from 'src/utils/validator';
 import Chapter from 'types/Chapter';
 import Reciter from 'types/Reciter';
 
@@ -153,11 +154,16 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
   try {
     const reciterId = params.reciterId as string;
     let chapterId = params.chapterId as string;
-    const sluggedChapterId = await getChapterIdBySlug(chapterId, locale);
-    if (!sluggedChapterId) {
-      return { notFound: true };
+    const isValidId = isValidChapterId(chapterId);
+    // if it's not a valid number or a number that exceed 114 or below 1
+    if (!isValidId) {
+      const sluggedChapterId = await getChapterIdBySlug(chapterId, locale);
+      // if it's not a valid number nor a valid slug
+      if (!sluggedChapterId) {
+        return { notFound: true };
+      }
+      chapterId = sluggedChapterId;
     }
-    chapterId = sluggedChapterId;
 
     const reciterData = await getReciterData(reciterId);
     const chapterData = await getChapterData(chapterId, locale);

--- a/src/pages/reciters/[reciterId]/[chapterId].tsx
+++ b/src/pages/reciters/[reciterId]/[chapterId].tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { useState } from 'react';
 
 import classNames from 'classnames';
@@ -16,7 +17,7 @@ import layoutStyle from '../../index.module.scss';
 
 import styles from './chapterId.module.scss';
 
-import { getChapterAudioData, getReciterData } from 'src/api';
+import { getChapterAudioData, getChapterIdBySlug, getReciterData } from 'src/api';
 import { download } from 'src/components/AudioPlayer/Buttons/DownloadAudioButton';
 import { triggerPauseAudio } from 'src/components/AudioPlayer/EventTriggers';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
@@ -151,7 +152,12 @@ export default RecitationPage;
 export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
   try {
     const reciterId = params.reciterId as string;
-    const chapterId = params.chapterId as string;
+    let chapterId = params.chapterId as string;
+    const sluggedChapterId = await getChapterIdBySlug(chapterId, locale);
+    if (!sluggedChapterId) {
+      return { notFound: true };
+    }
+    chapterId = sluggedChapterId;
 
     const reciterData = await getReciterData(reciterId);
     const chapterData = await getChapterData(chapterId, locale);


### PR DESCRIPTION
### Summary
This PR adds support for slugs of a chapter of a specific reciter e.g. `/reciters/1/an-nas`. Before only the chapter Id was supported e.g. `/reciters/1/114`.