### PR TITLE
Fix reciter's pause button styling

### DIFF
--- a/src/pages/reciters/[reciterId]/[chapterId].tsx
+++ b/src/pages/reciters/[reciterId]/[chapterId].tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { useState } from 'react';
 
 import classNames from 'classnames';
@@ -101,7 +102,11 @@ const RecitationPage = ({ selectedReciter, selectedChapter }: ShareRecitationPag
         </div>
         <div className={styles.actionsContainer}>
           {isCurrentlyPlayingThisChapter ? (
-            <Button onClick={() => triggerPauseAudio()} prefix={<PauseIcon />}>
+            <Button
+              onClick={() => triggerPauseAudio()}
+              prefix={<PauseIcon />}
+              className={styles.playButton}
+            >
               {t('common:audio.player.pause-audio')}
             </Button>
           ) : (


### PR DESCRIPTION
### Summary
This PR fixes the pause button's styling on a reciter's chapter page e.g . `/reciters/1/1`.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="519" alt="Screen Shot 2022-03-14 at 16 47 41" src="https://user-images.githubusercontent.com/15169499/158149617-c1d1bcc0-8488-40a0-bd76-94c4c60a81e8.png">|<img width="529" alt="Screen Shot 2022-03-14 at 16 47 32" src="https://user-images.githubusercontent.com/15169499/158149612-11032c3a-eec6-455b-b980-bcc1e9adfca9.png">|