### PR TITLE
Handle empty tafsir text

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -195,7 +195,8 @@
         "font-size": "Tafsir font size",
         "group-message": "You are reading a tafsir for the group of verses {{from}} to {{to}}",
         "surah": "Tafsir Surah",
-        "title": "Tafsir"
+        "title": "Tafsir",
+        "no-text": "{{tafsirName}} is not available for the current verse."
     },
     "tarteel": {
         "app": "Tarteel app",

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -11,6 +11,7 @@ import LanguageAndTafsirSelection from './LanguageAndTafsirSelection';
 import SurahAndAyahSelection from './SurahAndAyahSelection';
 import TafsirEndOfScrollingActions from './TafsirEndOfScrollingActions';
 import TafsirGroupMessage from './TafsirGroupMessage';
+import TafsirMessage from './TafsirMessage';
 import TafsirSkeleton from './TafsirSkeleton';
 import TafsirText from './TafsirText';
 import TafsirVerseText from './TafsirVerseText';
@@ -70,7 +71,7 @@ const TafsirBody = ({
 }: TafsirBodyProps) => {
   const dispatch = useDispatch();
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
-  const { lang } = useTranslation();
+  const { lang, t } = useTranslation('common');
   const userPreferredTafsirIds = useSelector(selectSelectedTafsirs, areArraysEqual);
   const isUsingDefaultFont = useSelector(selectIsUsingDefaultFont);
 
@@ -143,8 +144,6 @@ const TafsirBody = ({
       const { verses, text, languageId } = data.tafsir;
       const langData = getLanguageDataById(languageId);
 
-      if (!text) return <TafsirSkeleton />;
-
       const [firstVerseKey, lastVerseKey] = getFirstAndLastVerseKeys(verses);
       const [chapterNumber, verseNumber] = getVerseAndChapterNumbersFromKey(lastVerseKey);
       const hasNextVerseGroup = !isLastVerseOfSurah(chapterNumber, Number(verseNumber));
@@ -182,7 +181,14 @@ const TafsirBody = ({
 
       return (
         <div>
-          {Object.values(verses).length > 1 && (
+          {!text && (
+            <TafsirMessage>
+              {t('tafsir.no-text', {
+                tafsirName: data.tafsir.translatedName.name,
+              })}
+            </TafsirMessage>
+          )}
+          {Object.values(verses).length > 1 && !!text && (
             <TafsirGroupMessage from={firstVerseKey} to={lastVerseKey} />
           )}
           <div className={styles.verseTextContainer}>
@@ -191,7 +197,9 @@ const TafsirBody = ({
           <div className={styles.separatorContainer}>
             <Separator />
           </div>
-          <TafsirText direction={langData.direction} languageCode={langData.code} text={text} />
+          {!!text && (
+            <TafsirText direction={langData.direction} languageCode={langData.code} text={text} />
+          )}
           <TafsirEndOfScrollingActions
             hasNextVerseGroup={hasNextVerseGroup}
             hasPrevVerseGroup={hasPrevVerseGroup}
@@ -201,7 +209,7 @@ const TafsirBody = ({
         </div>
       );
     },
-    [lang, scrollToTop, selectedChapterId, selectedTafsirIdOrSlug],
+    [lang, scrollToTop, selectedChapterId, selectedTafsirIdOrSlug, t],
   );
 
   // Whether we should use the initial tafsir data or fetch the data on the client side

--- a/src/components/QuranReader/TafsirView/TafsirGroupMessage.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirGroupMessage.tsx
@@ -1,6 +1,6 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import styles from './TafsirView.module.scss';
+import TafsirMessage from './TafsirMessage';
 
 type TafsirGroupMessageProps = {
   from: string;
@@ -10,12 +10,12 @@ type TafsirGroupMessageProps = {
 const TafsirGroupMessage = ({ from, to }: TafsirGroupMessageProps) => {
   const { t } = useTranslation('common');
   return (
-    <div className={styles.tafsirGroupMessage}>
+    <TafsirMessage>
       {t('tafsir.group-message', {
         from,
         to,
       })}
-    </div>
+    </TafsirMessage>
   );
 };
 

--- a/src/components/QuranReader/TafsirView/TafsirMessage/TafsirMessage.module.scss
+++ b/src/components/QuranReader/TafsirView/TafsirMessage/TafsirMessage.module.scss
@@ -1,0 +1,9 @@
+.tafsirMessage {
+  position: relative;
+  padding: var(--spacing-medium);
+  margin-block-end: var(--spacing-medium);
+  background: var(--color-success-faded);
+  border-radius: var(--border-radius-default);
+  border: 1px solid var(--color-success-faint);
+  font-size: var(--font-size-normal);
+}

--- a/src/components/QuranReader/TafsirView/TafsirMessage/index.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirMessage/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import styles from './TafsirMessage.module.scss';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const TafsirMessage: React.FC<Props> = ({ children }) => {
+  return <div className={styles.tafsirMessage}>{children}</div>;
+};
+
+export default TafsirMessage;

--- a/src/components/QuranReader/TafsirView/TafsirView.module.scss
+++ b/src/components/QuranReader/TafsirView/TafsirView.module.scss
@@ -157,16 +157,6 @@ $container-max-width: calc(23 * var(--spacing-mega));
   margin-block-start: var(--spacing-small);
 }
 
-.tafsirGroupMessage {
-  position: relative;
-  padding: var(--spacing-medium);
-  margin-block-end: var(--spacing-medium);
-  background: var(--color-success-faded);
-  border-radius: var(--border-radius-default);
-  border: 1px solid var(--color-success-faint);
-  font-size: var(--font-size-normal);
-}
-
 .languageSelection {
   min-width: calc(6 * var(--spacing-medium));
   width: calc(6 * var(--spacing-medium));


### PR DESCRIPTION
### Summary
Based on user [feedback](https://feedback.quran.com/b/bugs/tafsir-dosent-always-load), this PR shows a message when the text of a Tafsir is empty instead of showing a skeleton which confuses people to think that the Tafsir text is about to be shown. An example on a Tafsir with empty text: https://quran.com/46:25/tafsirs/tafisr-fathul-majid-bn

### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
|<img width="705" alt="Screen Shot 2022-03-15 at 19 36 09" src="https://user-images.githubusercontent.com/15169499/158378964-97f7d6f6-1140-4922-9949-1040a860bf47.png">|<img width="725" alt="Screen Shot 2022-03-15 at 19 36 06" src="https://user-images.githubusercontent.com/15169499/158378951-84c9f9f4-88a7-4dca-918c-324aef6a2e8c.png">|