### PR TITLE
Include chapterId in reciter chapters search

### DIFF
--- a/src/pages/reciters/[reciterId]/index.tsx
+++ b/src/pages/reciters/[reciterId]/index.tsx
@@ -24,7 +24,7 @@ import Reciter from 'types/Reciter';
 
 const filterChapters = (chapters, searchQuery: string) => {
   const fuse = new Fuse(chapters, {
-    keys: ['transliteratedName'],
+    keys: ['transliteratedName', 'id', 'localizedId'],
     threshold: 0.3,
   });
 


### PR DESCRIPTION
### Summary
This PR makes it possible to use the chapter ID to search for a chapter in the list of chapters of a specific reciter e.g. `/reciters/1`