### PR TITLE
lighter text color on dark mode

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
@@ -1,5 +1,6 @@
 @use "src/styles/utility";
 @use "src/components/QuranReader/TranslationView/TranslationText/footnote";
+@use "src/styles/theme";
 
 $translation-line-height: 1.5;
 
@@ -8,6 +9,9 @@ $translation-line-height: 1.5;
   letter-spacing: 0;
   line-height: $translation-line-height;
   padding-block-end: var(--spacing-micro);
+  @include theme.dark {
+    opacity: var(--opacity-85);
+  }
 }
 
 @include utility.generate-font-scales("translation");

--- a/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationText/TranslationText.module.scss
@@ -9,9 +9,6 @@ $translation-line-height: 1.5;
   letter-spacing: 0;
   line-height: $translation-line-height;
   padding-block-end: var(--spacing-micro);
-  @include theme.dark {
-    opacity: var(--opacity-85);
-  }
 }
 
 @include utility.generate-font-scales("translation");

--- a/src/components/Verse/VerseText.module.scss
+++ b/src/components/Verse/VerseText.module.scss
@@ -7,10 +7,6 @@
   display: flex;
   align-items: center;
   line-height: var(--line-height);
-
-  @include theme.dark {
-    opacity: var(--opacity-85);
-  }
 }
 .verseTextContainer {
   display: block;

--- a/src/components/Verse/VerseText.module.scss
+++ b/src/components/Verse/VerseText.module.scss
@@ -1,11 +1,16 @@
 @use "src/styles/constants";
 @use "src/styles/utility";
 @use "src/styles/breakpoints";
+@use "src/styles/theme";
 
 .verseText {
   display: flex;
   align-items: center;
   line-height: var(--line-height);
+
+  @include theme.dark {
+    opacity: var(--opacity-85);
+  }
 }
 .verseTextContainer {
   display: block;

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -26,7 +26,7 @@
   --color-warning-medium: #f7b955;
   --color-warning-deep: #ffefcf;
 
-  --color-text-default: #fff;
+  --color-text-default: #e7e9ea;
   --color-text-faded: #777;
   --color-text-inverse: #000;
   --color-text-link: #2ca4ab;


### PR DESCRIPTION
## Before
<img width="823" alt="image" src="https://user-images.githubusercontent.com/12745166/158767127-0bf7b3e9-f2d4-4d6f-a777-2ba46faca85a.png">



## After

<img width="697" alt="image" src="https://user-images.githubusercontent.com/12745166/158766974-23a9befd-b9d8-41c0-8e7c-5715bd8712ed.png">


## Accessibility

<img width="422" alt="image" src="https://user-images.githubusercontent.com/12745166/158766877-584d71ff-de92-45b2-907a-97078c70eb92.png">


---

In Apple's safari reading mode , the text is also a bit transparent, and it feels sligtly more comfortable