### PR TITLE
[Perf] Lazy-load sidebar navigation selection lists

### DIFF
--- a/src/components/QuranReader/SidebarNavigation/SidebarNavigation.tsx
+++ b/src/components/QuranReader/SidebarNavigation/SidebarNavigation.tsx
@@ -3,13 +3,12 @@ import { useRef } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
-import dynamic from 'next/dynamic';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 
 import IconClose from '../../../../public/icons/close.svg';
 
 import styles from './SidebarNavigation.module.scss';
-import SidebarSelectionSkeleton from './SidebarSelectionSkeleton';
+import SidebarNavigationSelections from './SidebarNavigationSelections';
 
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import KeyboardInput from 'src/components/dls/KeyboardInput';
@@ -24,16 +23,6 @@ import {
   setIsVisible,
 } from 'src/redux/slices/QuranReader/sidebarNavigation';
 import { logButtonClick, logEvent, logValueChange } from 'src/utils/eventLogger';
-
-const PageSelection = dynamic(() => import('./PageSelection'), {
-  loading: SidebarSelectionSkeleton,
-});
-const SurahSelection = dynamic(() => import('./SurahSelection'), {
-  loading: SidebarSelectionSkeleton,
-});
-const JuzSelection = dynamic(() => import('./JuzSelection'), {
-  loading: SidebarSelectionSkeleton,
-});
 
 const SidebarNavigation = () => {
   const { isExpanded: isContextMenuExpanded } = useSelector(selectContextMenu, shallowEqual);
@@ -104,9 +93,10 @@ const SidebarNavigation = () => {
         <KeyboardInput meta keyboardKey="K" />
       </p>
       <div className={styles.contentContainer}>
-        {selectedNavigationItem === NavigationItem.Surah && <SurahSelection />}
-        {selectedNavigationItem === NavigationItem.Juz && <JuzSelection />}
-        {selectedNavigationItem === NavigationItem.Page && <PageSelection />}
+        <SidebarNavigationSelections
+          isVisible={isVisible}
+          selectedNavigationItem={selectedNavigationItem}
+        />
       </div>
     </div>
   );

--- a/src/components/QuranReader/SidebarNavigation/SidebarNavigationSelections.tsx
+++ b/src/components/QuranReader/SidebarNavigation/SidebarNavigationSelections.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import dynamic from 'next/dynamic';
+
+import SidebarSelectionSkeleton from './SidebarSelectionSkeleton';
+
+import { NavigationItem } from 'src/redux/slices/QuranReader/sidebarNavigation';
+
+const PageSelection = dynamic(() => import('./PageSelection'), {
+  loading: SidebarSelectionSkeleton,
+});
+const SurahSelection = dynamic(() => import('./SurahSelection'), {
+  loading: SidebarSelectionSkeleton,
+});
+const JuzSelection = dynamic(() => import('./JuzSelection'), {
+  loading: SidebarSelectionSkeleton,
+});
+
+type Props = {
+  isVisible: boolean;
+  selectedNavigationItem: string;
+};
+
+const SidebarNavigationSelections: React.FC<Props> = ({ isVisible, selectedNavigationItem }) => {
+  // we skip requesting any selection list if the drawer is not open.
+  if (!isVisible) {
+    return <></>;
+  }
+  if (selectedNavigationItem === NavigationItem.Surah) {
+    return <SurahSelection />;
+  }
+  if (selectedNavigationItem === NavigationItem.Juz) {
+    return <JuzSelection />;
+  }
+  return <PageSelection />;
+};
+
+export default SidebarNavigationSelections;


### PR DESCRIPTION
### Summary
This PR lazy loads the Juz, Surah and Page lists inside the sidebar navigation to 

1. Lower the initial bundle size.
2. Lower The number of elements in the DOM in the initial render.
3. Reduce the time the main thread is busy traversing the DOM tree.

|Screenshots|
| ------ |
|<img width="770" alt="Screen Shot 2022-03-19 at 10 29 53" src="https://user-images.githubusercontent.com/15169499/159105127-61e01bd0-d6d5-483a-8c7e-9924f0f86907.png">|