### PR TITLE
update quran font preview position

### DIFF
--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
@@ -133,11 +133,6 @@ const QuranFontSection = () => {
     <Section>
       <Section.Title>{t('fonts.quran-font')}</Section.Title>
       <Section.Row>
-        <div className={styles.versePreviewContainer}>
-          <VersePreview />
-        </div>
-      </Section.Row>
-      <Section.Row>
         <Switch items={types} selected={selectedType} onSelect={onFontChange} />
       </Section.Row>
       <Section.Row>
@@ -172,7 +167,14 @@ const QuranFontSection = () => {
           }
         />
       </Section.Row>
-      <QuranFontSectionFooter quranFont={quranFont} />
+      <Section.Row>
+        <QuranFontSectionFooter quranFont={quranFont} />
+      </Section.Row>
+      <Section.Row>
+        <div className={styles.versePreviewContainer}>
+          <VersePreview />
+        </div>
+      </Section.Row>
     </Section>
   );
 };


### PR DESCRIPTION
The font preview is now below the + and - button. So it prevent annoying layout shift

<img width="390" alt="image" src="https://user-images.githubusercontent.com/12745166/159153430-4f2156fb-b64e-4fbf-a826-fcfce131ee0c.png">
