### PR TITLE
[Perf] Import lodash module on demand

### DIFF
--- a/src/utils/verse.ts
+++ b/src/utils/verse.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 /* eslint-disable react-func/max-lines-per-function */
-import { random } from 'lodash';
+import random from 'lodash/random';
 import range from 'lodash/range';
 
 import { getAllChaptersData, getChapterData, getRandomChapterId } from './chapter';


### PR DESCRIPTION
### Summary
This PR makes sure all lodash modules are loaded on demand to reduce the bundle size. After this PR `node_modules` bundle size (GZipped) has gone down 35%. 

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="477" alt="Screen Shot 2022-03-20 at 17 38 42" src="https://user-images.githubusercontent.com/15169499/159158991-4544e8f9-60b3-497e-960f-bbf40e65dcf3.png">|<img width="206" alt="Screen Shot 2022-03-20 at 17 39 27" src="https://user-images.githubusercontent.com/15169499/159158995-5913e641-883f-4961-b07c-a7dbed7c3c41.png">|
|<img width="466" alt="Screen Shot 2022-03-20 at 17 57 22" src="https://user-images.githubusercontent.com/15169499/159159030-94854934-7e66-4893-80f4-e8afbd64d538.png">|<img width="171" alt="Screen Shot 2022-03-20 at 17 57 15" src="https://user-images.githubusercontent.com/15169499/159159027-eaa5db7b-74c4-4892-b280-b8116096a2d4.png">|