### PR TITLE
Increase maximum translation font scales

### DIFF
--- a/src/components/DeveloperUtility/FontAdjustment.tsx
+++ b/src/components/DeveloperUtility/FontAdjustment.tsx
@@ -12,6 +12,7 @@ import {
   setQuranFont,
   MAXIMUM_FONT_STEP,
   MAXIMUM_QURAN_FONT_STEP,
+  MAXIMUM_TRANSLATIONS_FONT_STEP,
   decreaseTranslationFontScale,
   increaseTranslationFontScale,
 } from 'src/redux/slices/QuranReader/styles';
@@ -79,7 +80,7 @@ const FontAdjustment = (): JSX.Element => {
         <button
           onClick={() => dispatch({ type: increaseTranslationFontScale.type })}
           type="button"
-          disabled={translationFontScale === MAXIMUM_FONT_STEP}
+          disabled={translationFontScale === MAXIMUM_TRANSLATIONS_FONT_STEP}
         >
           +
         </button>

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -14,7 +14,7 @@ import { setSettingsView, SettingsView } from 'src/redux/slices/navbar';
 import {
   decreaseTranslationFontScale,
   increaseTranslationFontScale,
-  MAXIMUM_FONT_STEP,
+  MAXIMUM_TRANSLATIONS_FONT_STEP,
   MINIMUM_FONT_STEP,
   selectQuranReaderStyles,
 } from 'src/redux/slices/QuranReader/styles';
@@ -115,7 +115,9 @@ const TranslationSection = () => {
           <Counter
             count={translationFontScale}
             onIncrement={
-              MAXIMUM_FONT_STEP === translationFontScale ? null : onFontScaleIncreaseClicked
+              MAXIMUM_TRANSLATIONS_FONT_STEP === translationFontScale
+                ? null
+                : onFontScaleIncreaseClicked
             }
             onDecrement={
               MINIMUM_FONT_STEP === translationFontScale ? null : onFontScaleDecreaseClicked

--- a/src/redux/slices/QuranReader/styles.ts
+++ b/src/redux/slices/QuranReader/styles.ts
@@ -7,6 +7,7 @@ import QuranReaderStyles from 'src/redux/types/QuranReaderStyles';
 import { MushafLines, QuranFont } from 'types/QuranReader';
 
 export const MAXIMUM_QURAN_FONT_STEP = 10;
+export const MAXIMUM_TRANSLATIONS_FONT_STEP = 10;
 export const MAXIMUM_FONT_STEP = 5;
 export const MINIMUM_FONT_STEP = 1;
 

--- a/src/styles/_utility.scss
+++ b/src/styles/_utility.scss
@@ -305,6 +305,11 @@ $scales-map: (
       3: 1.18rem,
       4: 1.4rem,
       5: 2rem,
+      6: 2.3rem,
+      7: 2.7rem,
+      8: 3rem,
+      9: 3.5rem,
+      10: 4rem,
     ),
     mobile: (
       1: 0.85rem,
@@ -312,6 +317,11 @@ $scales-map: (
       3: 1.05rem,
       4: 1.2rem,
       5: 1.5rem,
+      6: 1.8rem,
+      7: 2.1rem,
+      8: 2.4rem,
+      9: 2.75rem,
+      10: 3rem,
     ),
   ),
   tafsir: (


### PR DESCRIPTION
### Summary
This PR increases the maximum translation font scale to 10 instead of 5.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="385" alt="Screen Shot 2022-03-21 at 12 12 16" src="https://user-images.githubusercontent.com/15169499/159208609-d21ff9cc-6707-4af8-bd88-934e82b126ac.png">|<img width="383" alt="Screen Shot 2022-03-21 at 12 12 01" src="https://user-images.githubusercontent.com/15169499/159208598-885cbf68-6b23-465d-b045-9f8e91be164d.png">|