### PR TITLE
refactor tafsir data fetching: use useSWR SSR

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -298,10 +298,9 @@ export const getTafsirContent = (
 ): Promise<TafsirContentResponse> => {
   return fetcher(
     makeTafsirContentUrl(tafsirIdOrSlug as string, verseKey, {
-      locale,
-      words: true,
-      ...getDefaultWordFields(quranFont),
-      ...getMushafId(quranFont, mushafLines),
+      lang: locale,
+      quranFont,
+      mushafLines,
     }),
   );
 };

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -22,7 +22,6 @@ import DataFetcher from 'src/components/DataFetcher';
 import Separator from 'src/components/dls/Separator/Separator';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
-import { getDefaultWordFields, getMushafId } from 'src/utils/api';
 import { makeTafsirContentUrl, makeTafsirsUrl } from 'src/utils/apiPaths';
 import { areArraysEqual } from 'src/utils/array';
 import {
@@ -262,10 +261,9 @@ const TafsirBody = ({
       <DataFetcher
         loading={TafsirSkeleton}
         queryKey={makeTafsirContentUrl(selectedTafsirIdOrSlug, selectedVerseKey, {
-          locale: lang,
-          words: true,
-          ...getDefaultWordFields(quranReaderStyles.quranFont),
-          ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
+          lang,
+          quranFont: quranReaderStyles.quranFont,
+          mushafLines: quranReaderStyles.mushafLines,
         })}
         render={renderTafsir}
       />

--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 /* eslint-disable i18next/no-literal-string */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
@@ -20,10 +20,7 @@ import styles from './TafsirView.module.scss';
 import { fetcher } from 'src/api';
 import DataFetcher from 'src/components/DataFetcher';
 import Separator from 'src/components/dls/Separator/Separator';
-import {
-  selectIsUsingDefaultFont,
-  selectQuranReaderStyles,
-} from 'src/redux/slices/QuranReader/styles';
+import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';
 import { getDefaultWordFields, getMushafId } from 'src/utils/api';
 import { makeTafsirContentUrl, makeTafsirsUrl } from 'src/utils/apiPaths';
@@ -49,7 +46,6 @@ import { TafsirContentResponse, TafsirsResponse } from 'types/ApiResponses';
 type TafsirBodyProps = {
   initialChapterId: string;
   initialVerseNumber: string;
-  initialTafsirData?: TafsirContentResponse;
   initialTafsirIdOrSlug?: number | string;
   scrollToTop: () => void;
   shouldRender?: boolean;
@@ -63,7 +59,6 @@ type TafsirBodyProps = {
 const TafsirBody = ({
   initialChapterId,
   initialVerseNumber,
-  initialTafsirData,
   initialTafsirIdOrSlug,
   render,
   scrollToTop,
@@ -73,7 +68,6 @@ const TafsirBody = ({
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
   const { lang, t } = useTranslation('common');
   const userPreferredTafsirIds = useSelector(selectSelectedTafsirs, areArraysEqual);
-  const isUsingDefaultFont = useSelector(selectIsUsingDefaultFont);
 
   const [selectedChapterId, setSelectedChapterId] = useState(initialChapterId);
   const [selectedVerseNumber, setSelectedVerseNumber] = useState(initialVerseNumber);
@@ -212,25 +206,6 @@ const TafsirBody = ({
     [lang, scrollToTop, selectedChapterId, selectedTafsirIdOrSlug, t],
   );
 
-  // Whether we should use the initial tafsir data or fetch the data on the client side
-  const shouldUseInitialTafsirData = useMemo(
-    () =>
-      initialTafsirData &&
-      isUsingDefaultFont &&
-      Object.keys(initialTafsirData.tafsir.verses).includes(
-        makeVerseKey(Number(selectedChapterId), Number(selectedVerseNumber)),
-      ) &&
-      (selectedTafsirIdOrSlug === initialTafsirData?.tafsir?.slug ||
-        Number(selectedTafsirIdOrSlug) === initialTafsirData?.tafsir?.resourceId),
-    [
-      initialTafsirData,
-      isUsingDefaultFont,
-      selectedChapterId,
-      selectedTafsirIdOrSlug,
-      selectedVerseNumber,
-    ],
-  );
-
   const surahAndAyahSelection = (
     <SurahAndAyahSelection
       selectedChapterId={selectedChapterId}
@@ -284,20 +259,16 @@ const TafsirBody = ({
         styles[`tafsir-font-size-${quranReaderStyles.tafsirFontScale}`],
       )}
     >
-      {shouldUseInitialTafsirData ? (
-        renderTafsir(initialTafsirData)
-      ) : (
-        <DataFetcher
-          loading={TafsirSkeleton}
-          queryKey={makeTafsirContentUrl(selectedTafsirIdOrSlug, selectedVerseKey, {
-            locale: lang,
-            words: true,
-            ...getDefaultWordFields(quranReaderStyles.quranFont),
-            ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
-          })}
-          render={renderTafsir}
-        />
-      )}
+      <DataFetcher
+        loading={TafsirSkeleton}
+        queryKey={makeTafsirContentUrl(selectedTafsirIdOrSlug, selectedVerseKey, {
+          locale: lang,
+          words: true,
+          ...getDefaultWordFields(quranReaderStyles.quranFont),
+          ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
+        })}
+        render={renderTafsir}
+      />
     </div>
   );
 

--- a/src/pages/[chapterId]/[verseId]/tafsirs.tsx
+++ b/src/pages/[chapterId]/[verseId]/tafsirs.tsx
@@ -2,10 +2,11 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
+import { SWRConfig } from 'swr';
 
 import styles from './tafsirs.module.scss';
 
-import { getChapterIdBySlug, getTafsirContent } from 'src/api';
+import { fetcher, getChapterIdBySlug } from 'src/api';
 import NextSeoWrapper from 'src/components/NextSeoWrapper';
 import TafsirBody from 'src/components/QuranReader/TafsirView/TafsirBody';
 import Error from 'src/pages/_error';
@@ -13,6 +14,8 @@ import {
   getQuranReaderStylesInitialState,
   getTafsirsInitialState,
 } from 'src/redux/defaultSettings/util';
+import { getDefaultWordFields, getMushafId } from 'src/utils/api';
+import { makeTafsirContentUrl, makeTafsirsUrl } from 'src/utils/apiPaths';
 import { getChapterData } from 'src/utils/chapter';
 import { getLanguageAlternates, toLocalizedNumber } from 'src/utils/locale';
 import {
@@ -26,16 +29,16 @@ import {
 } from 'src/utils/staticPageGeneration';
 import { isValidVerseId } from 'src/utils/validator';
 import { makeVerseKey } from 'src/utils/verse';
-import { ChapterResponse, TafsirContentResponse, VersesResponse } from 'types/ApiResponses';
+import { ChapterResponse, VersesResponse } from 'types/ApiResponses';
 
 type AyahTafsirProp = {
   chapter?: ChapterResponse;
   verses?: VersesResponse;
-  tafsirData?: TafsirContentResponse;
   hasError?: boolean;
+  fallback: any;
 };
 
-const AyahTafsir: NextPage<AyahTafsirProp> = ({ hasError, chapter, tafsirData }) => {
+const AyahTafsir: NextPage<AyahTafsirProp> = ({ hasError, chapter, fallback }) => {
   const { t, lang } = useTranslation('common');
   const router = useRouter();
   const {
@@ -60,25 +63,28 @@ const AyahTafsir: NextPage<AyahTafsirProp> = ({ hasError, chapter, tafsirData })
           surahName: chapter.chapter.transliteratedName,
         })}
       />
-      <div className={styles.tafsirContainer}>
-        <TafsirBody
-          shouldRender
-          initialChapterId={chapter.chapter.id.toString()}
-          initialVerseNumber={verseId.toString()}
-          initialTafsirData={tafsirData}
-          initialTafsirIdOrSlug={router.query.tafsirId ? Number(router.query.tafsirId) : undefined}
-          scrollToTop={scrollWindowToTop}
-          render={({ body, languageAndTafsirSelection, surahAndAyahSelection }) => {
-            return (
-              <div>
-                {surahAndAyahSelection}
-                {languageAndTafsirSelection}
-                {body}
-              </div>
-            );
-          }}
-        />
-      </div>
+      <SWRConfig value={{ fallback }}>
+        <div className={styles.tafsirContainer}>
+          <TafsirBody
+            shouldRender
+            initialChapterId={chapter.chapter.id.toString()}
+            initialVerseNumber={verseId.toString()}
+            initialTafsirIdOrSlug={
+              router.query.tafsirId ? Number(router.query.tafsirId) : undefined
+            }
+            scrollToTop={scrollWindowToTop}
+            render={({ body, languageAndTafsirSelection, surahAndAyahSelection }) => {
+              return (
+                <div>
+                  {surahAndAyahSelection}
+                  {languageAndTafsirSelection}
+                  {body}
+                </div>
+              );
+            }}
+          />
+        </div>
+      </SWRConfig>
     </>
   );
 };
@@ -106,19 +112,32 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
 
     const chapterData = getChapterData(chapterIdOrSlug, locale);
     const { quranFont, mushafLines } = getQuranReaderStylesInitialState(locale);
-    const tafsirData = await getTafsirContent(
+
+    const tafsirContentUrl = makeTafsirContentUrl(
       getTafsirsInitialState(locale).selectedTafsirs[0],
       makeVerseKey(Number(chapterIdOrSlug), Number(verseId)),
-      quranFont,
-      mushafLines,
-      locale,
+      {
+        locale,
+        words: true,
+        ...getDefaultWordFields(quranFont),
+        ...getMushafId(quranFont, mushafLines),
+      },
     );
+    const tafsirListUrl = makeTafsirsUrl(locale);
+
+    const [tafsirContentData, tafsirListData] = await Promise.all([
+      fetcher(tafsirContentUrl),
+      fetcher(tafsirListUrl),
+    ]);
 
     if (!chapterData) return notFoundResponse;
 
     return {
       props: {
-        tafsirData,
+        fallback: {
+          [tafsirContentUrl]: tafsirContentData,
+          [tafsirListUrl]: tafsirListData,
+        },
         chapter: {
           chapter: { ...chapterData, id: chapterIdOrSlug },
         },

--- a/src/pages/[chapterId]/[verseId]/tafsirs.tsx
+++ b/src/pages/[chapterId]/[verseId]/tafsirs.tsx
@@ -14,7 +14,6 @@ import {
   getQuranReaderStylesInitialState,
   getTafsirsInitialState,
 } from 'src/redux/defaultSettings/util';
-import { getDefaultWordFields, getMushafId } from 'src/utils/api';
 import { makeTafsirContentUrl, makeTafsirsUrl } from 'src/utils/apiPaths';
 import { getChapterData } from 'src/utils/chapter';
 import { getLanguageAlternates, toLocalizedNumber } from 'src/utils/locale';
@@ -117,10 +116,9 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
       getTafsirsInitialState(locale).selectedTafsirs[0],
       makeVerseKey(Number(chapterIdOrSlug), Number(verseId)),
       {
-        locale,
-        words: true,
-        ...getDefaultWordFields(quranFont),
-        ...getMushafId(quranFont, mushafLines),
+        lang: locale,
+        quranFont,
+        mushafLines,
       },
     );
     const tafsirListUrl = makeTafsirsUrl(locale);

--- a/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
+++ b/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
@@ -126,6 +126,7 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
           [tafsirListUrl]: tafsirListData,
           [tafsirContentUrl]: tafsirContentData,
         },
+        tafsirData: tafsirContentData,
         chapterId: chapterNumber,
         chapter: { chapter: getChapterData(chapterNumber, locale) },
         verseNumber,

--- a/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
+++ b/src/pages/[chapterId]/tafsirs/[tafsirId].tsx
@@ -12,7 +12,6 @@ import NextSeoWrapper from 'src/components/NextSeoWrapper';
 import TafsirBody from 'src/components/QuranReader/TafsirView/TafsirBody';
 import Error from 'src/pages/_error';
 import { getQuranReaderStylesInitialState } from 'src/redux/defaultSettings/util';
-import { getDefaultWordFields, getMushafId } from 'src/utils/api';
 import { makeTafsirContentUrl, makeTafsirsUrl } from 'src/utils/apiPaths';
 import { getChapterData } from 'src/utils/chapter';
 import { getLanguageAlternates, toLocalizedNumber } from 'src/utils/locale';
@@ -108,10 +107,9 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
   const { quranFont, mushafLines } = getQuranReaderStylesInitialState(locale);
   try {
     const tafsirContentUrl = makeTafsirContentUrl(tafsirIdOrSlug as string, verseKey, {
-      locale,
-      words: true,
-      ...getDefaultWordFields(quranFont),
-      ...getMushafId(quranFont, mushafLines),
+      lang: locale,
+      quranFont,
+      mushafLines,
     });
     const tafsirListUrl = makeTafsirsUrl(locale);
 

--- a/src/utils/apiPaths.ts
+++ b/src/utils/apiPaths.ts
@@ -1,4 +1,4 @@
-import { ITEMS_PER_PAGE, makeUrl } from './api';
+import { getDefaultWordFields, getMushafId, ITEMS_PER_PAGE, makeUrl } from './api';
 
 import {
   getAudioPlayerStateInitialState,
@@ -157,8 +157,16 @@ export const makeTafsirsUrl = (language: string): string =>
 export const makeTafsirContentUrl = (
   tafsirId: number | string,
   verseKey: string,
-  params: Record<string, unknown>,
-) => makeUrl(`/tafsirs/${tafsirId}/by_ayah/${verseKey}`, params);
+  options: { lang: string; quranFont: QuranFont; mushafLines: MushafLines },
+) => {
+  const params = {
+    locale: options.lang,
+    words: true,
+    ...getDefaultWordFields(options.quranFont),
+    ...getMushafId(options.quranFont, options.mushafLines),
+  };
+  return makeUrl(`/tafsirs/${tafsirId}/by_ayah/${verseKey}`, params);
+};
 
 /**
  * Compose the url for the pages look up API.


### PR DESCRIPTION
SWR has this feature to simplify data loading process with nextjs https://swr.vercel.app/docs/with-nextjs

so instead of checking manually `shouldUseInitialTafsirData` we can leverage this SWR feature to simplify our logic