### PR TITLE
Downgrade prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "lint-staged": "^12.3.7",
     "next-sitemap": "^2.5.13",
     "node-fetch": "3.2.3",
-    "prettier": "^2.6.0",
+    "prettier": "^2.5.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "replace-in-file": "^6.3.2",
     "sass": "^1.49.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14971,7 +14971,7 @@ prettier-linter-helpers@^1.0.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
-prettier@^2.6.0:
+prettier@^2.5.1:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
   integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==


### PR DESCRIPTION
### Summary
There seems to be an [issue](https://github.com/prettier/prettier/issues/12504) with Prettier `v2.6.0` so this PR downgrades the version back to `2.5.1`.

| Screenshots |
| ------ |
|<img width="898" alt="Screen Shot 2022-03-23 at 10 17 16" src="https://user-images.githubusercontent.com/15169499/159617268-eb97a182-26a1-4712-bbff-4721bc8d2f02.png">|