### PR TITLE
Fix search drawer missing context data exception

### DIFF
--- a/src/components/Search/PreInput/index.tsx
+++ b/src/components/Search/PreInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
@@ -11,7 +11,7 @@ import SearchQuerySuggestion from './SearchQuerySuggestion';
 
 import Link from 'src/components/dls/Link/Link';
 import SearchHistory from 'src/components/Search/SearchHistory';
-import DataContext from 'src/contexts/DataContext';
+import useGetChaptersData from 'src/hooks/useGetChaptersData';
 import { getChapterData } from 'src/utils/chapter';
 import { logButtonClick } from 'src/utils/eventLogger';
 import { toLocalizedNumber, toLocalizedVerseKey } from 'src/utils/locale';
@@ -26,7 +26,10 @@ const POPULAR_SEARCH_QUERIES = { Mulk: 67, Noah: 71, Kahf: 18, Yaseen: 36 };
 
 const PreInput: React.FC<Props> = ({ onSearchKeywordClicked, isSearchDrawer }) => {
   const { t, lang } = useTranslation('common');
-  const chaptersData = useContext(DataContext);
+  const chaptersData = useGetChaptersData(lang);
+  if (!chaptersData) {
+    return <></>;
+  }
   const SEARCH_FOR_KEYWORDS = [
     `${t('juz')} ${toLocalizedNumber(1, lang)}`,
     `${t('page')} ${toLocalizedNumber(1, lang)}`,


### PR DESCRIPTION
### Summary
This PR fixes the issue with chapters data not being available in `DataContext` when opening the Search drawer because `Navbar` is higher in the components tree than the `DataContext` provider since it belongs to `_app`.

| Screenshots |
| ------ | 
|<img width="964" alt="Screen Shot 2022-03-23 at 19 00 40" src="https://user-images.githubusercontent.com/15169499/159694763-74fefe75-f776-4404-9938-1192be7ba1f0.png">|