### PR TITLE
add next and prev icon to chaper's end of scrolling

### DIFF
--- a/src/components/QuranReader/EndOfScrollingControls/ChapterControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/ChapterControls.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import EndOfScrollingButton from './EndOfScrollingButton';
+import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
+import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
 
+import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import useScrollToTop from 'src/hooks/useScrollToTop';
 import { isFirstSurah, isLastSurah } from 'src/utils/chapter';
 import { logButtonClick } from 'src/utils/eventLogger';
@@ -22,29 +24,38 @@ const ChapterControls: React.FC<Props> = ({ lastVerse }) => {
   return (
     <>
       {!isFirstSurah(chapterNumber) && (
-        <EndOfScrollingButton
-          text={t('prev-surah')}
+        <Button
+          type={ButtonType.Secondary}
+          prefix={<ChevronLeftIcon />}
           href={getSurahNavigationUrl(chapterNumber - 1)}
           onClick={() => {
             logButtonClick('chapter_control_prev_chapter');
           }}
-        />
+        >
+          {t('prev-surah')}
+        </Button>
       )}
-      <EndOfScrollingButton
-        text={t('surah-beginning')}
+      <Button
+        type={ButtonType.Secondary}
+        href={getSurahNavigationUrl(chapterNumber + 1)}
         onClick={() => {
           logButtonClick('chapter_control_scroll_to_beginning');
           scrollToTop();
         }}
-      />
+      >
+        {t('surah-beginning')}
+      </Button>
       {!isLastSurah(chapterNumber) && (
-        <EndOfScrollingButton
-          text={t('next-surah')}
+        <Button
+          type={ButtonType.Secondary}
+          suffix={<ChevronRightIcon />}
           href={getSurahNavigationUrl(chapterNumber + 1)}
           onClick={() => {
             logButtonClick('chapter_control_next_chapter');
           }}
-        />
+        >
+          {t('next-surah')}
+        </Button>
       )}
     </>
   );

--- a/src/components/QuranReader/EndOfScrollingControls/ChapterControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/ChapterControls.tsx
@@ -21,6 +21,7 @@ const ChapterControls: React.FC<Props> = ({ lastVerse }) => {
   const scrollToTop = useScrollToTop();
   const { chapterId } = lastVerse;
   const chapterNumber = Number(chapterId);
+
   return (
     <>
       {!isFirstSurah(chapterNumber) && (


### PR DESCRIPTION
It's easier to parse the information when there's an image/icon.
If this PR is good, will add the icon to the other EndOfScrolling as well, (juz and page)

## Before
<img width="552" alt="image" src="https://user-images.githubusercontent.com/12745166/160269241-54bedcf9-d5b6-4b6d-abf3-38fe41d67a9c.png">


## After

<img width="764" alt="image" src="https://user-images.githubusercontent.com/12745166/160269233-0c5d82a2-89a1-47fc-b75a-d3d6a2b429ea.png">
