### PR TITLE
[PWA] add production mode

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,7 @@ const config = {
   pwa: {
     disable: !isProduction,
     dest: 'public',
+    mode: isProduction ? 'production' : 'development',
     runtimeCaching,
     publicExcludes: [
       '!fonts/**/!(sura_names|ProximaVara)*', // exclude pre-caching all fonts that are not sura_names or ProximaVara


### PR DESCRIPTION
### Summary
This PR adds production `mode` to PWA configs as per the [documentation's recommendation](https://github.com/shadowwalker/next-pwa#tips):

>Force next-pwa to generate worker box production build by specify the option mode: 'production' in your pwa section of next.config.js. Though next-pwa automatically generate the worker box development build during development (by running next) and worker box production build during production (by running next build and next start). You may still want to force it to production build even during development of your web app for following reason:
>1. Reduce logging noise due to production build doesn't include logging.
>2. Improve performance a bit due to production build is optimized and minified.