### PR TITLE
search drawer: add "clear" separator & switch position

### DIFF
--- a/src/components/Navbar/SearchDrawer/Header/Header.module.scss
+++ b/src/components/Navbar/SearchDrawer/Header/Header.module.scss
@@ -33,3 +33,8 @@
   color: var(--color-text-default);
   font-size: var(--font-size-small);
 }
+
+.separator {
+  max-height: var(--spacing-mega);
+  margin-inline: calc(0.5 * var(--spacing-xxsmall));
+}

--- a/src/components/Navbar/SearchDrawer/Header/index.tsx
+++ b/src/components/Navbar/SearchDrawer/Header/index.tsx
@@ -7,6 +7,7 @@ import DrawerSearchIcon from '../Buttons/DrawerSearchIcon';
 
 import styles from './Header.module.scss';
 
+import Separator from 'src/components/dls/Separator/Separator';
 import TarteelVoiceSearchTrigger from 'src/components/TarteelVoiceSearch/Trigger';
 import useElementComputedPropertyValue from 'src/hooks/useElementComputedPropertyValue';
 import { logButtonClick } from 'src/utils/eventLogger';
@@ -65,16 +66,19 @@ const Header: React.FC<Props> = ({
                 disabled={isSearching}
               />
             </form>
+            {searchQuery && (
+              <>
+                <button type="button" className={styles.clear} onClick={resetQueryAndResults}>
+                  {t('input.clear')}
+                </button>
+                <Separator isVertical className={styles.separator} />
+              </>
+            )}
             <TarteelVoiceSearchTrigger
               onClick={() => {
                 logButtonClick('search_drawer_voice_search_start_flow');
               }}
             />
-            {searchQuery && (
-              <button type="button" className={styles.clear} onClick={resetQueryAndResults}>
-                {t('input.clear')}
-              </button>
-            )}
           </div>
         </>
       )}


### PR DESCRIPTION
**Note** : This PR has nothing to do with the RTL issue

1. on Google the "clear" or "x" button is always on the left side. It doesn't push the microphone icon to when it becomes visible
<img width="624" alt="image" src="https://user-images.githubusercontent.com/12745166/161002847-556e27c7-8931-40fc-b104-02dc23fede5b.png">


2. There's a tiny separator line to indicate that the the microphone and searchbox is separated

## Before



<img width="394" alt="image" src="https://user-images.githubusercontent.com/12745166/161002542-0d993bd3-e19d-40a9-a31d-359591497c6f.png">


## After

<img width="394" alt="image" src="https://user-images.githubusercontent.com/12745166/161002469-f0fb5908-afa6-4b26-8470-18e520099dd3.png">
