### PR TITLE
Handle when translation name is not in the response

### DIFF
--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -62,15 +62,15 @@ const TranslationSection = () => {
       );
 
       let selectedValueString = t('settings.no-translation-selected');
-      if (selectedTranslations.length === 1) selectedValueString = firstSelectedTranslation.name;
+      if (selectedTranslations.length === 1) selectedValueString = firstSelectedTranslation?.name;
       if (selectedTranslations.length === 2)
         selectedValueString = t('settings.value-and-other', {
-          value: firstSelectedTranslation.name,
+          value: firstSelectedTranslation?.name,
           othersCount: localizedSelectedTranslations,
         });
       if (selectedTranslations.length > 2)
         selectedValueString = t('settings.value-and-others', {
-          value: firstSelectedTranslation.name,
+          value: firstSelectedTranslation?.name,
           othersCount: localizedSelectedTranslations,
         });
 


### PR DESCRIPTION
### Screenshots

| Before | After |
| ------ | ------ |
|<img width="745" alt="Screen Shot 2022-04-03 at 5 14 16 PM" src="https://user-images.githubusercontent.com/15169499/161434812-b6013a04-7238-4bfb-871e-64502f7a2817.png">|<img width="388" alt="Screen Shot 2022-04-03 at 5 07 33 PM" src="https://user-images.githubusercontent.com/15169499/161434767-fccd91c4-5fb8-41e9-8318-8953d6297e43.png">|