### PR TITLE
Add audioPlayer lazy loading indicator

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.module.scss
+++ b/src/components/AudioPlayer/AudioPlayer.module.scss
@@ -23,3 +23,9 @@
 .containerHidden {
   display: none;
 }
+
+.spinner {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React, { useCallback, useEffect, useRef } from 'react';
 
 import classNames from 'classnames';
@@ -8,6 +9,7 @@ import usePlayNextAudioTrackForRadio from '../Radio/usePlayNextAudioTrackForRadi
 
 import styles from './AudioPlayer.module.scss';
 
+import Spinner from 'src/components/dls/Spinner/Spinner';
 import {
   setIsPlaying,
   selectAudioDataStatus,
@@ -19,6 +21,11 @@ import AudioDataStatus from 'src/redux/types/AudioDataStatus';
 
 const AudioPlayerBody = dynamic(() => import('./AudioPlayerBody'), {
   ssr: false,
+  loading: () => (
+    <div className={styles.spinner}>
+      <Spinner />
+    </div>
+  ),
 });
 
 const AudioPlayer = () => {


### PR DESCRIPTION
### Summary
This PR adds loading indicator while the `AudioPlayerBody` component is being loaded.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="1440" alt="Screen Shot 2022-04-08 at 10 26 30 AM" src="https://user-images.githubusercontent.com/15169499/162397010-13dfc4bd-58d5-4c4a-a37a-32b95428fdfe.png">|<img width="1440" alt="Screen Shot 2022-04-08 at 10 26 18 AM" src="https://user-images.githubusercontent.com/15169499/162396999-9259c057-e006-4106-9a19-323b76da8520.png">|