### PR TITLE
switch settings and search icon position

### DIFF
--- a/src/components/Navbar/NavbarBody/index.tsx
+++ b/src/components/Navbar/NavbarBody/index.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from 'react-redux';
 import IconMenu from '../../../../public/icons/menu.svg';
 import IconSearch from '../../../../public/icons/search.svg';
 import IconSettings from '../../../../public/icons/settings.svg';
-import LanguageSelector from '../LanguageSelector';
 import NavbarLogoWrapper from '../Logo/NavbarLogoWrapper';
 import NavigationDrawer from '../NavigationDrawer/NavigationDrawer';
 import SearchDrawer from '../SearchDrawer/SearchDrawer';
@@ -71,19 +70,6 @@ const NavbarBody: React.FC = () => {
       <div className={styles.centerVertically}>
         <div className={styles.rightCTA}>
           <>
-            <LanguageSelector />
-            <Button
-              tooltip={t('settings.title')}
-              shape={ButtonShape.Circle}
-              variant={ButtonVariant.Ghost}
-              onClick={openSettingsDrawer}
-              ariaLabel={t('aria.change-settings')}
-            >
-              <IconSettings />
-            </Button>
-            <SettingsDrawer />
-          </>
-          <>
             <Button
               tooltip={t('search.title')}
               variant={ButtonVariant.Ghost}
@@ -95,6 +81,18 @@ const NavbarBody: React.FC = () => {
               <IconSearch />
             </Button>
             <SearchDrawer />
+          </>
+          <>
+            <Button
+              tooltip={t('settings.title')}
+              shape={ButtonShape.Circle}
+              variant={ButtonVariant.Ghost}
+              onClick={openSettingsDrawer}
+              ariaLabel={t('aria.change-settings')}
+            >
+              <IconSettings />
+            </Button>
+            <SettingsDrawer />
           </>
         </div>
       </div>


### PR DESCRIPTION
This is very subjective, but I feel like the settings icon should always be on the outer side. (top right)

## Before
<img width="153" alt="image" src="https://user-images.githubusercontent.com/12745166/162659557-edd7f159-cc96-4c2f-96bc-e6ffad801096.png">


## After

<img width="113" alt="image" src="https://user-images.githubusercontent.com/12745166/162659428-a4592813-f8e3-4841-81eb-dc1cb8113328.png">
