### PR TITLE
Fix #1527

### DIFF
--- a/src/pages/[chapterId]/[verseId]/index.tsx
+++ b/src/pages/[chapterId]/[verseId]/index.tsx
@@ -47,7 +47,7 @@ const Verse: NextPage<VerseProps> = ({
 }) => {
   const { t, lang } = useTranslation('common');
   const {
-    query: { verseId },
+    query: { verseId, translations },
   } = useRouter();
   if (hasError || !versesResponse.verses.length) {
     return <Error statusCode={500} />;
@@ -64,8 +64,9 @@ const Verse: NextPage<VerseProps> = ({
         canonical={getCanonicalUrl(lang, path)}
         languageAlternates={getLanguageAlternates(path)}
         description={
-          versesResponse.verses[0].translations?.[0].text ??
-          versesResponse.verses[0].textImlaeiSimple}
+          translations ?
+            versesResponse.verses[0].translations?.[0].text :
+            versesResponse.verses[0].textImlaeiSimple}
       />
       <QuranReader
         initialData={versesResponse}

--- a/src/pages/[chapterId]/[verseId]/index.tsx
+++ b/src/pages/[chapterId]/[verseId]/index.tsx
@@ -63,7 +63,9 @@ const Verse: NextPage<VerseProps> = ({
         }`}
         canonical={getCanonicalUrl(lang, path)}
         languageAlternates={getLanguageAlternates(path)}
-        description={versesResponse.verses[0].textImlaeiSimple}
+        description={
+          versesResponse.verses[0].translations?.[0].text ??
+          versesResponse.verses[0].textImlaeiSimple}
       />
       <QuranReader
         initialData={versesResponse}


### PR DESCRIPTION
### Summary
This is a partial fix for the open graph description tag not taking in consideration the translation parameter.

The reason I said this is a partial fix, because I'm actually using the verse response to get the translation: `versesResponse.verses[0].translations?.[0].text`, and this response is not reflecting changes made in the UI or even if we change the translation param in the url: `?translation=x`

Thus the better solution is to reflect the translation changes in the UI or URL to the api call, which I did not figure out yet

### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
| <img width="597" alt="image" src="https://user-images.githubusercontent.com/17573483/167230876-4b4d33dc-87cc-4607-91f2-5ff2325ba04d.png"> | <img width="599" alt="image" src="https://user-images.githubusercontent.com/17573483/167230803-e0384d7b-51b6-4225-a4a8-a73456f7d9f6.png"> |