### PR TITLE
added a custom scrollbar for RecentReadingSessions

### DIFF
--- a/src/components/Verses/RecentReadingSessions.module.scss
+++ b/src/components/Verses/RecentReadingSessions.module.scss
@@ -1,3 +1,5 @@
+@use "../../styles/breakpoints";
+
 $verseLinkMinWidth: calc(6 * var(--spacing-mega));
 .sessionsContainer {
   padding-block-start: 0;
@@ -25,10 +27,30 @@ $verseLinkMinWidth: calc(6 * var(--spacing-mega));
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
+  padding-bottom: var(--spacing-xxsmall);
+  
   &::-webkit-scrollbar {
     -webkit-appearance: none;
     height: 0;
   }
+
+  @include breakpoints.desktop {
+    &::-webkit-scrollbar {
+      height: 7px;
+    }
+    &::-webkit-scrollbar-track {
+      background: var(--color-success-faint);
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--color-success-medium);
+      border-radius: var(--border-radius-default);
+      border: transparent;
+    }
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: var(--color-success-deep);
+    }
+  }
+
   & > .verseLink {
     min-width: $verseLinkMinWidth;
   }


### PR DESCRIPTION
**🚨 Currently, we don't have any scrollbar to see overflowed contents when using the desktop.**

**_This scrollbar will only appear for desktops ✔️
Suitable with all themes ✔️_**


### Screenshots

| Before | After |
| ------ | ------ |
| ![old3](https://user-images.githubusercontent.com/53380504/174831116-3f4211be-8066-4911-983e-546681430611.png)|![new3](https://user-images.githubusercontent.com/53380504/174831021-c017f1d9-41ae-4485-a77e-d03fa23ce098.png)|