### PR TITLE
Fix #1770

### DIFF
--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -44,12 +44,12 @@ const TranslationSection = () => {
       <div>
         {selectedTranslations.map((id) => (
           <Skeleton key={id}>
-            <div>{id}</div>
+            <div>{t('loading')}</div>
           </Skeleton>
         ))}
       </div>
     ),
-    [selectedTranslations],
+    [selectedTranslations, t],
   );
 
   const localizedSelectedTranslations = useMemo(


### PR DESCRIPTION
### Summary
Replaces the ID with a 'Loading' text when translation list is loading.


### Test Plan

### Screenshots

I was not able to reproduce the bug both on the website and locally.