### PR TITLE
Fix #1773

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -145,8 +145,8 @@ const Search: NextPage<SearchProps> = ({ translations, chaptersData }): JSX.Elem
             // if there is no navigations nor verses in the response
             if (response.pagination.totalRecords === 0 && !response.result.navigation.length) {
               logEmptySearchResults(query, 'search_page');
-            } else if (response.pagination.totalPages <= response.pagination.currentPage) {
-              setCurrentPage(response.pagination.totalPages);
+            } else if (response.pagination.totalPages < page) {
+              setCurrentPage(1);
             }
           }
         })

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -145,6 +145,8 @@ const Search: NextPage<SearchProps> = ({ translations, chaptersData }): JSX.Elem
             // if there is no navigations nor verses in the response
             if (response.pagination.totalRecords === 0 && !response.result.navigation.length) {
               logEmptySearchResults(query, 'search_page');
+            } else if (response.pagination.totalPages <= response.pagination.currentPage) {
+              setCurrentPage(response.pagination.totalPages);
             }
           }
         })


### PR DESCRIPTION
### Summary

If page number is higher or equal to the total page numbers, it updates the current page number to accomodate to the maximum possible page number of the new search result. 

I don't understand why this wouldn't work when I used only < operator, but I also had to use <=. 



