### PR TITLE
Icons import alias

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -41,6 +41,12 @@ module.exports = {
             path.resolve('./'),
         ];
 
+        // Add support for module aliases (same aliases in tsconfig.json)
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            '@/icons': path.resolve(__dirname, "../public/icons"),
+          };
+
         const fileLoaderRule = config.module.rules.find(rule => Array.isArray(rule.test) ? rule.test[0].test('.svg') : rule.test.test('.svg'));
         fileLoaderRule.exclude = /\.svg$/;
         // This is needed for inline svg imports

--- a/src/components/AudioPlayer/Buttons/AudioPlaybackRateMenu.tsx
+++ b/src/components/AudioPlayer/Buttons/AudioPlaybackRateMenu.tsx
@@ -3,9 +3,8 @@ import { useCallback, useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import CheckIcon from '../../../../public/icons/check.svg';
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-
+import CheckIcon from '@/icons/check.svg';
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import Spinner from 'src/components/dls/Spinner/Spinner';
 import { playbackRates } from 'src/components/Navbar/SettingsDrawer/AudioSection';

--- a/src/components/AudioPlayer/Buttons/CloseButton.tsx
+++ b/src/components/AudioPlayer/Buttons/CloseButton.tsx
@@ -2,8 +2,7 @@ import { useContext } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import CloseIcon from '../../../../public/icons/close.svg';
-
+import CloseIcon from '@/icons/close.svg';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import { logButtonClick } from 'src/utils/eventLogger';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';

--- a/src/components/AudioPlayer/Buttons/DownloadAudioButton.tsx
+++ b/src/components/AudioPlayer/Buttons/DownloadAudioButton.tsx
@@ -4,8 +4,7 @@ import { useSelector as useXstateSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, useSelector } from 'react-redux';
 
-import DownloadIcon from '../../../../public/icons/download.svg';
-
+import DownloadIcon from '@/icons/download.svg';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import Spinner, { SpinnerSize } from 'src/components/dls/Spinner/Spinner';
 import {

--- a/src/components/AudioPlayer/Buttons/PlayPauseButton.tsx
+++ b/src/components/AudioPlayer/Buttons/PlayPauseButton.tsx
@@ -3,10 +3,10 @@ import { useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import PauseIcon from '../../../../public/icons/pause.svg';
-import PlayIcon from '../../../../public/icons/play-arrow.svg';
 import SurahAudioMismatchModal from '../SurahAudioMismatchModal';
 
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import Spinner, { SpinnerSize } from 'src/components/dls/Spinner/Spinner';
 import DataContext from 'src/contexts/DataContext';

--- a/src/components/AudioPlayer/Buttons/SelectReciterMenu.tsx
+++ b/src/components/AudioPlayer/Buttons/SelectReciterMenu.tsx
@@ -3,11 +3,10 @@ import React, { useCallback, useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import CheckIcon from '../../../../public/icons/check.svg';
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-
 import styles from './SelectReciterMenu.module.scss';
 
+import CheckIcon from '@/icons/check.svg';
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
 import DataFetcher from 'src/components/DataFetcher';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import Spinner from 'src/components/dls/Spinner/Spinner';

--- a/src/components/AudioPlayer/OverflowAudioPlayActionsMenuBody.tsx
+++ b/src/components/AudioPlayer/OverflowAudioPlayActionsMenuBody.tsx
@@ -3,8 +3,6 @@ import { useState, useMemo, useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronRightIcon from '../../../public/icons/chevron-right.svg';
-import PersonIcon from '../../../public/icons/person.svg';
 import PopoverMenu from '../dls/PopoverMenu/PopoverMenu';
 
 import AudioPlaybackRateMenu from './Buttons/AudioPlaybackRateMenu';
@@ -13,6 +11,8 @@ import DownloadAudioButton from './Buttons/DownloadAudioButton';
 import SelectReciterMenu from './Buttons/SelectReciterMenu';
 import styles from './OverflowAudioPlayActionsMenuBody.module.scss';
 
+import ChevronRightIcon from '@/icons/chevron-right.svg';
+import PersonIcon from '@/icons/person.svg';
 import { logButtonClick } from 'src/utils/eventLogger';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
 

--- a/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.tsx
+++ b/src/components/AudioPlayer/OverflowAudioPlayerActionsMenu.tsx
@@ -1,10 +1,9 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import OverflowMenuIcon from '../../../public/icons/menu_more_horiz.svg';
-
 import OverflowAudioPlayActionsMenuBody from './OverflowAudioPlayActionsMenuBody';
 import styles from './OverflowAudioPlayerActionsMenu.module.scss';
 
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import useDirection from 'src/hooks/useDirection';

--- a/src/components/AudioPlayer/RepeatButton.tsx
+++ b/src/components/AudioPlayer/RepeatButton.tsx
@@ -3,12 +3,11 @@ import { useContext, useState } from 'react';
 
 import { useSelector } from '@xstate/react';
 
-import RepeatIcon from '../../../public/icons/repeat.svg';
-
 import RemainingRangeCount from './RemainingRangeCount';
 import RepeatAudioModal from './RepeatAudioModal/RepeatAudioModal';
 import { RepetitionMode } from './RepeatAudioModal/SelectRepetitionMode';
 
+import RepeatIcon from '@/icons/repeat.svg';
 import Badge from 'src/components/dls/Badge/Badge';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import Wrapper from 'src/components/Wrapper/Wrapper';

--- a/src/components/AudioPlayer/SeekButton.tsx
+++ b/src/components/AudioPlayer/SeekButton.tsx
@@ -3,9 +3,8 @@ import { useContext, useMemo } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import BackwardIcon from '../../../public/icons/backward.svg';
-import ForwardIcon from '../../../public/icons/forward.svg';
-
+import BackwardIcon from '@/icons/backward.svg';
+import ForwardIcon from '@/icons/forward.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import DataContext from 'src/contexts/DataContext';
 import { getChapterData } from 'src/utils/chapter';

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,6 +1,6 @@
 // import { useDispatch } from 'react-redux';
 
-// import CloseIcon from '../../../public/icons/close.svg';
+// import CloseIcon from '@/icons/close.svg';
 import { useState } from 'react';
 
 import classNames from 'classnames';

--- a/src/components/Collection/CollectionDetail/CollectionDetail.tsx
+++ b/src/components/Collection/CollectionDetail/CollectionDetail.tsx
@@ -1,10 +1,9 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronDownIcon from '../../../../public/icons/chevron-down.svg';
-import OverflowMenuIcon from '../../../../public/icons/menu_more_horiz.svg';
-
 import styles from './CollectionDetail.module.scss';
 
+import ChevronDownIcon from '@/icons/chevron-down.svg';
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 import Collapsible from 'src/components/dls/Collapsible/Collapsible';
 
 type CollectionItem = {

--- a/src/components/Collection/CollectionList/CollectionList.tsx
+++ b/src/components/Collection/CollectionList/CollectionList.tsx
@@ -1,11 +1,10 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronDownIcon from '../../../../public/icons/chevron-down.svg';
-import OverflowMenuIcon from '../../../../public/icons/menu_more_horiz.svg';
-import BookmarkIcon from '../../../../public/icons/unbookmarked.svg';
-
 import styles from './CollectionList.module.scss';
 
+import ChevronDownIcon from '@/icons/chevron-down.svg';
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
+import BookmarkIcon from '@/icons/unbookmarked.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 

--- a/src/components/Collection/SaveToCollectionModal/SaveToCollectionModal.tsx
+++ b/src/components/Collection/SaveToCollectionModal/SaveToCollectionModal.tsx
@@ -2,10 +2,9 @@ import { useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import PlusIcon from '../../../../public/icons/plus.svg';
-
 import styles from './SaveToCollectionModal.module.scss';
 
+import PlusIcon from '@/icons/plus.svg';
 import Button, { ButtonVariant } from 'src/components/dls/Button/Button';
 import Checkbox from 'src/components/dls/Forms/Checkbox/Checkbox';
 import Modal from 'src/components/dls/Modal/Modal';

--- a/src/components/CommandBar/CommandBarBody/index.tsx
+++ b/src/components/CommandBar/CommandBarBody/index.tsx
@@ -6,11 +6,11 @@ import groupBy from 'lodash/groupBy';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useSelector } from 'react-redux';
 
-import IconSearch from '../../../../public/icons/search.svg';
 import CommandsList, { Command } from '../CommandsList';
 
 import styles from './CommandBarBody.module.scss';
 
+import IconSearch from '@/icons/search.svg';
 import DataFetcher from 'src/components/DataFetcher';
 import TarteelAttribution from 'src/components/TarteelAttribution/TarteelAttribution';
 import VoiceSearchBodyContainer from 'src/components/TarteelVoiceSearch/BodyContainer';

--- a/src/components/CommandBar/CommandBarTrigger/index.tsx
+++ b/src/components/CommandBar/CommandBarTrigger/index.tsx
@@ -3,10 +3,9 @@ import React, { useCallback } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch } from 'react-redux';
 
-import IconSearch from '../../../../public/icons/search.svg';
-
 import styles from './CommandBarTrigger.module.scss';
 
+import IconSearch from '@/icons/search.svg';
 import KeyboardInput from 'src/components/dls/KeyboardInput';
 import TarteelVoiceSearchTrigger from 'src/components/TarteelVoiceSearch/Trigger';
 import { toggleIsOpen } from 'src/redux/slices/CommandBar/state';

--- a/src/components/CommandBar/CommandsList/CommandControl.tsx
+++ b/src/components/CommandBar/CommandsList/CommandControl.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEvent } from 'react';
 
-import CloseIcon from '../../../../public/icons/close.svg';
-
+import CloseIcon from '@/icons/close.svg';
 import Button, { ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 // import KeyboardInput from 'src/components/dls/KeyboardInput';
 

--- a/src/components/CommandBar/CommandsList/CommandPrefix/index.tsx
+++ b/src/components/CommandBar/CommandsList/CommandPrefix/index.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import NavigateIcon from '../../../../../public/icons/east.svg';
-
 import styles from './CommandPrefix.module.scss';
 
+import NavigateIcon from '@/icons/east.svg';
 import { SearchNavigationType } from 'types/SearchNavigationResult';
 
 interface Props {

--- a/src/components/DeveloperUtility/DeveloperUtility.tsx
+++ b/src/components/DeveloperUtility/DeveloperUtility.tsx
@@ -3,13 +3,12 @@ import React, { useState } from 'react';
 
 import classNames from 'classnames';
 
-import WrenchIcon from '../../../public/icons/wrench.svg';
-
 import ContextMenuAdjustment from './ContextMenuAdjustment';
 import styles from './DeveloperUtility.module.scss';
 import NavbarAdjustment from './NavbarAdjustment';
 import NotesAdjustment from './NotesAdjustment';
 
+import WrenchIcon from '@/icons/wrench.svg';
 import Separator from 'src/components/dls/Separator/Separator';
 
 /**

--- a/src/components/DonatePopup/DonatePopup.tsx
+++ b/src/components/DonatePopup/DonatePopup.tsx
@@ -3,13 +3,13 @@ import { useState } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { useSelector } from 'react-redux';
 
-import CloseIcon from '../../../public/icons/close.svg';
 import MoonIllustrationSVG from '../../../public/images/moon-illustration.svg';
 import Button, { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from '../dls/Button/Button';
 import Modal from '../dls/Modal/Modal';
 
 import styles from './DonatePopup.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
 import { selectSessionCount } from 'src/redux/slices/session';
 import { logEvent } from 'src/utils/eventLogger';
 import openGivingLoopPopup from 'src/utils/givingloop';

--- a/src/components/Error/index.tsx
+++ b/src/components/Error/index.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import RetryIcon from '../../../public/icons/retry.svg';
-
 import styles from './Error.module.scss';
 
+import RetryIcon from '@/icons/retry.svg';
 import { OFFLINE_ERROR } from 'src/api';
 import Button, { ButtonSize, ButtonType } from 'src/components/dls/Button/Button';
 

--- a/src/components/HomePage/HomePageMessage.tsx
+++ b/src/components/HomePage/HomePageMessage.tsx
@@ -4,11 +4,11 @@ import useTranslation from 'next-translate/useTranslation';
 
 // import useTranslation from 'next-translate/useTranslation';
 
-import CloseIcon from '../../../public/icons/close.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from '../dls/Button/Button';
 
 import styles from './HomePageMessage.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
 import { logEvent } from 'src/utils/eventLogger';
 import openGivingLoopPopup from 'src/utils/givingloop';
 

--- a/src/components/HomePage/PlayRadioButton.tsx
+++ b/src/components/HomePage/PlayRadioButton.tsx
@@ -4,8 +4,6 @@ import { useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import PauseIcon from '../../../public/icons/pause.svg';
-import PlayIcon from '../../../public/icons/play-arrow.svg';
 import Button from '../dls/Button/Button';
 import Spinner from '../dls/Spinner/Spinner';
 import { getRandomCuratedStationId } from '../Radio/curatedStations';
@@ -14,6 +12,8 @@ import { StationType } from '../Radio/types';
 import styles from './PlayRadioButton.module.scss';
 import RadioInformation from './RadioInformation';
 
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
 import { logEvent } from 'src/utils/eventLogger';
 import { selectIsLoading } from 'src/xstate/actors/audioPlayer/selectors';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';

--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -1,12 +1,12 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import MailIcon from '../../../public/icons/mail.svg';
-import ArrowLeft from '../../../public/icons/west.svg';
 import buildTranslatedErrorMessageByErrorId from '../FormBuilder/buildTranslatedErrorMessageByErrorId';
 import FormBuilder, { SubmissionResult } from '../FormBuilder/FormBuilder';
 
 import styles from './login.module.scss';
 
+import MailIcon from '@/icons/mail.svg';
+import ArrowLeft from '@/icons/west.svg';
 import Button, { ButtonType, ButtonVariant } from 'src/components/dls/Button/Button';
 import { makeSendMagicLinkUrl } from 'src/utils/auth/apiPaths';
 import { EMAIL_VALIDATION_REGEX } from 'src/utils/validation';

--- a/src/components/Login/SocialLogin.tsx
+++ b/src/components/Login/SocialLogin.tsx
@@ -1,12 +1,11 @@
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import AppleIcon from '../../../public/icons/apple.svg';
-import FacebookIcon from '../../../public/icons/facebook.svg';
-import GoogleIcon from '../../../public/icons/google.svg';
-
 import styles from './login.module.scss';
 
+import AppleIcon from '@/icons/apple.svg';
+import FacebookIcon from '@/icons/facebook.svg';
+import GoogleIcon from '@/icons/google.svg';
 import Button from 'src/components/dls/Button/Button';
 import {
   makeGoogleLoginUrl,

--- a/src/components/Navbar/Drawer/DrawerCloseButton.tsx
+++ b/src/components/Navbar/Drawer/DrawerCloseButton.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import IconClose from '../../../../public/icons/close.svg';
-
+import IconClose from '@/icons/close.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 
 interface Props {

--- a/src/components/Navbar/LanguageSelector.tsx
+++ b/src/components/Navbar/LanguageSelector.tsx
@@ -5,14 +5,14 @@ import setLanguage from 'next-translate/setLanguage';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, useSelector } from 'react-redux';
 
-import ChevronSelectIcon from '../../../public/icons/chevron-select.svg';
-import GlobeIcon from '../../../public/icons/globe.svg';
 import Button, { ButtonShape, ButtonVariant } from '../dls/Button/Button';
 import PopoverMenu, { PopoverMenuExpandDirection } from '../dls/PopoverMenu/PopoverMenu';
 import { ToastStatus, useToast } from '../dls/Toast/Toast';
 
 import styles from './LanguageSelector.module.scss';
 
+import ChevronSelectIcon from '@/icons/chevron-select.svg';
+import GlobeIcon from '@/icons/globe.svg';
 import i18nConfig from 'i18n.json';
 import resetSettings from 'src/redux/actions/reset-settings';
 import { selectIsUsingDefaultSettings } from 'src/redux/slices/defaultSettings';

--- a/src/components/Navbar/Logo/NavbarLogoWrapper.tsx
+++ b/src/components/Navbar/Logo/NavbarLogoWrapper.tsx
@@ -1,9 +1,8 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import QuranTextLogo from '../../../../public/icons/quran-text-logo.svg';
-
 import styles from './NavbarLogoWrapper.module.scss';
 
+import QuranTextLogo from '@/icons/quran-text-logo.svg';
 import Link from 'src/components/dls/Link/Link';
 
 const NavbarLogoWrapper = () => {

--- a/src/components/Navbar/NavbarBody/ProfileAvatarButton.tsx
+++ b/src/components/Navbar/NavbarBody/ProfileAvatarButton.tsx
@@ -5,10 +5,9 @@ import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 import { useDispatch } from 'react-redux';
 
-import ArrowIcon from '../../../../public/icons/east.svg';
-import LogoutIcon from '../../../../public/icons/logout.svg';
-import IconPerson from '../../../../public/icons/person.svg';
-
+import ArrowIcon from '@/icons/east.svg';
+import LogoutIcon from '@/icons/logout.svg';
+import IconPerson from '@/icons/person.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import { removeLastSyncAt } from 'src/redux/slices/Auth/userDataSync';

--- a/src/components/Navbar/NavbarBody/index.tsx
+++ b/src/components/Navbar/NavbarBody/index.tsx
@@ -3,9 +3,6 @@ import React, { memo } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch } from 'react-redux';
 
-import IconMenu from '../../../../public/icons/menu.svg';
-import IconSearch from '../../../../public/icons/search.svg';
-import IconSettings from '../../../../public/icons/settings.svg';
 import LanguageSelector from '../LanguageSelector';
 import NavbarLogoWrapper from '../Logo/NavbarLogoWrapper';
 import NavigationDrawer from '../NavigationDrawer/NavigationDrawer';
@@ -15,6 +12,9 @@ import SettingsDrawer from '../SettingsDrawer/SettingsDrawer';
 import styles from './NavbarBody.module.scss';
 import ProfileAvatarButton from './ProfileAvatarButton';
 
+import IconMenu from '@/icons/menu.svg';
+import IconSearch from '@/icons/search.svg';
+import IconSettings from '@/icons/settings.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import {
   setIsSearchDrawerOpen,

--- a/src/components/Navbar/NavigationDrawer/CommunitySection.tsx
+++ b/src/components/Navbar/NavigationDrawer/CommunitySection.tsx
@@ -1,9 +1,8 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import DiscordIcon from '../../../../public/icons/discord-icon.svg';
-
 import styles from './CommunitySection.module.scss';
 
+import DiscordIcon from '@/icons/discord-icon.svg';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import Link from 'src/components/dls/Link/Link';
 

--- a/src/components/Navbar/NavigationDrawer/MobileApps.tsx
+++ b/src/components/Navbar/NavigationDrawer/MobileApps.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import Image from 'next/image';
 
-import IconMobile from '../../../../public/icons/mobile.svg';
-
 import styles from './MobileApps.module.scss';
 import NavigationDrawerItem from './NavigationDrawerItem';
+
+import IconMobile from '@/icons/mobile.svg';
 
 const MobileApps = () => {
   const { t } = useTranslation('common');

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerBody/index.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerBody/index.tsx
@@ -2,30 +2,30 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import IconDevelopers from '../../../../../public/icons/developers.svg';
-import IconFeedback from '../../../../../public/icons/feedback.svg';
-import IconHome from '../../../../../public/icons/home.svg';
-import IconInfo from '../../../../../public/icons/info.svg';
-import IconLock from '../../../../../public/icons/lock.svg';
-import MobileIcon from '../../../../../public/icons/mobile.svg';
-import IconProductUpdates from '../../../../../public/icons/product-updates.svg';
-import IconQ from '../../../../../public/icons/Q_simple.svg';
-import QuranReflect from '../../../../../public/icons/QR.svg';
-import IconQuestionMark from '../../../../../public/icons/question-mark.svg';
-import IconRadio2 from '../../../../../public/icons/radio-2.svg';
-import IconRadio from '../../../../../public/icons/radio.svg';
-import Tarteel from '../../../../../public/icons/tarteel.svg';
-// import MobileApps from '../MobileApps';
 import NavigationDrawerItem from '../NavigationDrawerItem';
 
 import styles from './NavigationDrawerBody.module.scss';
 
+import IconDevelopers from '@/icons/developers.svg';
+import IconFeedback from '@/icons/feedback.svg';
+import IconHome from '@/icons/home.svg';
+import IconInfo from '@/icons/info.svg';
+import IconLock from '@/icons/lock.svg';
+import MobileIcon from '@/icons/mobile.svg';
+import IconProductUpdates from '@/icons/product-updates.svg';
+import IconQ from '@/icons/Q_simple.svg';
+import QuranReflect from '@/icons/QR.svg';
+import IconQuestionMark from '@/icons/question-mark.svg';
+import IconRadio2 from '@/icons/radio-2.svg';
+import IconRadio from '@/icons/radio.svg';
+import Tarteel from '@/icons/tarteel.svg';
+// import MobileApps from '../MobileApps';
 import FundraisingBanner from 'src/components/Fundaraising/FundraisingBanner';
 import { logTarteelLinkClick } from 'src/utils/eventLogger';
 
-// import IconDonate from '../../../../../public/icons/donate.svg';
-// import IconUpdates from '../../../../../public/icons/updates.svg';
-// import IconCollection from '../../../../../public/icons/collection.svg';
+// import IconDonate from '@/icons/donate.svg';
+// import IconUpdates from '@/icons/updates.svg';
+// import IconCollection from '@/icons/collection.svg';
 
 const NavigationDrawerBody = () => {
   const { t } = useTranslation('common');

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerItem.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerItem.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import IconNorthEast from '../../../../public/icons/north_east.svg';
-
 import LinkContainer from './LinkContainer';
 import styles from './NavigationDrawerItem.module.scss';
 
+import IconNorthEast from '@/icons/north_east.svg';
 import IconContainer, { IconColor, IconSize } from 'src/components/dls/IconContainer/IconContainer';
 
 type NavigationDrawerItemProps = {

--- a/src/components/Navbar/SearchDrawer/Buttons/DrawerSearchIcon.tsx
+++ b/src/components/Navbar/SearchDrawer/Buttons/DrawerSearchIcon.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import IconSearch from '../../../../../public/icons/search.svg';
-
 import styles from './DrawerSearchIcon.module.scss';
+
+import IconSearch from '@/icons/search.svg';
 
 const DrawerSearchIcon: React.FC = () => (
   <div className={styles.container}>

--- a/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/ReciterSelectionBody.tsx
@@ -5,10 +5,9 @@ import Fuse from 'fuse.js';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 
-import IconSearch from '../../../../public/icons/search.svg';
-
 import styles from './ReciterSelectionBody.module.scss';
 
+import IconSearch from '@/icons/search.svg';
 import DataFetcher from 'src/components/DataFetcher';
 import Input from 'src/components/dls/Forms/Input';
 import RadioGroup, { RadioGroupOrientation } from 'src/components/dls/Forms/RadioGroup/RadioGroup';

--- a/src/components/Navbar/SettingsDrawer/RepeatSettings.tsx
+++ b/src/components/Navbar/SettingsDrawer/RepeatSettings.tsx
@@ -1,9 +1,8 @@
 import Trans from 'next-translate/Trans';
 
-import RepeatIcon from '../../../../public/icons/repeat.svg';
-
 import styles from './RepeatSettings.module.scss';
 
+import RepeatIcon from '@/icons/repeat.svg';
 import IconContainer, { IconSize } from 'src/components/dls/IconContainer/IconContainer';
 
 const RepeatSettings = () => {

--- a/src/components/Navbar/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/components/Navbar/SettingsDrawer/SettingsDrawer.tsx
@@ -5,11 +5,10 @@ import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 import { useDispatch, useSelector } from 'react-redux';
 
-import BackIcon from '../../../../public/icons/west.svg';
-
 import SettingsBodySkeleton from './SettingsBodySkeleton';
 import styles from './SettingsDrawer.module.scss';
 
+import BackIcon from '@/icons/west.svg';
 import Button, { ButtonVariant } from 'src/components/dls/Button/Button';
 import Drawer, { DrawerType } from 'src/components/Navbar/Drawer';
 import { selectNavbar, setSettingsView, SettingsView } from 'src/redux/slices/navbar';

--- a/src/components/Navbar/SettingsDrawer/TafsirSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSelectionBody.tsx
@@ -5,10 +5,9 @@ import groupBy from 'lodash/groupBy';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, useSelector } from 'react-redux';
 
-import IconSearch from '../../../../public/icons/search.svg';
-
 import styles from './SearchSelectionBody.module.scss';
 
+import IconSearch from '@/icons/search.svg';
 import DataFetcher from 'src/components/DataFetcher';
 import Input from 'src/components/dls/Forms/Input';
 import { selectSelectedTafsirs, setSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';

--- a/src/components/Navbar/SettingsDrawer/ThemeSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/ThemeSection.tsx
@@ -4,14 +4,13 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useSelector } from 'react-redux';
 
-import AutoIcon from '../../../../public/icons/auto.svg';
-import MoonIcon from '../../../../public/icons/moon-outline.svg';
-import SunIcon from '../../../../public/icons/sun-outline.svg';
-import SunsetIcon from '../../../../public/icons/sunset.svg';
-
 import Section from './Section';
 import styles from './ThemeSection.module.scss';
 
+import AutoIcon from '@/icons/auto.svg';
+import MoonIcon from '@/icons/moon-outline.svg';
+import SunIcon from '@/icons/sun-outline.svg';
+import SunsetIcon from '@/icons/sunset.svg';
 import Switch, { SwitchSize } from 'src/components/dls/Switch/Switch';
 import usePersistPreferenceGroup from 'src/hooks/auth/usePersistPreferenceGroup';
 import { selectTheme, setTheme } from 'src/redux/slices/theme';

--- a/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
@@ -7,10 +7,9 @@ import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
-import IconSearch from '../../../../public/icons/search.svg';
-
 import styles from './SearchSelectionBody.module.scss';
 
+import IconSearch from '@/icons/search.svg';
 import DataFetcher from 'src/components/DataFetcher';
 import Checkbox from 'src/components/dls/Forms/Checkbox/Checkbox';
 import Input from 'src/components/dls/Forms/Input';

--- a/src/components/Notion/Page/index.tsx
+++ b/src/components/Notion/Page/index.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import BackIcon from '../../../../public/icons/west.svg';
 import Blocks from '../Blocks';
 
 import styles from './Page.module.scss';
 
+import BackIcon from '@/icons/west.svg';
 import Link, { LinkVariant } from 'src/components/dls/Link/Link';
 import { getPageTitle } from 'src/utils/notion';
 

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -6,10 +6,9 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
-import ChevronDownIcon from '../../../public/icons/chevron-down.svg';
-
 import styles from './ContextMenu.module.scss';
 
+import ChevronDownIcon from '@/icons/chevron-down.svg';
 import DataContext from 'src/contexts/DataContext';
 import { selectNavbar } from 'src/redux/slices/navbar';
 import { selectContextMenu } from 'src/redux/slices/QuranReader/contextMenu';

--- a/src/components/QuranReader/EndOfScrollingControls/ChapterControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/ChapterControls.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
-
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
+import ChevronRightIcon from '@/icons/chevron-right.svg';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import useScrollToTop from 'src/hooks/useScrollToTop';
 import { isFirstSurah, isLastSurah } from 'src/utils/chapter';

--- a/src/components/QuranReader/EndOfScrollingControls/HizbControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/HizbControls.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
-
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
+import ChevronRightIcon from '@/icons/chevron-right.svg';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import useScrollToTop from 'src/hooks/useScrollToTop';
 import { logButtonClick } from 'src/utils/eventLogger';

--- a/src/components/QuranReader/EndOfScrollingControls/JuzControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/JuzControls.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
-
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
+import ChevronRightIcon from '@/icons/chevron-right.svg';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import useScrollToTop from 'src/hooks/useScrollToTop';
 import { logButtonClick } from 'src/utils/eventLogger';

--- a/src/components/QuranReader/EndOfScrollingControls/PageControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/PageControls.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { useSelector } from 'react-redux';
 
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
-
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
+import ChevronRightIcon from '@/icons/chevron-right.svg';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import { selectQuranReaderStyles } from 'src/redux/slices/QuranReader/styles';
 import { logButtonClick } from 'src/utils/eventLogger';

--- a/src/components/QuranReader/EndOfScrollingControls/VerseControls.tsx
+++ b/src/components/QuranReader/EndOfScrollingControls/VerseControls.tsx
@@ -2,9 +2,8 @@ import React, { useContext } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronLeftIcon from '../../../../public/icons/chevron-left.svg';
-import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
-
+import ChevronLeftIcon from '@/icons/chevron-left.svg';
+import ChevronRightIcon from '@/icons/chevron-right.svg';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';
 import DataContext from 'src/contexts/DataContext';
 import { isFirstSurah, isLastSurah } from 'src/utils/chapter';

--- a/src/components/QuranReader/PlayChapterAudioButton.tsx
+++ b/src/components/QuranReader/PlayChapterAudioButton.tsx
@@ -3,12 +3,12 @@ import { useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import PauseIcon from '../../../public/icons/pause.svg';
-import PlayIcon from '../../../public/icons/play-arrow.svg';
 import Spinner from '../dls/Spinner/Spinner';
 
 import styles from './PlayButton.module.scss';
 
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
 import Button, { ButtonSize, ButtonType, ButtonVariant } from 'src/components/dls/Button/Button';
 import DataContext from 'src/contexts/DataContext';
 import { getChapterData } from 'src/utils/chapter';

--- a/src/components/QuranReader/ReadingView/PageNavigationButtons/index.tsx
+++ b/src/components/QuranReader/ReadingView/PageNavigationButtons/index.tsx
@@ -4,10 +4,9 @@ import { useSelector } from '@xstate/react';
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import ChevronDownIcon from '../../../../../public/icons/chevron-down.svg';
-
 import styles from './PageNavigationButtons.module.scss';
 
+import ChevronDownIcon from '@/icons/chevron-down.svg';
 import Button, { ButtonSize } from 'src/components/dls/Button/Button';
 import KeyboardInput from 'src/components/dls/KeyboardInput';
 import { ContentSide } from 'src/components/dls/Tooltip';

--- a/src/components/QuranReader/ReadingView/TranslationsButton/index.tsx
+++ b/src/components/QuranReader/ReadingView/TranslationsButton/index.tsx
@@ -5,10 +5,9 @@ import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 import { useSelector } from 'react-redux';
 
-import TranslationsIcon from '../../../../../public/icons/translation.svg';
-
 import styles from './TranslationsButton.module.scss';
 
+import TranslationsIcon from '@/icons/translation.svg';
 import DataFetcher from 'src/components/DataFetcher';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentModalHandles';

--- a/src/components/QuranReader/ReadingView/WordByWordVerseAction/index.tsx
+++ b/src/components/QuranReader/ReadingView/WordByWordVerseAction/index.tsx
@@ -3,11 +3,10 @@ import { useRef, useState } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 
-import SearchIcon from '../../../../../public/icons/search-book.svg';
-
 import WordByWordHeading from './WordByWordHeading';
 import styles from './WordByWordVerseAction.module.scss';
 
+import SearchIcon from '@/icons/search-book.svg';
 import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentModalHandles';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import Separator from 'src/components/dls/Separator/Separator';

--- a/src/components/QuranReader/ReflectionView/ReflectionItem.tsx
+++ b/src/components/QuranReader/ReflectionView/ReflectionItem.tsx
@@ -6,17 +6,16 @@ import classNames from 'classnames';
 import clipboardCopy from 'clipboard-copy';
 import useTranslation from 'next-translate/useTranslation';
 
-import ChatIcon from '../../../../public/icons/chat.svg';
-import ChevronDownIcon from '../../../../public/icons/chevron-down.svg';
-import CopyLinkIcon from '../../../../public/icons/copy-link.svg';
-import CopyIcon from '../../../../public/icons/copy.svg';
-import LoveIcon from '../../../../public/icons/love.svg';
-import OverflowMenuIcon from '../../../../public/icons/menu_more_horiz.svg';
-import ShareIcon from '../../../../public/icons/share.svg';
-import VerifiedIcon from '../../../../public/icons/verified.svg';
-
 import styles from './ReflectionItem.module.scss';
 
+import ChatIcon from '@/icons/chat.svg';
+import ChevronDownIcon from '@/icons/chevron-down.svg';
+import CopyLinkIcon from '@/icons/copy-link.svg';
+import CopyIcon from '@/icons/copy.svg';
+import LoveIcon from '@/icons/love.svg';
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
+import ShareIcon from '@/icons/share.svg';
+import VerifiedIcon from '@/icons/verified.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import Link, { LinkVariant } from 'src/components/dls/Link/Link';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';

--- a/src/components/QuranReader/SidebarNavigation/SidebarNavigation.tsx
+++ b/src/components/QuranReader/SidebarNavigation/SidebarNavigation.tsx
@@ -5,11 +5,10 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 
-import IconClose from '../../../../public/icons/close.svg';
-
 import styles from './SidebarNavigation.module.scss';
 import SidebarNavigationSelections from './SidebarNavigationSelections';
 
+import IconClose from '@/icons/close.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import KeyboardInput from 'src/components/dls/KeyboardInput';
 import Switch from 'src/components/dls/Switch/Switch';

--- a/src/components/QuranReader/TafsirView/TafsirVerseAction.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirVerseAction.tsx
@@ -5,8 +5,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
-import TafsirIcon from '../../../../public/icons/book-open.svg';
-
+import TafsirIcon from '@/icons/book-open.svg';
 import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentModalHandles';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import { selectSelectedTafsirs } from 'src/redux/slices/QuranReader/tafsirs';

--- a/src/components/QuranReader/TranslationView/BookmarkIcon.tsx
+++ b/src/components/QuranReader/TranslationView/BookmarkIcon.tsx
@@ -6,10 +6,9 @@ import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useSWRConfig } from 'swr';
 
-import BookmarkedIcon from '../../../../public/icons/bookmark.svg';
-
 import styles from './TranslationViewCell.module.scss';
 
+import BookmarkedIcon from '@/icons/bookmark.svg';
 import Button, { ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import { ToastStatus, useToast } from 'src/components/dls/Toast/Toast';
 import { selectBookmarks, toggleVerseBookmark } from 'src/redux/slices/QuranReader/bookmarks';

--- a/src/components/QuranReader/TranslationView/QuranReflectButton.tsx
+++ b/src/components/QuranReader/TranslationView/QuranReflectButton.tsx
@@ -4,10 +4,9 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 
-import ChatIcon from '../../../../public/icons/chat.svg';
-
 import styles from './TranslationViewCell.module.scss';
 
+import ChatIcon from '@/icons/chat.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import ContentModal from 'src/components/dls/ContentModal/ContentModal';
 import ReflectionBodyContainer from 'src/components/QuranReader/ReflectionView/ReflectionBodyContainer';

--- a/src/components/QuranReader/TranslationView/ShareVerseButton.tsx
+++ b/src/components/QuranReader/TranslationView/ShareVerseButton.tsx
@@ -2,10 +2,9 @@ import classNames from 'classnames';
 import clipboardCopy from 'clipboard-copy';
 import useTranslation from 'next-translate/useTranslation';
 
-import CopyLinkIcon from '../../../../public/icons/copy-link.svg';
-
 import styles from './TranslationViewCell.module.scss';
 
+import CopyLinkIcon from '@/icons/copy-link.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import { ToastStatus, useToast } from 'src/components/dls/Toast/Toast';
 import { logButtonClick } from 'src/utils/eventLogger';

--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -5,11 +5,10 @@ import React, { MouseEvent } from 'react';
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import CloseIcon from '../../../../../public/icons/close.svg';
-
 import styles from './FootnoteText.module.scss';
 import transStyles from './TranslationText.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
 import Button, { ButtonSize, ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import Spinner from 'src/components/dls/Spinner/Spinner';
 import { getLanguageDataById, findLanguageIdByLocale } from 'src/utils/locale';

--- a/src/components/Radio/CuratedStationList.tsx
+++ b/src/components/Radio/CuratedStationList.tsx
@@ -3,14 +3,14 @@ import { useContext } from 'react';
 import { useSelector } from '@xstate/react';
 import useTranslation from 'next-translate/useTranslation';
 
-import PauseIcon from '../../../public/icons/pause.svg';
-import PlayIcon from '../../../public/icons/play-arrow.svg';
 import Card, { CardSize } from '../dls/Card/Card';
 
 import styles from './CuratedStationList.module.scss';
 import curatedStations from './curatedStations';
 import { StationType } from './types';
 
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
 import { logEvent } from 'src/utils/eventLogger';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
 

--- a/src/components/Radio/ReciterStationList.tsx
+++ b/src/components/Radio/ReciterStationList.tsx
@@ -2,8 +2,6 @@ import { useContext } from 'react';
 
 import { useSelector } from '@xstate/react';
 
-import PauseIcon from '../../../public/icons/pause.svg';
-import PlayIcon from '../../../public/icons/play-arrow.svg';
 import { getReciterNavigationUrl } from '../../utils/navigation';
 import Card, { CardSize } from '../dls/Card/Card';
 import Link from '../dls/Link/Link';
@@ -11,6 +9,8 @@ import Link from '../dls/Link/Link';
 import styles from './ReciterStationList.module.scss';
 import { StationType } from './types';
 
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
 import { makeCDNUrl } from 'src/utils/cdn';
 import { logEvent } from 'src/utils/eventLogger';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';

--- a/src/components/Reciter/ChaptersList.tsx
+++ b/src/components/Reciter/ChaptersList.tsx
@@ -5,10 +5,6 @@ import classNames from 'classnames';
 import clipboardCopy from 'clipboard-copy';
 import useTranslation from 'next-translate/useTranslation';
 
-import CopyLinkIcon from '../../../public/icons/copy-link.svg';
-import DownloadIcon from '../../../public/icons/download.svg';
-import PauseIcon from '../../../public/icons/pause.svg';
-import PlayIcon from '../../../public/icons/play-arrow.svg';
 import { download } from '../AudioPlayer/Buttons/DownloadAudioButton';
 import ChapterIconContainer from '../chapters/ChapterIcon/ChapterIconContainer';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from '../dls/Button/Button';
@@ -17,6 +13,10 @@ import { ToastStatus, useToast } from '../dls/Toast/Toast';
 
 import styles from './ChapterList.module.scss';
 
+import CopyLinkIcon from '@/icons/copy-link.svg';
+import DownloadIcon from '@/icons/download.svg';
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
 import { getChapterAudioData } from 'src/api';
 import { logButtonClick, logEvent } from 'src/utils/eventLogger';
 import { getReciterChapterNavigationUrl } from 'src/utils/navigation';

--- a/src/components/Reciter/QuranReciterListHero.tsx
+++ b/src/components/Reciter/QuranReciterListHero.tsx
@@ -1,10 +1,11 @@
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import SearchIcon from '../../../public/icons/search.svg';
 import Input from '../dls/Forms/Input';
 
 import styles from './QuranReciterListHero.module.scss';
+
+import SearchIcon from '@/icons/search.svg';
 
 type QuranReciterListHeroProps = {
   searchQuery: string;

--- a/src/components/Reciter/ReciterInfo.tsx
+++ b/src/components/Reciter/ReciterInfo.tsx
@@ -4,12 +4,12 @@ import { useContext, useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import PlayIcon from '../../../public/icons/play-arrow.svg';
 import Button from '../dls/Button/Button';
 import { StationType } from '../Radio/types';
 
 import styles from './ReciterInfo.module.scss';
 
+import PlayIcon from '@/icons/play-arrow.svg';
 import { makeCDNUrl } from 'src/utils/cdn';
 import { logEvent } from 'src/utils/eventLogger';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';

--- a/src/components/Search/NoResults/index.tsx
+++ b/src/components/Search/NoResults/index.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import IconSearch from '../../../../public/icons/search.svg';
-
 import styles from './NoResults.module.scss';
 
+import IconSearch from '@/icons/search.svg';
 import AdvancedSearchLink from 'src/components/Navbar/SearchDrawer/AdvancedSearchLink';
 
 interface Props {

--- a/src/components/Search/PreInput/SearchQuerySuggestion/index.tsx
+++ b/src/components/Search/PreInput/SearchQuerySuggestion/index.tsx
@@ -1,11 +1,11 @@
 import React, { MouseEvent, KeyboardEvent } from 'react';
 
-import CloseIcon from '../../../../../public/icons/close.svg';
-import SearchIcon from '../../../../../public/icons/search.svg';
 import SearchItem from '../SearchItem';
 
 import styles from './SearchQuerySuggestion.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
+import SearchIcon from '@/icons/search.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 
 interface Props {

--- a/src/components/Search/PreInput/index.tsx
+++ b/src/components/Search/PreInput/index.tsx
@@ -2,13 +2,12 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import TrendUpIcon from '../../../../public/icons/trend-up.svg';
-
 import Header from './Header';
 import styles from './PreInput.module.scss';
 import SearchItem from './SearchItem';
 import SearchQuerySuggestion from './SearchQuerySuggestion';
 
+import TrendUpIcon from '@/icons/trend-up.svg';
 import Link from 'src/components/dls/Link/Link';
 import SearchHistory from 'src/components/Search/SearchHistory';
 import useGetChaptersData from 'src/hooks/useGetChaptersData';

--- a/src/components/TarteelAttribution/TarteelAttribution.tsx
+++ b/src/components/TarteelAttribution/TarteelAttribution.tsx
@@ -1,10 +1,9 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import TarteelLogo from '../../../public/icons/tarteel-logo.svg';
-import TarteelText from '../../../public/icons/tarteel-text.svg';
-
 import styles from './TarteelAttribution.module.scss';
 
+import TarteelLogo from '@/icons/tarteel-logo.svg';
+import TarteelText from '@/icons/tarteel-text.svg';
 import Link from 'src/components/dls/Link/Link';
 import { logTarteelLinkClick } from 'src/utils/eventLogger';
 

--- a/src/components/TarteelVoiceSearch/BodyContainer/Error/index.tsx
+++ b/src/components/TarteelVoiceSearch/BodyContainer/Error/index.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import ErrorIcon from '../../../../../public/icons/info.svg';
-import MicrophoneIcon from '../../../../../public/icons/microphone.svg';
-import NoMicrophoneIcon from '../../../../../public/icons/no-mic.svg';
-
 import styles from './Error.module.scss';
 
+import ErrorIcon from '@/icons/info.svg';
+import MicrophoneIcon from '@/icons/microphone.svg';
+import NoMicrophoneIcon from '@/icons/no-mic.svg';
 import Link, { LinkVariant } from 'src/components/dls/Link/Link';
 import { logTarteelLinkClick } from 'src/utils/eventLogger';
 import VoiceError from 'types/Tarteel/VoiceError';

--- a/src/components/TarteelVoiceSearch/BodyContainer/PartialResult/index.tsx
+++ b/src/components/TarteelVoiceSearch/BodyContainer/PartialResult/index.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import MicrophoneIcon from '../../../../../public/icons/microphone.svg';
-
 import styles from './PartialResult.module.scss';
 
+import MicrophoneIcon from '@/icons/microphone.svg';
 import { getVolumeLevelMultiplier } from 'src/audioInput/voice';
 
 interface Props {

--- a/src/components/TarteelVoiceSearch/Trigger.tsx
+++ b/src/components/TarteelVoiceSearch/Trigger.tsx
@@ -3,11 +3,10 @@ import React, { useRef } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
-import CloseIcon from '../../../public/icons/close.svg';
-import MicrophoneIcon from '../../../public/icons/microphone.svg';
-
 import styles from './Trigger.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
+import MicrophoneIcon from '@/icons/microphone.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import useBrowserLayoutEffect from 'src/hooks/useBrowserLayoutEffect';
 import {

--- a/src/components/Verse/OverflowVerseActionsMenu.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenu.tsx
@@ -5,11 +5,11 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 
-import OverflowMenuIcon from '../../../public/icons/menu_more_horiz.svg';
 import cellStyles from '../QuranReader/TranslationView/TranslationViewCell.module.scss';
 
 import styles from './OverflowVerseActionsMenuBody.module.scss';
 
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import Spinner from 'src/components/dls/Spinner/Spinner';

--- a/src/components/Verse/OverflowVerseActionsMenuBody.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenuBody.tsx
@@ -9,15 +9,15 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useSWRConfig } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
-import BookmarkedIcon from '../../../public/icons/bookmark.svg';
-import CopyIcon from '../../../public/icons/copy.svg';
-import LinkIcon from '../../../public/icons/east.svg';
-import UnBookmarkedIcon from '../../../public/icons/unbookmarked.svg';
 import TafsirVerseAction from '../QuranReader/TafsirView/TafsirVerseAction';
 
 import VerseActionAdvancedCopy from './VerseActionAdvancedCopy';
 import VerseActionRepeatAudio from './VerseActionRepeatAudio';
 
+import BookmarkedIcon from '@/icons/bookmark.svg';
+import CopyIcon from '@/icons/copy.svg';
+import LinkIcon from '@/icons/east.svg';
+import UnBookmarkedIcon from '@/icons/unbookmarked.svg';
 import PopoverMenu from 'src/components/dls/PopoverMenu/PopoverMenu';
 import Spinner from 'src/components/dls/Spinner/Spinner';
 import { ToastStatus, useToast } from 'src/components/dls/Toast/Toast';

--- a/src/components/Verse/PlayVerseAudioButton.tsx
+++ b/src/components/Verse/PlayVerseAudioButton.tsx
@@ -4,11 +4,11 @@ import { useSelector as useXstateSelector } from '@xstate/react';
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
-import PauseIcon from '../../../public/icons/pause-outline.svg';
-import PlayIcon from '../../../public/icons/play-outline.svg';
 import Spinner from '../dls/Spinner/Spinner';
 import styles from '../QuranReader/TranslationView/TranslationViewCell.module.scss';
 
+import PauseIcon from '@/icons/pause-outline.svg';
+import PlayIcon from '@/icons/play-outline.svg';
 import Button, {
   ButtonShape,
   ButtonSize,

--- a/src/components/Verse/VerseActionAdvancedCopy/index.tsx
+++ b/src/components/Verse/VerseActionAdvancedCopy/index.tsx
@@ -2,11 +2,11 @@ import { useRef, useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import AdvancedCopyIcon from '../../../../public/icons/clipboard.svg';
 import VerseAdvancedCopy from '../AdvancedCopy/VerseAdvancedCopy';
 
 import styles from './VerseActionAdvancedCopy.module.scss';
 
+import AdvancedCopyIcon from '@/icons/clipboard.svg';
 import ContentModal from 'src/components/dls/ContentModal/ContentModal';
 import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentModalHandles';
 import Action from 'src/components/dls/Modal/Action';

--- a/src/components/Verse/VerseActionRepeatAudio.tsx
+++ b/src/components/Verse/VerseActionRepeatAudio.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import RepeatIcon from '../../../public/icons/repeat.svg';
 import { RepetitionMode } from '../AudioPlayer/RepeatAudioModal/SelectRepetitionMode';
 import PopoverMenu from '../dls/PopoverMenu/PopoverMenu';
 
+import RepeatIcon from '@/icons/repeat.svg';
 import RepeatAudioModal from 'src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal';
 import { getChapterNumberFromKey } from 'src/utils/verse';
 

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 
-import CaretDownIcon from '../../../public/icons/caret-down.svg';
 import Link from '../dls/Link/Link';
 import SurahPreviewRow from '../dls/SurahPreview/SurahPreviewRow';
 import Tabs from '../dls/Tabs/Tabs';
@@ -13,6 +12,7 @@ import Tabs from '../dls/Tabs/Tabs';
 import styles from './ChapterAndJuzList.module.scss';
 import ChapterAndJuzListSkeleton from './ChapterAndJuzListSkeleton';
 
+import CaretDownIcon from '@/icons/caret-down.svg';
 import { logButtonClick, logValueChange } from 'src/utils/eventLogger';
 import { shouldUseMinimalLayout, toLocalizedNumber } from 'src/utils/locale';
 import Chapter from 'types/Chapter';

--- a/src/components/chapters/ChapterHeader/index.tsx
+++ b/src/components/chapters/ChapterHeader/index.tsx
@@ -3,10 +3,9 @@ import React, { useRef } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { useDispatch } from 'react-redux';
 
-import InfoIcon from '../../../../public/icons/info.svg';
-
 import styles from './ChapterHeader.module.scss';
 
+import InfoIcon from '@/icons/info.svg';
 import ChapterIconContainer, {
   ChapterIconsSize,
 } from 'src/components/chapters/ChapterIcon/ChapterIconContainer';

--- a/src/components/chapters/Info/index.tsx
+++ b/src/components/chapters/Info/index.tsx
@@ -5,10 +5,9 @@ import React from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import Image from 'next/image';
 
-import BackIcon from '../../../../public/icons/west.svg';
-
 import styles from './Info.module.scss';
 
+import BackIcon from '@/icons/west.svg';
 import Button, { ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import { logButtonClick } from 'src/utils/eventLogger';
 import { getBlurDataUrl } from 'src/utils/image';

--- a/src/components/dls/Badge/Badge.stories.tsx
+++ b/src/components/dls/Badge/Badge.stories.tsx
@@ -1,5 +1,4 @@
-import RepeatIcon from '../../../../public/icons/repeat.svg';
-
+import RepeatIcon from '@/icons/repeat.svg';
 import Badge from 'src/components/dls/Badge/Badge';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 

--- a/src/components/dls/Button/Button.stories.tsx
+++ b/src/components/dls/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
-import SettingIcon from '../../../../public/icons/settings.svg';
-
 import Button, { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from './Button';
+
+import SettingIcon from '@/icons/settings.svg';
 
 export default {
   title: 'dls/Button',

--- a/src/components/dls/Collapsible/Collapsible.stories.tsx
+++ b/src/components/dls/Collapsible/Collapsible.stories.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/no-multi-comp */
-import ChevronDownIcon from '../../../../public/icons/chevron-down.svg';
-import OverflowMenuIcon from '../../../../public/icons/menu_more_horiz.svg';
 import Button, { ButtonSize, ButtonVariant } from '../Button/Button';
 import PopoverMenu from '../PopoverMenu/PopoverMenu';
 
 import Collapsible from './Collapsible';
+
+import ChevronDownIcon from '@/icons/chevron-down.svg';
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 
 export default {
   title: 'dls/Collapsible',

--- a/src/components/dls/ContentModal/ContentModal.tsx
+++ b/src/components/dls/ContentModal/ContentModal.tsx
@@ -4,11 +4,11 @@ import * as Dialog from '@radix-ui/react-dialog';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 
-import CloseIcon from '../../../../public/icons/close.svg';
 import Button, { ButtonShape, ButtonVariant } from '../Button/Button';
 
 import styles from './ContentModal.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
 import ContentModalHandles from 'src/components/dls/ContentModal/types/ContentModalHandles';
 import { isRTLLocale } from 'src/utils/locale';
 

--- a/src/components/dls/Counter/Counter.tsx
+++ b/src/components/dls/Counter/Counter.tsx
@@ -2,11 +2,10 @@ import { useMemo } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
-import MinusIcon from '../../../../public/icons/minus.svg';
-import PlusIcon from '../../../../public/icons/plus.svg';
-
 import styles from './Counter.module.scss';
 
+import MinusIcon from '@/icons/minus.svg';
+import PlusIcon from '@/icons/plus.svg';
 import Button, { ButtonShape, ButtonVariant } from 'src/components/dls/Button/Button';
 import { toLocalizedNumber } from 'src/utils/locale';
 

--- a/src/components/dls/Footer/FooterThemeSwitcher.tsx
+++ b/src/components/dls/Footer/FooterThemeSwitcher.tsx
@@ -1,12 +1,12 @@
 import useTranslation from 'next-translate/useTranslation';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 
-import ChevronSelectIcon from '../../../../public/icons/chevron-select.svg';
 import Button, { ButtonVariant } from '../Button/Button';
 import PopoverMenu from '../PopoverMenu/PopoverMenu';
 
 import styles from './FooterThemeSwitcher.module.scss';
 
+import ChevronSelectIcon from '@/icons/chevron-select.svg';
 import { themeIcons } from 'src/components/Navbar/SettingsDrawer/ThemeSection';
 import { selectTheme, setTheme } from 'src/redux/slices/theme';
 import ThemeType from 'src/redux/types/ThemeType';

--- a/src/components/dls/Footer/TitleAndDescription.tsx
+++ b/src/components/dls/Footer/TitleAndDescription.tsx
@@ -1,8 +1,8 @@
 import useTranslation from 'next-translate/useTranslation';
 
-import QuranTextLogo from '../../../../public/icons/quran-text-logo.svg';
-
 import styles from './Footer.module.scss';
+
+import QuranTextLogo from '@/icons/quran-text-logo.svg';
 
 const TitleAndDescription = () => {
   const { t } = useTranslation('common');

--- a/src/components/dls/Forms/Checkbox/Checkbox.tsx
+++ b/src/components/dls/Forms/Checkbox/Checkbox.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import * as RadixCheckbox from '@radix-ui/react-checkbox';
 import classNames from 'classnames';
 
-import DividerHorizontalIcon from '../../../../../public/icons/divider-horizontal.svg';
-import TickIcon from '../../../../../public/icons/tick.svg';
-
 import styles from './Checkbox.module.scss';
+
+import DividerHorizontalIcon from '@/icons/divider-horizontal.svg';
+import TickIcon from '@/icons/tick.svg';
 
 const INDETERMINATE = 'indeterminate';
 

--- a/src/components/dls/Forms/Combobox/Icons/CaretInputIcon.tsx
+++ b/src/components/dls/Forms/Combobox/Icons/CaretInputIcon.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import CaretIcon from '../../../../../../public/icons/caret-down.svg';
-
 import styles from './CaretInputIcon.module.scss';
+
+import CaretIcon from '@/icons/caret-down.svg';
 
 interface Props {
   shouldShowIcon: boolean;

--- a/src/components/dls/Forms/Combobox/Icons/ClearInputIcon.tsx
+++ b/src/components/dls/Forms/Combobox/Icons/ClearInputIcon.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import CloseIcon from '../../../../../../public/icons/close.svg';
-
 import styles from './ClearInputIcon.module.scss';
+
+import CloseIcon from '@/icons/close.svg';
 
 interface Props {
   shouldShowIcon: boolean;

--- a/src/components/dls/Forms/Combobox/Icons/SearchInputIcon.tsx
+++ b/src/components/dls/Forms/Combobox/Icons/SearchInputIcon.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import IconSearch from '../../../../../../public/icons/search.svg';
-
 import styles from './SearchInputIcon.module.scss';
+
+import IconSearch from '@/icons/search.svg';
 
 const SearchInputIcon: React.FC = () => (
   <span

--- a/src/components/dls/Forms/Combobox/MultiSelect.stories.tsx
+++ b/src/components/dls/Forms/Combobox/MultiSelect.stories.tsx
@@ -2,12 +2,12 @@
 /* eslint-disable react/no-multi-comp */
 import React, { useState, useEffect, useCallback } from 'react';
 
-import SearchIcon from '../../../../../public/icons/search.svg';
-import SettingIcon from '../../../../../public/icons/settings.svg';
-
 import ComboboxSize from './types/ComboboxSize';
 
 import Combobox from './index';
+
+import SearchIcon from '@/icons/search.svg';
+import SettingIcon from '@/icons/settings.svg';
 
 export default {
   title: 'dls/Combobox/MultiSelect',

--- a/src/components/dls/Forms/Combobox/SingleSelect.stories.tsx
+++ b/src/components/dls/Forms/Combobox/SingleSelect.stories.tsx
@@ -2,12 +2,12 @@
 /* eslint-disable react/no-multi-comp */
 import React, { useState, useEffect, useCallback } from 'react';
 
-import SearchIcon from '../../../../../public/icons/search.svg';
-import SettingIcon from '../../../../../public/icons/settings.svg';
-
 import ComboboxSize from './types/ComboboxSize';
 
 import Combobox from './index';
+
+import SearchIcon from '@/icons/search.svg';
+import SettingIcon from '@/icons/settings.svg';
 
 export default {
   title: 'dls/Combobox/SingleSelect',

--- a/src/components/dls/Forms/Combobox/Tag/index.tsx
+++ b/src/components/dls/Forms/Combobox/Tag/index.tsx
@@ -2,10 +2,9 @@ import React, { memo } from 'react';
 
 import classNames from 'classnames';
 
-import CloseIcon from '../../../../../../public/icons/close.svg';
-
 import styles from './Tag.module.scss';
 
+import CloseIcon from '@/icons/close.svg';
 import ComboboxSize from 'src/components/dls/Forms/Combobox/types/ComboboxSize';
 
 interface Props {

--- a/src/components/dls/Forms/Input/Input.stories.tsx
+++ b/src/components/dls/Forms/Input/Input.stories.tsx
@@ -2,10 +2,10 @@
 /* eslint-disable react/no-multi-comp */
 import React, { useState, useEffect, useCallback } from 'react';
 
-import SearchIcon from '../../../../../public/icons/search.svg';
-import SettingIcon from '../../../../../public/icons/settings.svg';
-
 import Input, { InputSize, InputType } from '.';
+
+import SearchIcon from '@/icons/search.svg';
+import SettingIcon from '@/icons/settings.svg';
 
 export default {
   title: 'dls/Input',

--- a/src/components/dls/Forms/Input/index.tsx
+++ b/src/components/dls/Forms/Input/index.tsx
@@ -2,10 +2,11 @@ import React, { ReactNode, useState, useEffect, ChangeEvent } from 'react';
 
 import classNames from 'classnames';
 
-import ClearIcon from '../../../../../public/icons/close.svg';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from '../../Button/Button';
 
 import styles from './Input.module.scss';
+
+import ClearIcon from '@/icons/close.svg';
 
 export enum InputSize {
   Small = 'small',

--- a/src/components/dls/Forms/Select/index.tsx
+++ b/src/components/dls/Forms/Select/index.tsx
@@ -2,9 +2,9 @@ import React, { ChangeEvent, useCallback } from 'react';
 
 import classNames from 'classnames';
 
-import CaretIcon from '../../../../../public/icons/caret-down.svg';
-
 import styles from './Select.module.scss';
+
+import CaretIcon from '@/icons/caret-down.svg';
 
 export interface SelectOption {
   label: string;

--- a/src/components/dls/HelperTooltip/HelperTooltip.tsx
+++ b/src/components/dls/HelperTooltip/HelperTooltip.tsx
@@ -1,7 +1,8 @@
-import QuestionMarkIcon from '../../../../public/icons/help-circle.svg';
 import HoverablePopover from '../Popover/HoverablePopover';
 
 import styles from './HelperTooltip.module.scss';
+
+import QuestionMarkIcon from '@/icons/help-circle.svg';
 
 interface HelperTooltipProps {
   children: React.ReactNode;

--- a/src/components/dls/Pagination/Pagination.tsx
+++ b/src/components/dls/Pagination/Pagination.tsx
@@ -4,11 +4,10 @@ import classNames from 'classnames';
 import range from 'lodash/range';
 import useTranslation from 'next-translate/useTranslation';
 
-import PreviousIcon from '../../../../public/icons/caret-back.svg';
-import NextIcon from '../../../../public/icons/caret-forward.svg';
-
 import styles from './Pagination.module.scss';
 
+import PreviousIcon from '@/icons/caret-back.svg';
+import NextIcon from '@/icons/caret-forward.svg';
 import Button, { ButtonVariant } from 'src/components/dls/Button/Button';
 import { toLocalizedNumber } from 'src/utils/locale';
 

--- a/src/components/dls/PopoverMenu/PopoverMenu.stories.tsx
+++ b/src/components/dls/PopoverMenu/PopoverMenu.stories.tsx
@@ -2,14 +2,14 @@
 /* eslint-disable react/no-multi-comp */
 import { useState, useMemo } from 'react';
 
-import LinkIcon from '../../../../public/icons/east.svg';
-import RepeatIcon from '../../../../public/icons/repeat.svg';
-import ShareIcon from '../../../../public/icons/share.svg';
-import TafsirIcon from '../../../../public/icons/tafsir.svg';
-import UnBookmarkedIcon from '../../../../public/icons/unbookmarked.svg';
-import BackIcon from '../../../../public/icons/west.svg';
-
 import PopoverMenu from './PopoverMenu';
+
+import LinkIcon from '@/icons/east.svg';
+import RepeatIcon from '@/icons/repeat.svg';
+import ShareIcon from '@/icons/share.svg';
+import TafsirIcon from '@/icons/tafsir.svg';
+import UnBookmarkedIcon from '@/icons/unbookmarked.svg';
+import BackIcon from '@/icons/west.svg';
 
 export default {
   title: 'dls/PopoverMenu',

--- a/src/components/dls/SelectionCard/SelectionCard.tsx
+++ b/src/components/dls/SelectionCard/SelectionCard.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import ChevronRightIcon from '../../../../public/icons/chevron-right.svg';
-
 import styles from './SelectionCard.module.scss';
+
+import ChevronRightIcon from '@/icons/chevron-right.svg';
 
 type SelectionCard = {
   label?: string;

--- a/src/pages/reciters/[reciterId]/[chapterId].tsx
+++ b/src/pages/reciters/[reciterId]/[chapterId].tsx
@@ -8,15 +8,15 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 
-import CopyIcon from '../../../../public/icons/copy.svg';
-import DownloadIcon from '../../../../public/icons/download.svg';
-import PauseIcon from '../../../../public/icons/pause.svg';
-import PlayIcon from '../../../../public/icons/play-arrow.svg';
-import ReaderIcon from '../../../../public/icons/reader.svg';
 import layoutStyle from '../../index.module.scss';
 
 import styles from './chapterId.module.scss';
 
+import CopyIcon from '@/icons/copy.svg';
+import DownloadIcon from '@/icons/download.svg';
+import PauseIcon from '@/icons/pause.svg';
+import PlayIcon from '@/icons/play-arrow.svg';
+import ReaderIcon from '@/icons/reader.svg';
 import { getChapterAudioData, getChapterIdBySlug, getReciterData } from 'src/api';
 import { download } from 'src/components/AudioPlayer/Buttons/DownloadAudioButton';
 import Button, { ButtonType } from 'src/components/dls/Button/Button';

--- a/src/pages/reciters/[reciterId]/index.tsx
+++ b/src/pages/reciters/[reciterId]/index.tsx
@@ -5,10 +5,10 @@ import Fuse from 'fuse.js';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import useTranslation from 'next-translate/useTranslation';
 
-import SearchIcon from '../../../../public/icons/search.svg';
 import layoutStyle from '../../index.module.scss';
 import pageStyle from '../reciterPage.module.scss';
 
+import SearchIcon from '@/icons/search.svg';
 import { getReciterData } from 'src/api';
 import Input from 'src/components/dls/Forms/Input';
 import NextSeoWrapper from 'src/components/NextSeoWrapper';

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -6,11 +6,10 @@ import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
-import FilterIcon from '../../public/icons/filter.svg';
-import SearchIcon from '../../public/icons/search.svg';
-
 import styles from './search.module.scss';
 
+import FilterIcon from '@/icons/filter.svg';
+import SearchIcon from '@/icons/search.svg';
 import { getAvailableLanguages, getAvailableTranslations, getSearchResults } from 'src/api';
 import Button, { ButtonSize, ButtonVariant } from 'src/components/dls/Button/Button';
 import ContentModal, { ContentModalSize } from 'src/components/dls/ContentModal/ContentModal';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,10 @@
     "skipLibCheck": true,
     "strict": false,
     "target": "es5",
-    "incremental": true
+    "incremental": true,
+    "paths": {
+      "@/icons/*": ["./public/icons/*"]
+    }
   },
   "exclude": [
     "node_modules"

--- a/tsconfig.storybook.json
+++ b/tsconfig.storybook.json
@@ -10,6 +10,9 @@
     "moduleResolution": "node",
     "rootDirs": ["src", "stories"],
     "baseUrl": "src",
+    "paths": {
+      "@/icons/*": ["../public/icons/*"]
+    },
     "forceConsistentCasingInFileNames": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,4 +1,6 @@
 declare module '*.svg' {
-  const content: any;
+  import { ReactElement, SVGProps } from 'react';
+
+  const content: (props: SVGProps<SVGElement>) => ReactElement;
   export default content;
 }


### PR DESCRIPTION
### Summary
A while ago I made a [PR](https://github.com/quran/quran.com-frontend-next/pull/1375) to improve working with icons. The PR's idea was to put all icons in separate files, and have an `index.tsx` that imports and exports all of them. However, the PR was about 6k new lines. So, I decided to use module aliases instead, and type the icons in the declaration file. Also, I updated all icon imports to use the new module alias and made sure it works with storybook.

*Here are how icon imports look now:*
| Before | After |
| ------ | ------ |
| `../../../../public/icons/repeat.svg` | `@/icons/repeat.svg` |


### Future improvements:
- [ ] add an eslint rule to make the icon import name match the file name, ex:
  * ❌ `import BlaBla from '@/icons/user-icon.svg'`
  * ✅ `import UserIcon from '@/icons/user-icon.svg'`
- [ ] add an eslint rule to prevent importing icons the old way
- [ ] add module aliases for other parts for the projects like `@/dls`, `@/utils`, etc...



