### PR TITLE
spinner, add props to delay visibility

### DIFF
--- a/src/components/Collection/CollectionDetailContainer/CollectionDetailContainer.tsx
+++ b/src/components/Collection/CollectionDetailContainer/CollectionDetailContainer.tsx
@@ -71,7 +71,7 @@ const CollectionDetailContainer = ({
   if (!data) {
     return (
       <div className={classNames(styles.container, styles.loadingContainer)}>
-        <Spinner size={SpinnerSize.Large} />
+        <Spinner shouldDelayVisibility size={SpinnerSize.Large} />
       </div>
     );
   }
@@ -146,7 +146,7 @@ const CollectionDetailContainer = ({
                 onUpdated={onUpdated}
                 onItemDeleted={onItemDeleted}
               />
-              {isValidating && <Spinner size={SpinnerSize.Large} />}
+              {isValidating && <Spinner shouldDelayVisibility size={SpinnerSize.Large} />}
               {hasNextPage && (
                 <div className={styles.loadMoreContainer}>
                   <Button onClick={loadMore}>{t('collection:load-more')}</Button>

--- a/src/components/dls/Spinner/Spinner.module.scss
+++ b/src/components/dls/Spinner/Spinner.module.scss
@@ -14,6 +14,8 @@
 .spinner {
   display: block;
   box-sizing: border-box;
+  opacity: 0;
+  animation: fadeIn 2s ease 1s forwards;
 }
 
 .centered {
@@ -97,4 +99,13 @@
 .span:nth-child(12) {
   animation-delay: -0.1s;
   transform: rotate(330deg) translate(146%);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/src/components/dls/Spinner/Spinner.module.scss
+++ b/src/components/dls/Spinner/Spinner.module.scss
@@ -14,6 +14,9 @@
 .spinner {
   display: block;
   box-sizing: border-box;
+}
+
+.delayVisibility {
   opacity: 0;
   animation: fadeIn 2s ease 1s forwards;
 }

--- a/src/components/dls/Spinner/Spinner.tsx
+++ b/src/components/dls/Spinner/Spinner.tsx
@@ -11,15 +11,22 @@ type SpinnerProps = {
   size?: SpinnerSize;
   isCentered?: boolean;
   className?: string;
+  shouldDelayVisibility?: boolean;
 };
 
-const Spinner = ({ size = SpinnerSize.Medium, isCentered = true, className }: SpinnerProps) => (
+const Spinner = ({
+  size = SpinnerSize.Medium,
+  isCentered = true,
+  className,
+  shouldDelayVisibility,
+}: SpinnerProps) => (
   <div
     className={classNames(styles.spinner, className, {
       [styles.large]: size === SpinnerSize.Large,
       [styles.normal]: size === SpinnerSize.Medium,
       [styles.small]: size === SpinnerSize.Small,
       [styles.centered]: isCentered,
+      [styles.delayVisibility]: shouldDelayVisibility,
     })}
   >
     <div className={styles.container}>{getSpans()}</div>


### PR DESCRIPTION
In a few place, spinner only shown for a split second. Almost useless, and quite distracting.

This PR add `shouldDelayVisibility` props to the Spinner. So that the spinner only shown when the loading is long enough