### PR TITLE
fix: verse delay not working

### DIFF
--- a/src/xstate/actors/rangeCycle/rangeCycleMachine.ts
+++ b/src/xstate/actors/rangeCycle/rangeCycleMachine.ts
@@ -195,7 +195,7 @@ export const createRangeCycleMachine = ({
           const nextVerseTiming: VerseTiming = context.verseTimings[currentIndex + 1];
 
           const nextVerseNumber = context.currentVerseNumber + 1;
-          const previousVerseDuration = currentVerseTiming.duration;
+          const previousVerseDuration = Math.abs(currentVerseTiming.duration);
 
           return [
             stop(context.verseCycleActor.id),


### PR DESCRIPTION
the root cause of this issue is that the `duration` data from API becomes negative `-`.
This PR is just a bandage

<img width="460" alt="image" src="https://user-images.githubusercontent.com/12745166/190964159-c15c095f-cd13-412e-b2c5-a793a8e6b10c.png">
