### PR TITLE
Making Nav bar visible on re-render with drawer open

### DIFF
--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -18,6 +18,7 @@ import {
   setIsNavigationDrawerOpen,
   setIsSearchDrawerOpen,
   setIsSettingsDrawerOpen,
+  setIsVisible,
 } from '@/redux/slices/navbar';
 import { stopSearchDrawerVoiceFlow } from '@/redux/slices/voiceSearch';
 import { logEvent } from '@/utils/eventLogger';
@@ -110,14 +111,19 @@ const Drawer: React.FC<Props> = ({
     { enabled: isOpen, enableOnTags: ['INPUT', 'SELECT'] },
   );
 
-  // Hide navbar after successful navigation
   useEffect(() => {
+    // Keep nav bar visible when drawer is open
+    if (isOpen) {
+      dispatch(setIsVisible(true));
+    }
+
+    // Hide navbar after successful navigation
     router.events.on('routeChangeComplete', () => {
       if (isOpen && closeOnNavigation) {
         closeDrawer('navigation');
       }
     });
-  }, [closeDrawer, router.events, isOpen, closeOnNavigation]);
+  }, [closeDrawer, router.events, isNavbarVisible, isOpen, closeOnNavigation]);
 
   useOutsideClickDetector(
     drawerRef,

--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -123,7 +123,7 @@ const Drawer: React.FC<Props> = ({
         closeDrawer('navigation');
       }
     });
-  }, [closeDrawer, router.events, isNavbarVisible, isOpen, closeOnNavigation]);
+  }, [closeDrawer, dispatch, router.events, isNavbarVisible, isOpen, closeOnNavigation]);
 
   useOutsideClickDetector(
     drawerRef,


### PR DESCRIPTION
### Summary
Fixes #1807 

When drawer triggers an action to fetch e.g. translation. the drawer is moved to the top on render with the nav on nav hidden. This will keep the nav visible on drawer open.

The issue is on both mobile and desktop. This PR fixes both.

### Test Plan


### Screenshots
| Before | After |
| ------ | ------ |
|![bug-cropped-trimmed](https://user-images.githubusercontent.com/31985946/192151879-4cfa1ae5-92a3-4b17-80f4-fa7792a7955a.gif)|![final-bug-fixed](https://user-images.githubusercontent.com/31985946/192151882-98612edd-9354-4aae-bb21-fa47a7e843d4.gif)|
| <img width="387" alt="Screenshot 2022-09-25 at 16 46 54" src="https://user-images.githubusercontent.com/31985946/192152511-d938c239-5cb5-49a3-b29b-e4d739bd624c.png">|<img width="388" alt="Screenshot 2022-09-25 at 16 47 14" src="https://user-images.githubusercontent.com/31985946/192152509-8f272622-bdab-45ce-8464-becd8bbc3777.png">|
