### PR TITLE
Bug-1810: Increasing max-width and wrapping content of tooltip

### DIFF
--- a/src/components/dls/QuranWord/QuranWord.module.scss
+++ b/src/components/dls/QuranWord/QuranWord.module.scss
@@ -49,6 +49,7 @@
   padding-block-end: var(--spacing-micro);
   padding-inline-start: var(--spacing-micro);
   padding-inline-end: var(--spacing-micro);
+  white-space: normal;
 }
 
 .popoverTrigger {

--- a/src/components/dls/Tooltip/Tooltip.module.scss
+++ b/src/components/dls/Tooltip/Tooltip.module.scss
@@ -14,7 +14,7 @@
   color: var(--color-text-inverse);
   background-color: var(--color-background-inverse);
   text-align: center;
-  max-width: calc(8 * var(--spacing-mega));
+  max-width: calc(10 * var(--spacing-mega));
   & > span {
     fill: var(--color-background-inverse);
   }


### PR DESCRIPTION
### Summary
Addressing the issue: https://github.com/quran/quran.com-frontend-next/issues/1810

Increasing the max-width and wrapping content of tooltip.


### Test Plan
One of the longest translation is: `"and those who seclude themselves for devotion and prayer"` (2:125) - see screenshot below

### Screenshots
| Before | After |
| ------ | ------ |
| ![Screenshot 2022-09-25 at 21 03 00](https://user-images.githubusercontent.com/31985946/192163110-f8b47f2b-7abd-4679-96ab-ac0cebbcce92.png) | ![Screenshot 2022-09-25 at 21 02 41](https://user-images.githubusercontent.com/31985946/192163112-6ccdd462-1dbd-4417-a94e-7c9c6b10d23b.png)|
|![Screenshot 2022-09-25 at 21 13 26](https://user-images.githubusercontent.com/31985946/192163329-5124fced-5cd8-4f1f-aabd-a107e857c5f1.png)|![Screenshot 2022-09-25 at 21 13 42](https://user-images.githubusercontent.com/31985946/192163328-d2912759-cae7-42f9-823e-90ac9507ec52.png)|