### PR TITLE
Remove translation query param when no translations

### DIFF
--- a/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSelectionBody.tsx
@@ -14,6 +14,7 @@ import Checkbox from '@/dls/Forms/Checkbox/Checkbox';
 import Input from '@/dls/Forms/Input';
 import SpinnerContainer from '@/dls/Spinner/SpinnerContainer';
 import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
+import useRemoveQueryParam from '@/hooks/useRemoveQueryParam';
 import IconSearch from '@/icons/search.svg';
 import {
   selectTranslations,
@@ -38,6 +39,7 @@ const TranslationSelectionBody = () => {
   const translationsState = useSelector(selectTranslations);
   const { selectedTranslations } = translationsState;
   const [searchQuery, setSearchQuery] = useState('');
+  const removeQueryParam = useRemoveQueryParam();
 
   /**
    * Persist settings in the DB if the user is logged in before dispatching
@@ -69,6 +71,11 @@ const TranslationSelectionBody = () => {
           ? [...selectedTranslations, selectedTranslationId]
           : selectedTranslations.filter((id) => id !== selectedTranslationId); // remove the id
 
+        // if unchecked also remove from query param
+        if (!isChecked) {
+          removeQueryParam(QueryParam.Translations);
+        }
+
         logItemSelectionChange('translation', selectedTranslationId.toString(), isChecked);
         logValueChange('selected_translations', selectedTranslations, nextTranslations);
         onTranslationsSettingsChange(
@@ -82,7 +89,7 @@ const TranslationSelectionBody = () => {
         }
       };
     },
-    [lang, onTranslationsSettingsChange, router, selectedTranslations],
+    [lang, onTranslationsSettingsChange, router, selectedTranslations, removeQueryParam],
   );
 
   const renderTranslationGroup = useCallback(

--- a/src/hooks/useRemoveQueryParam.ts
+++ b/src/hooks/useRemoveQueryParam.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+import router from 'next/router';
+
+import QueryParam from '@/types/QueryParam';
+
+const useRemoveQueryParam = () => {
+  const { pathname, query } = router;
+
+  return useCallback(
+    (queryParam: QueryParam) => {
+      // @ts-ignore
+      const params = new URLSearchParams(query);
+      params.delete(queryParam);
+      router.replace({ pathname, query: params.toString() }, undefined, { shallow: true });
+    },
+    [pathname, query],
+  );
+};
+
+export default useRemoveQueryParam;


### PR DESCRIPTION
When user settings remove all translations, remove translations from query param in URI

### Summary
When system wide translations are changed whilst on a Surah page a query param ?translations=... is added. Once the system wide translations is removed, the translations is not removed.

