### PR TITLE
Fix: Loading skeleton showing text on setting drawer

### DIFF
--- a/src/components/Navbar/SettingsDrawer/TafsirSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.module.scss
@@ -7,3 +7,8 @@
   flex-direction: column;
   margin-block-start: var(--spacing-xsmall);
 }
+
+.skeleton {
+  height: calc(1.5 * var(--spacing-mega));
+  width: 100%;
+}

--- a/src/components/Navbar/SettingsDrawer/TafsirSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.module.scss
@@ -9,6 +9,6 @@
 }
 
 .skeleton {
-  height: calc(1.5 * var(--spacing-mega));
+  height: calc(2.2 * var(--spacing-mega));
   width: 100%;
 }

--- a/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TafsirSection.tsx
@@ -36,9 +36,7 @@ const TafsirSection = () => {
     () => (
       <div>
         {selectedTafsirs.map((id) => (
-          <Skeleton key={id}>
-            <div>{id}</div>
-          </Skeleton>
+          <Skeleton className={styles.skeleton} key={id} />
         ))}
       </div>
     ),

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.module.scss
@@ -8,6 +8,6 @@
 }
 
 .skeleton {
-  height: calc(1.5 * var(--spacing-mega));
+  height: calc(2.2 * var(--spacing-mega));
   width: 100%;
 }

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.module.scss
@@ -6,3 +6,8 @@
   flex-direction: column;
   margin-block-start: var(--spacing-xsmall);
 }
+
+.skeleton {
+  height: calc(1.5 * var(--spacing-mega));
+  width: 100%;
+}

--- a/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/TranslationSection.tsx
@@ -43,9 +43,7 @@ const TranslationSection = () => {
     () => (
       <div>
         {selectedTranslations.map((id) => (
-          <Skeleton key={id}>
-            <div>{id}</div>
-          </Skeleton>
+          <Skeleton className={styles.skeleton} key={id} />
         ))}
       </div>
     ),


### PR DESCRIPTION
### Summary
This PR resolves issue #1770. Skeleton of translation and tafsir sections in the setting drawer were rendering IDs inside the skeleton. I am guessing it was implemented like that previously in order to have the id texts as a placeholder. 
This PR resolves the issue by removing ID renders and adding a style to the skeletons like it's done in other places like [LanguageAndTafsirSelection](https://github.com/quran/quran.com-frontend-next/blob/master/src/components/QuranReader/TafsirView/LanguageAndTafsirSelection.tsx#L32)

### Test Plan
I was not able to reproduce the issue on Chrome 106.0 Mac OS, but I was able to replicate it in Safari 16.0. In order to test this issue, you can replace `DataFetcher` block (line 139) with `translationLoading()` on [TranslationSection](https://github.com/quran/quran.com-frontend-next/blob/master/src/components/Navbar/SettingsDrawer/TranslationSection.tsx)

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="367" alt="Screen Shot 2022-10-02 at 5 30 15 PM" src="https://user-images.githubusercontent.com/39024901/193460228-372fea34-0286-4546-8019-23e12b031834.png">|<img width="386" alt="Screen Shot 2022-10-02 at 5 31 34 PM" src="https://user-images.githubusercontent.com/39024901/193460235-58628818-c0de-4b3b-b631-ab4afe6f5e32.png">|