### PR TITLE
fix: combobox empty message not readable

### DIFF
--- a/src/components/dls/Forms/Combobox/ComboboxItem/ComboboxItem.module.scss
+++ b/src/components/dls/Forms/Combobox/ComboboxItem/ComboboxItem.module.scss
@@ -21,7 +21,7 @@
   }
 }
 .disabledItem {
-  color: var(--color-secondary-medium);
+  color: var(--color-text-faded);
 }
 
 .checkedItem {


### PR DESCRIPTION
Before
<img width="342" alt="image" src="https://user-images.githubusercontent.com/12745166/193764126-246cf03b-83ae-4c27-a707-d0c91970a730.png">
<img width="314" alt="image" src="https://user-images.githubusercontent.com/12745166/193764222-a3531c83-5178-4685-bfb0-b7ab174b3307.png">

After
<img width="321" alt="image" src="https://user-images.githubusercontent.com/12745166/193764305-50fcff73-d8f3-4e6d-a0bb-006b44d88fe8.png">
<img width="336" alt="image" src="https://user-images.githubusercontent.com/12745166/193764264-c536f8ee-d90e-414d-87d0-281675555d5b.png">
