### PR TITLE
[Feat]:Extend repeat ranges for audio repeat settings #1647

### DIFF
--- a/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.tsx
+++ b/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.tsx
@@ -187,7 +187,7 @@ const RepeatAudioModal = ({
             label={t('audio.player.play-range')}
             value={verseRepetition.repeatRange}
             minValue={1}
-            infinityThreshold={3}
+            infinityThreshold={8}
             onChange={onRepeatRangeChange}
             suffix={t('audio.player.times')}
           />
@@ -195,7 +195,7 @@ const RepeatAudioModal = ({
             label={t('audio.player.repeat-verse')}
             value={verseRepetition.repeatEachVerse}
             minValue={1}
-            infinityThreshold={3}
+            infinityThreshold={8}
             onChange={onRepeatEachVerseChange}
             suffix={t('audio.player.times')}
           />


### PR DESCRIPTION
Previously play range go from 3 to infinity and now it will go from 8 to infinity. Changing infinityThreshold from 3 to 8.

### Summary
Fix issue #1647 


### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
| [
![repeatsettings](https://user-images.githubusercontent.com/52318459/199259558-61b19bf5-a2e4-4482-bc0e-2a89eeb21036.png)
] | [
![Screenshot (26)](https://user-images.githubusercontent.com/52318459/199259048-408175c7-2ff9-423b-bd20-d5c5c14dd4ff.png)
] |