### PR TITLE
Handle range navigation results

### DIFF
--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,7 +1,7 @@
 import { stringify } from 'querystring';
 
 import { getBasePath } from './url';
-import { getVerseAndChapterNumbersFromKey } from './verse';
+import { getVerseAndChapterNumbersFromKey, getVerseNumberRangeFromKey } from './verse';
 
 import { SearchNavigationType } from 'types/SearchNavigationResult';
 
@@ -14,6 +14,17 @@ import { SearchNavigationType } from 'types/SearchNavigationResult';
 export const getVerseNavigationUrlByVerseKey = (verseKey: string): string => {
   const [chapterId, verseNumber] = getVerseAndChapterNumbersFromKey(verseKey);
   return `/${chapterId}/${verseNumber}`;
+};
+
+/**
+ * Get the href link to a verse range e.g. 3:5-7.
+ *
+ * @param {string} key
+ * @returns {string}
+ */
+export const getSurahRangeNavigationUrlByVerseKey = (key: string): string => {
+  const { surah, from, to } = getVerseNumberRangeFromKey(key);
+  return `/${surah}/${from}-${to}`;
 };
 
 /**
@@ -144,6 +155,9 @@ export const resolveUrlBySearchNavigationType = (
   }
   if (type === SearchNavigationType.SEARCH_PAGE) {
     return getSearchQueryNavigationUrl(key as string);
+  }
+  if (type === SearchNavigationType.RANGE) {
+    return getSurahRangeNavigationUrlByVerseKey(key as string);
   }
   // for the Surah navigation
   return getSurahNavigationUrl(key);

--- a/src/utils/verse.ts
+++ b/src/utils/verse.ts
@@ -48,15 +48,19 @@ export const getVerseNumberFromKey = (verseKey: string): number =>
 
 /**
  * If the verse is a range of verses, for example 1:3-5
- * we'll return {from: 3, to: 5}
+ * we'll return {surah: 1, from: 3, to: 5}
  *
  * @param {string} verseKey
- * @returns {from: Number, to: Number}
+ * @returns {surah: number, from: Number, to: Number}
  */
-export const getVerseNumberRangeFromKey = (verseKey: string): { from: number; to: number } => {
-  const verseNumber = verseKey.split(COLON_SPLITTER)[1]; // for example (3-5)
+export const getVerseNumberRangeFromKey = (
+  verseKey: string,
+): { surah: number; from: number; to: number } => {
+  const splits = verseKey.split(COLON_SPLITTER);
+  const surahNumber = splits[0];
+  const verseNumber = splits[1]; // for example (3-5)
   const [from, to] = verseNumber.split('-'); // for example [3, 5]
-  return { from: Number(from), to: to ? Number(to) : Number(from) };
+  return { surah: Number(surahNumber), from: Number(from), to: to ? Number(to) : Number(from) };
 };
 
 /**

--- a/types/SearchNavigationResult.ts
+++ b/types/SearchNavigationResult.ts
@@ -6,6 +6,7 @@ export enum SearchNavigationType {
   RUB_EL_HIZB = 'rub_el_hizb',
   SEARCH_PAGE = 'search_page',
   PAGE = 'page',
+  RANGE = 'range',
 }
 
 export interface SearchNavigationResult {


### PR DESCRIPTION
### Summary
This PR handles when the search API returns `range` type. e.g. when typing "3:5-7".