### PR TITLE
[feature]: Sort Chapters by number of Ayahs

### DIFF
--- a/src/components/chapters/ChapterAndJuzList.module.scss
+++ b/src/components/chapters/ChapterAndJuzList.module.scss
@@ -76,8 +76,8 @@
 }
 
 .sortByValueDropDown {
-  // background: rgba(0, 0, 0, 0);
   background-color: var(--color-background-default);
+  color: var(--color-text-default);
   border: none;
   display: flex;
   align-items: center;

--- a/src/components/chapters/ChapterAndJuzList.module.scss
+++ b/src/components/chapters/ChapterAndJuzList.module.scss
@@ -75,6 +75,30 @@
   }
 }
 
+.sortByValueDropDown {
+  // background: rgba(0, 0, 0, 0);
+  background-color: var(--color-background-default);
+  border: none;
+  display: flex;
+  align-items: center;
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  cursor: pointer;
+  margin-inline-start: var(--spacing-xxsmall);
+  & > span {
+    display: flex;
+    align-items: center;
+  }
+  & > .rotate180 > svg {
+    transform: rotate(180deg);
+  }
+  & > span > svg {
+    width: var(--spacing-small);
+    margin-inline-start: var(--spacing-xxsmall);
+    transition: transform var(--transition-regular);
+  }
+}
+
 .loadingContainer {
   min-height: 100vh; // reduce layout shift
 }

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -65,11 +65,11 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
       var dropdown = document.getElementById("dropdown") as HTMLSelectElement;
       var option_value = dropdown.options[dropdown.selectedIndex].value;
  
-      const newValue = option_value === "ASC" 
+      const newValue = option_value === Sort.ASC  
       ? Sort.ASC 
-      : option_value === "DESC"  
+      : option_value === Sort.DESC 
       ? Sort.DESC
-      : option_value === "A_ASC"
+      : option_value === Sort.A_ASC
       ? Sort.A_ASC
       : Sort.A_DESC
       ;
@@ -124,20 +124,20 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
         <div className={styles.sorter}>
           <div className={styles.uppercase}>{t('sort.by')}:</div>
           {view === View.Surah && (<select id="dropdown" onChange={onSort}>
-              <option value="ASC">Ascending</option>
-              <option value="DESC">Descending</option>
-              <option value="A_ASC">Ascending Ayahs</option>
-              <option value="A_DESC">Descending Ayahs</option>
+              <option value="ascending">Ascending</option>
+              <option value="descending">Descending</option>
+              <option value="a_ascending">Ascending Ayahs</option>
+              <option value="a_descending">Descending Ayahs</option>
             </select>)}
-            {view === View.Juz && <div
+          {view === View.Juz && <div
             className={styles.sortByValue}
             onClick={onSortJuz}
             role="button"
             onKeyPress={onSortJuz}
             tabIndex={0}
           >
-            <span>{t(`sort.${sortBy}`)}</span>
-            <span className={sortBy === Sort.ASC ? styles.rotate180 : ''}>
+            <span>{t(sortBy === Sort.DESC ? Sort.DESC : Sort.ASC)}</span>
+            <span className={sortBy === Sort.DESC ? '' : styles.rotate180}>
               <CaretDownIcon />
             </span>
           </div>}

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -80,6 +80,17 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
     });
   };
 
+  const onSortJuz = () => {
+    setSortBy((prevValue) => {
+
+      const newValue = prevValue === Sort.DESC ? Sort.ASC : Sort.DESC;
+
+      // eslint-disable-next-line i18next/no-literal-string
+      logValueChange(`homepage_${view}_sorting`, prevValue, newValue);
+      return newValue;
+    });
+  };
+
   const tabs = useMemo(
     () => [
       { title: t(`${View.Surah}`), value: View.Surah },
@@ -111,15 +122,25 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
       <div className={styles.tabsContainer}>
         <Tabs tabs={tabs} selected={view} onSelect={onTabSelected} />
         <div className={styles.sorter}>
-          <div className={styles.uppercase}>{t('sort.by')}:  
-            <select id="dropdown" onChange={onSort}>
+          <div className={styles.uppercase}>{t('sort.by')}:</div>
+          {view === View.Surah && (<select id="dropdown" onChange={onSort}>
               <option value="ASC">Ascending</option>
               <option value="DESC">Descending</option>
               <option value="A_ASC">Ascending Ayahs</option>
-              <option value="A_DESC">Descieding Ayahs</option>
-            </select>
-          
-          </div>
+              <option value="A_DESC">Descending Ayahs</option>
+            </select>)}
+            {view === View.Juz && <div
+            className={styles.sortByValue}
+            onClick={onSortJuz}
+            role="button"
+            onKeyPress={onSortJuz}
+            tabIndex={0}
+          >
+            <span>{t(`sort.${sortBy}`)}</span>
+            <span className={sortBy === Sort.ASC ? styles.rotate180 : ''}>
+              <CaretDownIcon />
+            </span>
+          </div>}
         </div>
       </div>
       <div

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -16,6 +16,7 @@ import CaretDownIcon from '@/icons/caret-down.svg';
 import { logButtonClick, logValueChange } from '@/utils/eventLogger';
 import { shouldUseMinimalLayout, toLocalizedNumber } from '@/utils/locale';
 import Chapter from 'types/Chapter';
+import { openStdin } from 'process';
 
 enum View {
   Surah = 'surah',
@@ -60,13 +61,17 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
 
   const onSort = () => {
     setSortBy((prevValue) => {
-      const newValue = prevValue === Sort.ASC 
-      ? Sort.DESC 
-      : prevValue === Sort.DESC 
-      ? Sort.A_ASC 
-      : prevValue === Sort.A_ASC 
-      ? Sort.A_DESC
-      : Sort.ASC
+
+      var dropdown = document.getElementById("dropdown") as HTMLSelectElement;
+      var option_value = dropdown.options[dropdown.selectedIndex].value;
+ 
+      const newValue = option_value === "ASC" 
+      ? Sort.ASC 
+      : option_value === "DESC"  
+      ? Sort.DESC
+      : option_value === "A_ASC"
+      ? Sort.A_ASC
+      : Sort.A_DESC
       ;
 
       // eslint-disable-next-line i18next/no-literal-string
@@ -106,18 +111,14 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
       <div className={styles.tabsContainer}>
         <Tabs tabs={tabs} selected={view} onSelect={onTabSelected} />
         <div className={styles.sorter}>
-          <div className={styles.uppercase}>{t('sort.by')}:</div>
-          <div
-            className={styles.sortByValue}
-            onClick={onSort}
-            role="button"
-            onKeyPress={onSort}
-            tabIndex={0}
-          >
-            <span>{t(`sort.${sortBy}`)}</span>
-            <span className={sortBy === Sort.ASC ? styles.rotate180 : ''}>
-              <CaretDownIcon />
-            </span>
+          <div className={styles.uppercase}>{t('sort.by')}:  
+            <select id="dropdown" onChange={onSort}>
+              <option value="ASC">Ascending</option>
+              <option value="DESC">Descending</option>
+              <option value="A_ASC">Ascending Ayahs</option>
+              <option value="A_DESC">Descieding Ayahs</option>
+            </select>
+          
           </div>
         </div>
       </div>

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -130,6 +130,7 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
               id="dropdown"
               onChange={onSort}
               className={styles.sortByValueDropDown}
+              value = {sortBy}
             >
               <option value="ascending">Ascending</option>
               <option value="descending">Descending</option>

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -34,6 +34,8 @@ type ChapterAndJuzListProps = {
 enum Sort {
   ASC = 'ascending',
   DESC = 'descending',
+  A_ASC = 'a_ascending',
+  A_DESC = 'a_descending',
 }
 
 const MOST_VISITED_CHAPTERS = {
@@ -58,7 +60,15 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
 
   const onSort = () => {
     setSortBy((prevValue) => {
-      const newValue = prevValue === Sort.DESC ? Sort.ASC : Sort.DESC;
+      const newValue = prevValue === Sort.ASC 
+      ? Sort.DESC 
+      : prevValue === Sort.DESC 
+      ? Sort.A_ASC 
+      : prevValue === Sort.A_ASC 
+      ? Sort.A_DESC
+      : Sort.ASC
+      ;
+
       // eslint-disable-next-line i18next/no-literal-string
       logValueChange(`homepage_${view}_sorting`, prevValue, newValue);
       return newValue;
@@ -75,9 +85,13 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
 
   const sortedChapters = useMemo(
     () =>
-      sortBy === Sort.DESC
+      sortBy === Sort.ASC
+        ? chapters
+        : sortBy === Sort.DESC
         ? chapters.slice().sort((a, b) => Number(b.id) - Number(a.id))
-        : chapters,
+        : sortBy === Sort.A_ASC
+        ? chapters.slice().sort((a, b) => Number(a.versesCount) - Number(b.versesCount))
+        : chapters.slice().sort((a, b) => Number(b.versesCount) - Number(a.versesCount)),
     [sortBy, chapters],
   );
 

--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -1,29 +1,29 @@
 /* eslint-disable react/no-multi-comp */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo } from "react";
 
-import classNames from 'classnames';
-import useTranslation from 'next-translate/useTranslation';
-import dynamic from 'next/dynamic';
+import classNames from "classnames";
+import useTranslation from "next-translate/useTranslation";
+import dynamic from "next/dynamic";
 
-import Link from '../dls/Link/Link';
-import SurahPreviewRow from '../dls/SurahPreview/SurahPreviewRow';
-import Tabs from '../dls/Tabs/Tabs';
+import Link from "../dls/Link/Link";
+import SurahPreviewRow from "../dls/SurahPreview/SurahPreviewRow";
+import Tabs from "../dls/Tabs/Tabs";
 
-import styles from './ChapterAndJuzList.module.scss';
-import ChapterAndJuzListSkeleton from './ChapterAndJuzListSkeleton';
+import styles from "./ChapterAndJuzList.module.scss";
+import ChapterAndJuzListSkeleton from "./ChapterAndJuzListSkeleton";
 
-import CaretDownIcon from '@/icons/caret-down.svg';
-import { logButtonClick, logValueChange } from '@/utils/eventLogger';
-import { shouldUseMinimalLayout, toLocalizedNumber } from '@/utils/locale';
-import Chapter from 'types/Chapter';
-import { openStdin } from 'process';
+import CaretDownIcon from "@/icons/caret-down.svg";
+import { logButtonClick, logValueChange } from "@/utils/eventLogger";
+import { shouldUseMinimalLayout, toLocalizedNumber } from "@/utils/locale";
+import Chapter from "types/Chapter";
+import { openStdin } from "process";
 
 enum View {
-  Surah = 'surah',
-  Juz = 'juz',
+  Surah = "surah",
+  Juz = "juz",
 }
 
-const JuzView = dynamic(() => import('./JuzView'), {
+const JuzView = dynamic(() => import("./JuzView"), {
   ssr: false,
   loading: () => <ChapterAndJuzListSkeleton />,
 });
@@ -33,10 +33,10 @@ type ChapterAndJuzListProps = {
 };
 
 enum Sort {
-  ASC = 'ascending',
-  DESC = 'descending',
-  A_ASC = 'a_ascending',
-  A_DESC = 'a_descending',
+  ASC = "ascending",
+  DESC = "descending",
+  A_ASC = "a_ascending",
+  A_DESC = "a_descending",
 }
 
 const MOST_VISITED_CHAPTERS = {
@@ -55,25 +55,23 @@ const MOST_VISITED_CHAPTERS = {
 const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
   chapters,
 }: ChapterAndJuzListProps) => {
-  const { t, lang } = useTranslation('common');
+  const { t, lang } = useTranslation("common");
   const [view, setView] = useState(View.Surah);
   const [sortBy, setSortBy] = useState(Sort.ASC);
 
   const onSort = () => {
     setSortBy((prevValue) => {
-
       var dropdown = document.getElementById("dropdown") as HTMLSelectElement;
       var option_value = dropdown.options[dropdown.selectedIndex].value;
- 
-      const newValue = option_value === Sort.ASC  
-      ? Sort.ASC 
-      : option_value === Sort.DESC 
-      ? Sort.DESC
-      : option_value === Sort.A_ASC
-      ? Sort.A_ASC
-      : Sort.A_DESC
-      ;
 
+      const newValue =
+        option_value === Sort.ASC
+          ? Sort.ASC
+          : option_value === Sort.DESC
+          ? Sort.DESC
+          : option_value === Sort.A_ASC
+          ? Sort.A_ASC
+          : Sort.A_DESC;
       // eslint-disable-next-line i18next/no-literal-string
       logValueChange(`homepage_${view}_sorting`, prevValue, newValue);
       return newValue;
@@ -82,7 +80,6 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
 
   const onSortJuz = () => {
     setSortBy((prevValue) => {
-
       const newValue = prevValue === Sort.DESC ? Sort.ASC : Sort.DESC;
 
       // eslint-disable-next-line i18next/no-literal-string
@@ -96,7 +93,7 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
       { title: t(`${View.Surah}`), value: View.Surah },
       { title: t(`${View.Juz}`), value: View.Juz },
     ],
-    [t],
+    [t]
   );
 
   const sortedChapters = useMemo(
@@ -106,9 +103,13 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
         : sortBy === Sort.DESC
         ? chapters.slice().sort((a, b) => Number(b.id) - Number(a.id))
         : sortBy === Sort.A_ASC
-        ? chapters.slice().sort((a, b) => Number(a.versesCount) - Number(b.versesCount))
-        : chapters.slice().sort((a, b) => Number(b.versesCount) - Number(a.versesCount)),
-    [sortBy, chapters],
+        ? chapters
+            .slice()
+            .sort((a, b) => Number(a.versesCount) - Number(b.versesCount))
+        : chapters
+            .slice()
+            .sort((a, b) => Number(b.versesCount) - Number(a.versesCount)),
+    [sortBy, chapters]
   );
 
   const onTabSelected = (newView) => {
@@ -122,25 +123,35 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
       <div className={styles.tabsContainer}>
         <Tabs tabs={tabs} selected={view} onSelect={onTabSelected} />
         <div className={styles.sorter}>
-          <div className={styles.uppercase}>{t('sort.by')}:</div>
-          {view === View.Surah && (<select id="dropdown" onChange={onSort}>
+          <div className={styles.uppercase}>{t("sort.by")}:</div>
+
+          {view === View.Surah && (
+            <select
+              id="dropdown"
+              onChange={onSort}
+              className={styles.sortByValueDropDown}
+            >
               <option value="ascending">Ascending</option>
               <option value="descending">Descending</option>
               <option value="a_ascending">Ascending Ayahs</option>
               <option value="a_descending">Descending Ayahs</option>
-            </select>)}
-          {view === View.Juz && <div
-            className={styles.sortByValue}
-            onClick={onSortJuz}
-            role="button"
-            onKeyPress={onSortJuz}
-            tabIndex={0}
-          >
-            <span>{t(sortBy === Sort.DESC ? Sort.DESC : Sort.ASC)}</span>
-            <span className={sortBy === Sort.DESC ? '' : styles.rotate180}>
-              <CaretDownIcon />
-            </span>
-          </div>}
+            </select>
+          )}
+
+          {view === View.Juz && (
+            <div
+              className={styles.sortByValue}
+              onClick={onSortJuz}
+              role="button"
+              onKeyPress={onSortJuz}
+              tabIndex={0}
+            >
+              <span>{t(sortBy === Sort.DESC ? Sort.DESC : Sort.ASC)}</span>
+              <span className={sortBy === Sort.DESC ? "" : styles.rotate180}>
+                <CaretDownIcon />
+              </span>
+            </div>
+          )}
         </div>
       </div>
       <div
@@ -154,11 +165,16 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
             <div className={styles.chapterContainer} key={chapter.id}>
               <Link
                 href={`/${chapter.id}`}
-                shouldPrefetch={MOST_VISITED_CHAPTERS[Number(chapter.id)] === true}
+                shouldPrefetch={
+                  MOST_VISITED_CHAPTERS[Number(chapter.id)] === true
+                }
               >
                 <SurahPreviewRow
                   chapterId={Number(chapter.id)}
-                  description={`${toLocalizedNumber(chapter.versesCount, lang)} ${t('ayahs')}`}
+                  description={`${toLocalizedNumber(
+                    chapter.versesCount,
+                    lang
+                  )} ${t("ayahs")}`}
                   surahName={chapter.transliteratedName}
                   surahNumber={Number(chapter.id)}
                   translatedSurahName={chapter.translatedName as string}


### PR DESCRIPTION
### Summary
This PR adds a dropdown menu that allows the Surahs on the main page to be sorted by ascending and descending ayahs

### Test Plan
To test our functionality please manually test it out by going to the main page and selecting the ascending ayahs and descending ayahs options for sort by. We also checked the sort button on Juz to make sure it is functioning correctly. Furthermore we tested by running the pre-existing test present as shown in the screenshot below:
![image](https://user-images.githubusercontent.com/56792653/205523019-9a5412ee-aaec-4e3f-83fb-82c2d7e7051f.png)

### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/56792653/205522912-bed593f7-934b-4438-93cc-ccdc1ca92c12.png)| ![image](https://user-images.githubusercontent.com/56792653/205522949-dc0c1cfd-fa3b-433d-b32a-ce3ae0b62938.png) ![image](https://user-images.githubusercontent.com/56792653/205522930-f494260d-deea-4a38-8c5d-6865c6e6eaa9.png) ![image](https://user-images.githubusercontent.com/56792653/205523138-4cd3ac30-d5cb-4d65-8fc0-da2a1ee1d8e5.png)
|