### PR TITLE
Fix persist gate double mounting

### DIFF
--- a/src/components/DisableAnimationsUntilHydration.tsx
+++ b/src/components/DisableAnimationsUntilHydration.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { useSelector } from 'react-redux';
 
-import { selectisPersistGateHydrationComplete } from '../redux/slices/persistGateHydration';
-import isClient from '../utils/isClient';
+import { selectIsPersistGateHydrationComplete } from '@/redux/slices/persistGateHydration';
+import isClient from '@/utils/isClient';
 
 // This utility disables all animations until the redux-persist store hydration is complete.
-// This is done to prevent a bunch of animations from happening on iniitial page load.
+// This is done to prevent a bunch of animations from happening on initial page load.
 const DisableAnimationsUntilHydration = () => {
-  const isPersistGateHydrationComplete = useSelector(selectisPersistGateHydrationComplete);
+  const isPersistGateHydrationComplete = useSelector(selectIsPersistGateHydrationComplete);
 
   if (isClient && !isPersistGateHydrationComplete) {
     return (

--- a/src/components/DisableAnimationsUntilHydration.tsx
+++ b/src/components/DisableAnimationsUntilHydration.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { useSelector } from 'react-redux';
+
+import { selectisPersistGateHydrationComplete } from '../redux/slices/persistGateHydration';
+import isClient from '../utils/isClient';
+
+// This utility disables all animations until the redux-persist store hydration is complete.
+// This is done to prevent a bunch of animations from happening on iniitial page load.
+const DisableAnimationsUntilHydration = () => {
+  const isPersistGateHydrationComplete = useSelector(selectisPersistGateHydrationComplete);
+
+  if (isClient && !isPersistGateHydrationComplete) {
+    return (
+      <style jsx global>
+        {`
+          * {
+            transition: all 0s !important;
+          }
+        `}
+      </style>
+    );
+  }
+
+  return <></>;
+};
+
+export default DisableAnimationsUntilHydration;

--- a/src/components/DisableAnimationsUntilHydration.tsx
+++ b/src/components/DisableAnimationsUntilHydration.tsx
@@ -12,7 +12,7 @@ const DisableAnimationsUntilHydration = () => {
 
   if (isClient && !isPersistGateHydrationComplete) {
     return (
-      <style jsx global>
+      <style>
         {`
           * {
             transition: all 0s !important;

--- a/src/components/GlobalListeners.tsx
+++ b/src/components/GlobalListeners.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import DisableAnimationsUntilHydration from './DisableAnimationsUntilHydration';
+import GlobalPersistGateHydrationListener from './GlobalPersistGateHydrationListener';
+
 import GlobalKeyboardListeners from '@/components/GlobalKeyboardListeners';
 import GlobalScrollListener from '@/components/GlobalScrollListener';
 
@@ -8,6 +11,8 @@ const GlobalListeners = () => {
     <>
       <GlobalKeyboardListeners />
       <GlobalScrollListener />
+      <GlobalPersistGateHydrationListener />
+      <DisableAnimationsUntilHydration />
     </>
   );
 };

--- a/src/components/GlobalPersistGateHydrationListener.tsx
+++ b/src/components/GlobalPersistGateHydrationListener.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+  selectisPersistGateHydrationInProgress,
+  setIsPersistGateHydrationComplete,
+  setIsPersistGateHydrationInProgress,
+} from '../redux/slices/persistGateHydration';
+
+const PERSIST_GATE_HYDRATION_DURATION_MS = 50; // This number is mostly arbitrary. Long enough to ensure that the hydration is complete.
+
+// This component listens to the REHYDRATE event from redux persist
+// and dispatches an action to set the hydration as complete.
+// The component works by setting a timeout to fire after the REHYDRATE event.
+// Because the redux store is synchronous, there's no way to ensure the order of actions.
+// So we have to use a timeout. The dispatch is done async and doesn't block the main thread.
+const GlobalPersistGateHydrationListener = () => {
+  const dispatch = useDispatch();
+  const isPersistGateHydrationInProgress = useSelector(selectisPersistGateHydrationInProgress);
+
+  useEffect(() => {
+    if (isPersistGateHydrationInProgress) {
+      setTimeout(() => {
+        dispatch({ type: setIsPersistGateHydrationComplete.type, payload: true });
+        dispatch({ type: setIsPersistGateHydrationInProgress.type, payload: false });
+      }, PERSIST_GATE_HYDRATION_DURATION_MS);
+    }
+  }, [dispatch, isPersistGateHydrationInProgress]);
+  return <></>;
+};
+
+export default GlobalPersistGateHydrationListener;

--- a/src/components/GlobalPersistGateHydrationListener.tsx
+++ b/src/components/GlobalPersistGateHydrationListener.tsx
@@ -3,10 +3,10 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  selectisPersistGateHydrationInProgress,
+  selectIsPersistGateHydrationInProgress,
   setIsPersistGateHydrationComplete,
   setIsPersistGateHydrationInProgress,
-} from '../redux/slices/persistGateHydration';
+} from '@/redux/slices/persistGateHydration';
 
 const PERSIST_GATE_HYDRATION_DURATION_MS = 50; // This number is mostly arbitrary. Long enough to ensure that the hydration is complete.
 
@@ -17,7 +17,7 @@ const PERSIST_GATE_HYDRATION_DURATION_MS = 50; // This number is mostly arbitrar
 // So we have to use a timeout to ensure that the hydration complete event happens *after* REHYDRATE.
 const GlobalPersistGateHydrationListener = () => {
   const dispatch = useDispatch();
-  const isPersistGateHydrationInProgress = useSelector(selectisPersistGateHydrationInProgress);
+  const isPersistGateHydrationInProgress = useSelector(selectIsPersistGateHydrationInProgress);
 
   useEffect(() => {
     if (isPersistGateHydrationInProgress) {

--- a/src/components/GlobalPersistGateHydrationListener.tsx
+++ b/src/components/GlobalPersistGateHydrationListener.tsx
@@ -14,7 +14,7 @@ const PERSIST_GATE_HYDRATION_DURATION_MS = 50; // This number is mostly arbitrar
 // and dispatches an action to set the hydration as complete.
 // The component works by setting a timeout to fire after the REHYDRATE event.
 // Because the redux store is synchronous, there's no way to ensure the order of actions.
-// So we have to use a timeout. The dispatch is done async and doesn't block the main thread.
+// So we have to use a timeout to ensure that the hydration complete event happens *after* REHYDRATE.
 const GlobalPersistGateHydrationListener = () => {
   const dispatch = useDispatch();
   const isPersistGateHydrationInProgress = useSelector(selectisPersistGateHydrationInProgress);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -104,7 +104,6 @@ function MyApp({ Component, pageProps }): JSX.Element {
           </ToastContainerProvider>
         </TooltipProvider>
       </DirectionProvider>
-
       <ThirdPartyScripts />
     </>
   );

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -4,8 +4,6 @@ import setLanguage from 'next-translate/setLanguage';
 import { Provider } from 'react-redux';
 import { persistStore } from 'redux-persist';
 import { PersistGate } from 'redux-persist/integration/react';
-import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
-import PreferenceGroup from 'types/auth/PreferenceGroup';
 
 import getStore from './store';
 
@@ -13,6 +11,9 @@ import syncUserPreferences from '@/redux/actions/sync-user-preferences';
 import { getUserPreferences } from '@/utils/auth/api';
 import { isLoggedIn } from '@/utils/auth/login';
 import { setLocaleCookie } from '@/utils/cookies';
+import isClient from '@/utils/isClient';
+import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
+import PreferenceGroup from 'types/auth/PreferenceGroup';
 
 /**
  * A wrapper around the Provider component to skip rendering <PersistGate />
@@ -28,23 +29,11 @@ const ReduxProvider = ({ children, locale }) => {
   const persistor = useMemo(() => persistStore(store), [store]);
   const audioService = useContext(AudioPlayerMachineContext);
 
-  const isClient = !!(
-    typeof window !== 'undefined' &&
-    window.document &&
-    window.document.createElement
-  );
-
   /**
    * Before the Gate lifts, we want to get the user preferences
    * then store in Redux so that they can be used.
    */
   const onBeforeLift = async () => {
-    if (isClient) {
-      // Set a global flag to indicate that the persist gate has been hydrated.
-      window.isPersistGateHydrated = true;
-      console.log('gate hydrated');
-    }
-
     if (isClient && isLoggedIn()) {
       try {
         const userPreferences = await getUserPreferences();

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -61,7 +61,6 @@ const ReduxProvider = ({ children, locale }) => {
     }
   };
 
-  // if (isClient) {
   return (
     <Provider store={store}>
       <PersistGate loading={<GateLoader />} persistor={persistor} onBeforeLift={onBeforeLift}>
@@ -69,9 +68,6 @@ const ReduxProvider = ({ children, locale }) => {
       </PersistGate>
     </Provider>
   );
-  // }
-
-  // return <Provider store={store}>{children}</Provider>;
 };
 
 export default ReduxProvider;

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -9,7 +9,6 @@ import PreferenceGroup from 'types/auth/PreferenceGroup';
 
 import getStore from './store';
 
-import GateLoader from '@/components/GateLoader';
 import syncUserPreferences from '@/redux/actions/sync-user-preferences';
 import { getUserPreferences } from '@/utils/auth/api';
 import { isLoggedIn } from '@/utils/auth/login';

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -40,6 +40,12 @@ const ReduxProvider = ({ children, locale }) => {
    * then store in Redux so that they can be used.
    */
   const onBeforeLift = async () => {
+    if (isClient) {
+      // Set a global flag to indicate that the persist gate has been hydrated.
+      window.isPersistGateHydrated = true;
+      console.log('gate hydrated');
+    }
+
     if (isClient && isLoggedIn()) {
       try {
         const userPreferences = await getUserPreferences();
@@ -63,7 +69,7 @@ const ReduxProvider = ({ children, locale }) => {
 
   return (
     <Provider store={store}>
-      <PersistGate loading={<GateLoader />} persistor={persistor} onBeforeLift={onBeforeLift}>
+      <PersistGate persistor={persistor} onBeforeLift={onBeforeLift}>
         {() => <>{children}</>}
       </PersistGate>
     </Provider>

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -65,7 +65,7 @@ const ReduxProvider = ({ children, locale }) => {
   return (
     <Provider store={store}>
       <PersistGate loading={<GateLoader />} persistor={persistor} onBeforeLift={onBeforeLift}>
-        {() => ({ children })}
+        {() => <>{children}</>}
       </PersistGate>
     </Provider>
   );

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -65,7 +65,7 @@ const ReduxProvider = ({ children, locale }) => {
   return (
     <Provider store={store}>
       <PersistGate loading={<GateLoader />} persistor={persistor} onBeforeLift={onBeforeLift}>
-        {children}
+        {() => ({ children })}
       </PersistGate>
     </Provider>
   );

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -4,6 +4,8 @@ import setLanguage from 'next-translate/setLanguage';
 import { Provider } from 'react-redux';
 import { persistStore } from 'redux-persist';
 import { PersistGate } from 'redux-persist/integration/react';
+import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
+import PreferenceGroup from 'types/auth/PreferenceGroup';
 
 import getStore from './store';
 
@@ -12,8 +14,6 @@ import syncUserPreferences from '@/redux/actions/sync-user-preferences';
 import { getUserPreferences } from '@/utils/auth/api';
 import { isLoggedIn } from '@/utils/auth/login';
 import { setLocaleCookie } from '@/utils/cookies';
-import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
-import PreferenceGroup from 'types/auth/PreferenceGroup';
 
 /**
  * A wrapper around the Provider component to skip rendering <PersistGate />
@@ -61,17 +61,17 @@ const ReduxProvider = ({ children, locale }) => {
     }
   };
 
-  if (isClient) {
-    return (
-      <Provider store={store}>
-        <PersistGate loading={<GateLoader />} persistor={persistor} onBeforeLift={onBeforeLift}>
-          {children}
-        </PersistGate>
-      </Provider>
-    );
-  }
+  // if (isClient) {
+  return (
+    <Provider store={store}>
+      <PersistGate loading={<GateLoader />} persistor={persistor} onBeforeLift={onBeforeLift}>
+        {children}
+      </PersistGate>
+    </Provider>
+  );
+  // }
 
-  return <Provider store={store}>{children}</Provider>;
+  // return <Provider store={store}>{children}</Provider>;
 };
 
 export default ReduxProvider;

--- a/src/redux/slices/persistGateHydration.ts
+++ b/src/redux/slices/persistGateHydration.ts
@@ -39,8 +39,10 @@ export const persistGateHydrationSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(REHYDRATE, (state: PersistGateHydrationState) => {
-      // eslint-disable-next-line no-param-reassign
-      state.isPersistGateHydrationInProgress = true;
+      return {
+        ...state,
+        isPersistGateHydrationInProgress: true,
+      };
     });
   },
 });
@@ -48,9 +50,9 @@ export const persistGateHydrationSlice = createSlice({
 export const { setIsPersistGateHydrationInProgress, setIsPersistGateHydrationComplete } =
   persistGateHydrationSlice.actions;
 
-export const selectisPersistGateHydrationInProgress = (state: RootState) =>
+export const selectIsPersistGateHydrationInProgress = (state: RootState) =>
   state.persistGateHydration.isPersistGateHydrationInProgress;
-export const selectisPersistGateHydrationComplete = (state: RootState) =>
+export const selectIsPersistGateHydrationComplete = (state: RootState) =>
   state.persistGateHydration.isPersistGateHydrationComplete;
 
 export default persistGateHydrationSlice.reducer;

--- a/src/redux/slices/persistGateHydration.ts
+++ b/src/redux/slices/persistGateHydration.ts
@@ -1,0 +1,56 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { REHYDRATE } from 'redux-persist';
+
+import { RootState } from '../RootState';
+
+import SliceName from '@/redux/types/SliceName';
+
+export type PersistGateHydrationState = {
+  isPersistGateHydrationInProgress: boolean;
+  isPersistGateHydrationComplete: boolean;
+};
+
+const initialState: PersistGateHydrationState = {
+  isPersistGateHydrationInProgress: false,
+  isPersistGateHydrationComplete: false,
+};
+
+// This slice checks if redux-persist has finished hydrating the store.
+// Hydration happens a bit after the page loads, useful for preventing
+// the animations until the state is settled in.
+export const persistGateHydrationSlice = createSlice({
+  name: SliceName.PERSIST_GATE_HYDRATION,
+  initialState,
+  reducers: {
+    setIsPersistGateHydrationInProgress: (
+      state: PersistGateHydrationState,
+      action: PayloadAction<boolean>,
+    ) => ({
+      ...state,
+      isPersistGateHydrationInProgress: action.payload,
+    }),
+    setIsPersistGateHydrationComplete: (
+      state: PersistGateHydrationState,
+      action: PayloadAction<boolean>,
+    ) => ({
+      ...state,
+      isPersistGateHydrationComplete: action.payload,
+    }),
+  },
+  extraReducers: (builder) => {
+    builder.addCase(REHYDRATE, (state: PersistGateHydrationState) => {
+      // eslint-disable-next-line no-param-reassign
+      state.isPersistGateHydrationInProgress = true;
+    });
+  },
+});
+
+export const { setIsPersistGateHydrationInProgress, setIsPersistGateHydrationComplete } =
+  persistGateHydrationSlice.actions;
+
+export const selectisPersistGateHydrationInProgress = (state: RootState) =>
+  state.persistGateHydration.isPersistGateHydrationInProgress;
+export const selectisPersistGateHydrationComplete = (state: RootState) =>
+  state.persistGateHydration.isPersistGateHydrationComplete;
+
+export default persistGateHydrationSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -22,6 +22,7 @@ import commandBarPersistConfig from './slices/CommandBar/persistConfig';
 import commandBar from './slices/CommandBar/state';
 import defaultSettings from './slices/defaultSettings';
 import navbar from './slices/navbar';
+import persistGateHydration from './slices/persistGateHydration';
 import bookmarks from './slices/QuranReader/bookmarks';
 import contextMenu from './slices/QuranReader/contextMenu';
 import fontFaces from './slices/QuranReader/font-faces';
@@ -88,6 +89,7 @@ export const rootReducer = combineReducers({
   banner,
   session,
   userDataSync,
+  persistGateHydration,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/redux/types/SliceName.ts
+++ b/src/redux/types/SliceName.ts
@@ -22,6 +22,7 @@ enum SliceName {
   SEARCH = 'search',
   LOCALE = 'locale',
   USER_DATA_SYNC = 'userDataSync',
+  PERSIST_GATE_HYDRATION = 'persistGateHydration',
 }
 
 export default SliceName;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,10 +1,6 @@
 @use "src/styles/theme";
 @use "src/styles/constants";
 
-* {
-  transition: all 0s !important;
-}
-
 body {
   min-height: 100vh;
   background: var(--color-background-default);

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,6 +1,10 @@
 @use "src/styles/theme";
 @use "src/styles/constants";
 
+* {
+  transition: all 0s !important;
+}
+
 body {
   min-height: 100vh;
   background: var(--color-background-default);

--- a/src/utils/isClient.ts
+++ b/src/utils/isClient.ts
@@ -1,0 +1,8 @@
+// A utility to check if the code is running on the client (vs. nextjs server)
+const isClient = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);
+
+export default isClient;

--- a/types/Window.ts
+++ b/types/Window.ts
@@ -8,5 +8,6 @@ declare global {
     wordByWordAudioPlayerEl: HTMLAudioElement;
     webkitAudioContext: typeof AudioContext;
     gtag: any;
+    isPersistGateHydrated?: boolean;
   }
 }


### PR DESCRIPTION
Previously we had redux persist gate logic that would cause all the DOM elements to be unmounted on initial page load during the redux-persist hydration, and mounted again right after. 

This was caused by the following piece of code: 

![image](https://user-images.githubusercontent.com/11590314/209543412-8ea959a4-9d62-420a-93c7-0f775e444ee0.png)

I've modified the code to use a single dom tree for both the hydrated and non-hydrated states. Redux uses the non persist initial state, and then dispatches a `REHYDRATE` event to populate the state. With this approach, a bunch of animations would happen on initial load (because the state is modified). I added a global utility that prevents all animations until the hydration is complete. 
