### PR TITLE
Show the most recent bookmarks first

### DIFF
--- a/src/components/Verses/BookmarkedVersesList.tsx
+++ b/src/components/Verses/BookmarkedVersesList.tsx
@@ -54,7 +54,7 @@ const BookmarkedVersesList: React.FC = () => {
 
     const isUserLoggedIn = isLoggedIn();
     if (isUserLoggedIn && data) {
-      return data.map((bookmark) => makeVerseKey(bookmark.key, bookmark.verseNumber));
+      return data.map((bookmark) => makeVerseKey(bookmark.key, bookmark.verseNumber)).reverse();
     }
 
     if (!isUserLoggedIn) {


### PR DESCRIPTION
Unlike the local storage logic, the api returns the oldest bookmark first. 

This change makes the most recent bookmarks show up first for a more consistent experience + better ux. 

