### PR TITLE
Migrate to new next/link

### DIFF
--- a/src/components/Navbar/NavigationDrawer/LinkContainer.tsx
+++ b/src/components/Navbar/NavigationDrawer/LinkContainer.tsx
@@ -18,12 +18,12 @@ const LinkContainer = ({ href, isExternalLink, children, onClick }: LinkContaine
   return (
     <Link
       href={href}
-      shouldPassHref
       shouldPrefetch={false}
       onClick={onClick}
       isNewTab={isExternalLink}
+      className={styles.anchor}
     >
-      <div className={styles.anchor}>{children}</div>
+      {children}
     </Link>
   );
 };

--- a/src/components/Navbar/SearchDrawer/AdvancedSearchLink.tsx
+++ b/src/components/Navbar/SearchDrawer/AdvancedSearchLink.tsx
@@ -18,14 +18,12 @@ const AdvancedSearchLink: React.FC<Props> = ({ searchUrl }) => {
     <div className={styles.linkContainer}>
       <Link
         href={searchUrl || getSearchQueryNavigationUrl()}
-        shouldPassHref
+        className={styles.link}
         onClick={() => {
           logButtonClick('search_drawer_advanced_search');
         }}
       >
-        <a className={styles.link}>
-          <p>{t('search.switch-mode')}</p>
-        </a>
+        <p>{t('search.switch-mode')}</p>
       </Link>
     </div>
   );

--- a/src/components/QuranReader/ReadingView/PageFooter.tsx
+++ b/src/components/QuranReader/ReadingView/PageFooter.tsx
@@ -18,8 +18,8 @@ const PageFooter: React.FC<Props> = ({ page }) => {
 
   return (
     <div className={styles.pageText}>
-      <Link href={pageUrl} shouldPassHref shouldPrefetch={false}>
-        <p className={styles.pageLink}>{toLocalizedNumber(page, lang)}</p>
+      <Link href={pageUrl} shouldPrefetch={false} className={styles.pageLink}>
+        {toLocalizedNumber(page, lang)}
       </Link>
     </div>
   );

--- a/src/components/Search/SearchResults/SearchResultItem.tsx
+++ b/src/components/Search/SearchResults/SearchResultItem.tsx
@@ -46,14 +46,12 @@ const SearchResultItem: React.FC<Props> = ({ result, source }) => {
       <div className={styles.itemContainer}>
         <Link
           href={getChapterWithStartingVerseUrl(result.verseKey)}
-          shouldPassHref
+          className={styles.verseKey}
           onClick={() => {
             logButtonClick(`${source}_result_item`);
           }}
         >
-          <a className={styles.verseKey}>
-            {chapterData.transliteratedName} {localizedVerseKey}
-          </a>
+          {chapterData.transliteratedName} {localizedVerseKey}
         </Link>
         <div className={styles.quranTextContainer}>
           <div className={styles.quranTextResult} translate="no">

--- a/src/components/Search/SearchResults/index.tsx
+++ b/src/components/Search/SearchResults/index.tsx
@@ -66,15 +66,12 @@ const SearchResults: React.FC<Props> = ({
               {searchResult.pagination.totalRecords > 0 && (
                 <Link
                   href={`/search?query=${searchQuery}`}
-                  shouldPassHref
                   onClick={() => {
                     if (onSearchResultClicked) onSearchResultClicked();
                     logButtonClick('search_drawer_show_all');
                   }}
                 >
-                  <a>
-                    <p className={styles.showAll}>{t('common:search.show-all')}</p>
-                  </a>
+                  <p className={styles.showAll}>{t('common:search.show-all')}</p>
                 </Link>
               )}
             </div>

--- a/src/components/dls/Link/Link.tsx
+++ b/src/components/dls/Link/Link.tsx
@@ -4,8 +4,6 @@ import NextLink from 'next/link';
 
 import styles from './Link.module.scss';
 
-import Wrapper from '@/components/Wrapper/Wrapper';
-
 export enum LinkVariant {
   Highlight = 'highlight',
   Primary = 'primary',
@@ -41,22 +39,15 @@ const Link: React.FC<LinkProps> = ({
   shouldPrefetch = true,
   title,
   ariaLabel,
-}) => (
-  <Wrapper
-    shouldWrap={!download}
-    wrapper={(node) => (
-      <NextLink
-        href={href}
-        {...(shouldPassHref && { shouldPassHref })}
-        {...(shouldPrefetch === false && { prefetch: false })}
-        shallow={isShallow}
-      >
-        {node}
-      </NextLink>
-    )}
-  >
-    <a
+}) => {
+  const El = download ? 'a' : NextLink;
+
+  return (
+    <El
       href={href}
+      {...(shouldPassHref && { passHref: shouldPassHref })}
+      {...(shouldPrefetch === false && { prefetch: false })}
+      shallow={isShallow}
       download={download}
       target={isNewTab ? '_blank' : undefined}
       rel={isNewTab ? 'noreferrer' : undefined}
@@ -72,8 +63,8 @@ const Link: React.FC<LinkProps> = ({
       {...(ariaLabel && { 'aria-label': ariaLabel })}
     >
       {children}
-    </a>
-  </Wrapper>
-);
+    </El>
+  );
+};
 
 export default Link;


### PR DESCRIPTION
### Summary
Next.js v13 introduces a [new behavior](https://nextjs.org/docs/upgrading#link-component) for `next/link`. There is no need for a child `<a>` anymore. This PR migrates all occurrences of `next/link` to the new behavior.