### PR TITLE
load shortcut on client only

### DIFF
--- a/src/components/dls/KeyboardInput/MetaShortcut.tsx
+++ b/src/components/dls/KeyboardInput/MetaShortcut.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  isMacOs?: boolean;
+}
+
+const MetaShortcut: React.FC<Props> = ({ isMacOs }) => <>{isMacOs ? '⌘' : 'ctrl'}</>;
+
+export default MetaShortcut;

--- a/src/components/dls/KeyboardInput/MetaShortcut.tsx
+++ b/src/components/dls/KeyboardInput/MetaShortcut.tsx
@@ -1,7 +1,9 @@
-interface Props {
-  isMacOs?: boolean;
-}
+import isClient from '@/utils/isClient';
 
-const MetaShortcut: React.FC<Props> = ({ isMacOs }) => <>{isMacOs ? '⌘' : 'ctrl'}</>;
+const MetaShortcut: React.FC = () => {
+  const isMacOs = isClient && window.navigator.userAgent.search('Mac') !== -1;
+
+  return <span>{isMacOs ? '⌘' : 'ctrl'}</span>;
+};
 
 export default MetaShortcut;

--- a/src/components/dls/KeyboardInput/index.tsx
+++ b/src/components/dls/KeyboardInput/index.tsx
@@ -6,7 +6,7 @@ import dynamic from 'next/dynamic';
 
 import styles from './KeyboardInput.module.scss';
 
-// this solves a hydration error because we detect the OS on the client side, so the text might be different on the server and the client
+// Returns ctrl or ⌘ based on the OS. This component is loaded on the client only to prevent hydration errors
 const MetaShortcut = dynamic(() => import('./MetaShortcut'), {
   ssr: false,
 });
@@ -28,15 +28,9 @@ const KeyboardInput: React.FC<Props> = ({
   ctrl,
   invertColors = false,
 }) => {
-  const isMacOs = typeof window !== 'undefined' && window.navigator.userAgent.search('Mac') !== -1;
-
   return (
     <kbd className={classNames(styles.container, { [styles.invertedColors]: invertColors })}>
-      {meta && (
-        <span>
-          <MetaShortcut isMacOs={isMacOs} />
-        </span>
-      )}
+      {meta && <MetaShortcut />}
       {shift && <span>⇧</span>}
       {alt && <span>⌥</span>}
       {ctrl && <span>⌃</span>}

--- a/src/components/dls/KeyboardInput/index.tsx
+++ b/src/components/dls/KeyboardInput/index.tsx
@@ -2,8 +2,14 @@
 import React from 'react';
 
 import classNames from 'classnames';
+import dynamic from 'next/dynamic';
 
 import styles from './KeyboardInput.module.scss';
+
+// this solves a hydration error because we detect the OS on the client side, so the text might be different on the server and the client
+const MetaShortcut = dynamic(() => import('./MetaShortcut'), {
+  ssr: false,
+});
 
 interface Props {
   keyboardKey?: string;
@@ -23,9 +29,14 @@ const KeyboardInput: React.FC<Props> = ({
   invertColors = false,
 }) => {
   const isMacOs = typeof window !== 'undefined' && window.navigator.userAgent.search('Mac') !== -1;
+
   return (
     <kbd className={classNames(styles.container, { [styles.invertedColors]: invertColors })}>
-      {meta && <span>{isMacOs ? '⌘' : 'ctrl'}</span>}
+      {meta && (
+        <span>
+          <MetaShortcut isMacOs={isMacOs} />
+        </span>
+      )}
       {shift && <span>⇧</span>}
       {alt && <span>⌥</span>}
       {ctrl && <span>⌃</span>}


### PR DESCRIPTION
### Summary
This line causes the text to change on the client because `isMacOs` defaults to `false` on the server.
```tsx
// src/components/dls/KeyboardInput/index.tsx
{meta && (<span>{isMacOs ? '⌘' : 'ctrl'}</span>)}
```
This PR fixes this issue by lazy loading the shortcut on the client only.

### Screenshots
The error:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/58295120/212464663-4ee79034-1531-4dca-bf1e-f7c372984fbc.png">
