### PR TITLE
Remove next-compose-plugins and write custom logic for plugins

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,6 @@ const path = require('path');
 
 const withBundleAnalyzer = require('@next/bundle-analyzer');
 const { withSentryConfig } = require('@sentry/nextjs');
-const withPlugins = require('next-compose-plugins');
 const withPWA = require('next-pwa');
 const nextTranslate = require('next-translate');
 
@@ -139,16 +138,19 @@ const config = {
   },
 };
 
-const finalConfig = withPlugins(
-  [
-    withBundleAnalyzer({
-      enabled: process.env.ANALYZE_BUNDLE === 'true',
-    }),
-    withPWA(pwa),
-    nextTranslate,
-  ],
-  config,
-);
+let finalConfig = { ...config };
+
+const plugins = [
+  withBundleAnalyzer({
+    enabled: process.env.ANALYZE_BUNDLE === 'true',
+  }),
+  withPWA(pwa),
+  nextTranslate,
+];
+
+plugins.forEach((plugin) => {
+  finalConfig = plugin(finalConfig);
+});
 
 // withSentryConfig must be outside withPlugins because its config is the second argument
 module.exports = withSentryConfig(finalConfig, sentry);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
     "next": "^13.1.1",
-    "next-compose-plugins": "^2.2.0",
     "next-pwa": "^5.6.0",
     "next-seo": "^5.5.0",
     "next-translate": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12998,11 +12998,6 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-compose-plugins@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz#020fc53f275a7e719d62521bef4300fbb6fde5ab"
-  integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
-
 next-pwa@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/next-pwa/-/next-pwa-5.6.0.tgz#f7b1960c4fdd7be4253eb9b41b612ac773392bf4"


### PR DESCRIPTION
### Summary
Next v13 was showing warnings due to invalid config:
<img width="633" alt="image" src="https://user-images.githubusercontent.com/58295120/212470178-31067333-3afd-4683-897e-79471984a18a.png">

This PR solves this issue by removing `next-compose-plugins` and writing custom logic for plugins:
```js
let finalConfig = { ...config };

const plugins = [
  // ...
];

plugins.forEach((plugin) => {
  finalConfig = plugin(finalConfig);
});
```



