### PR TITLE
Show links as <p> tags in footer while loading

### DIFF
--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -111,6 +111,11 @@
   margin-block-start: var(--spacing-xxsmall);
 }
 
+.disabledlinkContainer {
+  opacity: var(--opacity-50);
+  cursor: not-allowed;
+}
+
 .titleAndDescriptionContainer {
   max-width: calc(12.5 * var(--spacing-mega));
   margin-inline-end: var(--spacing-medium);

--- a/src/components/dls/Footer/Links.tsx
+++ b/src/components/dls/Footer/Links.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
 import styles from './Footer.module.scss';
@@ -10,11 +11,9 @@ import { logTarteelLinkClick } from '@/utils/eventLogger';
 const Links = () => {
   const { t, lang } = useTranslation('common');
   const chaptersData = useGetChaptersData(lang);
+  const isLoading = !chaptersData;
 
-  if (!chaptersData) {
-    return <></>;
-  }
-  const getChapterSlug = (id) => `/${chaptersData[id].slug}`;
+  const getChapterSlug = (id) => (!isLoading ? `/${chaptersData[id].slug}` : undefined);
 
   const linksGroup = [
     {
@@ -54,33 +53,46 @@ const Links = () => {
     },
     {
       title: t('popular-links'),
+      loading: isLoading,
       links: [
-        { text: t('quick-links:ayat-ul-kursi'), url: '/ayatul-kursi' },
-        { text: t('quick-links:yaseen'), url: getChapterSlug('36') },
-        { text: t('quick-links:mulk'), url: getChapterSlug('67') },
-        { text: t('quick-links:rahman'), url: getChapterSlug('55') },
-        { text: t('quick-links:waqiah'), url: getChapterSlug('56') },
-        { text: t('quick-links:kahf'), url: getChapterSlug('18') },
-        { text: t('quick-links:muzzammil'), url: getChapterSlug('73') },
+        // We add ids here so that we use them as keys in the map function because urls might still be loading
+        { id: '/ayatul-kursi', text: t('quick-links:ayat-ul-kursi'), url: '/ayatul-kursi' },
+        { id: '36', text: t('quick-links:yaseen'), url: getChapterSlug('36') },
+        { id: '67', text: t('quick-links:mulk'), url: getChapterSlug('67') },
+        { id: '55', text: t('quick-links:rahman'), url: getChapterSlug('55') },
+        { id: '56', text: t('quick-links:waqiah'), url: getChapterSlug('56') },
+        { id: '18', text: t('quick-links:kahf'), url: getChapterSlug('18') },
+        { id: '73', text: t('quick-links:muzzammil'), url: getChapterSlug('73') },
       ],
     },
   ];
+
   return (
     <div className={styles.groupListContainer}>
       {linksGroup.map((group) => (
         <div className={styles.group} key={group.title}>
           <div className={styles.groupTitle}>{group.title}</div>
           {group.links.map((link) => (
-            <div key={link.url} className={styles.linkContainer}>
-              <Link
-                href={link.url}
-                className={link.className}
-                variant={LinkVariant.Primary}
-                isNewTab={!!link.isExternal}
-                {...(link.onClick && { onClick: link.onClick })}
-              >
-                {link.text}
-              </Link>
+            <div
+              key={link.id || link.url}
+              className={classNames(
+                styles.linkContainer,
+                group.loading && styles.disabledlinkContainer,
+              )}
+            >
+              {group.loading ? (
+                <p className={link.className}>{link.text}</p>
+              ) : (
+                <Link
+                  href={link.url}
+                  className={link.className}
+                  variant={LinkVariant.Primary}
+                  isNewTab={!!link.isExternal}
+                  {...(link.onClick && { onClick: link.onClick })}
+                >
+                  {link.text}
+                </Link>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
### Summary
We currently return an empty fragment in the footer's links while loading localized slugs. However, this causes a huge CLS and is not ideal since only one section (Popular Links) requires the localized slugs.
```tsx
// src/components/dls/Footer/Links.tsx

const chaptersData = useGetChaptersData(lang);
if (!chaptersData) {
  return <></>;
}
```
---
This PR solves this issue by showing a disabled `<p>` with the title as a placeholder until we load the slugs. Preview:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/58295120/212476456-430fb41a-49f6-49e8-a98e-5a2bb243939b.png">

---

### Screenshots
| Before | After |
| ------ | ----- |
| <img width="400" alt="image" src="https://user-images.githubusercontent.com/58295120/212475980-9305755f-3520-445c-866b-732c42cf1956.png"> <img width="400" alt="image" src="https://user-images.githubusercontent.com/58295120/212475965-adfd8180-0e11-4446-88f5-42ccbd5b2247.png"> | <img width="700" alt="image" src="https://user-images.githubusercontent.com/58295120/212476000-f7cf7c27-aaf6-4219-b421-a054e8012be7.png"> |

