### PR TITLE
Fix issues

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationPage/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationPage/index.tsx
@@ -94,7 +94,7 @@ const TranslationPage: React.FC<Props> = ({
     }),
     verseFetcher,
     {
-      fallbackData: shouldUseInitialData ? initialData.verses : null,
+      fallbackData: shouldUseInitialData ? initialData.verses : undefined,
       revalidateOnMount: !shouldUseInitialData,
     },
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "target": "es5",
     "incremental": true,
     "paths": {
+      "audio-worklet": ["./src/audioInput/audio-worklet.ts"],
       "@/icons/*": ["./public/icons/*"],
       "@/dls/*": ["./src/components/dls/*"],
       "@/data/*": ["./data/*"],


### PR DESCRIPTION
### Summary

When selecting Indopak, opening a surah, and navigating to a new one, the loading skeleton shows forever. Preview:
![image](https://user-images.githubusercontent.com/58295120/212550643-d2fe6027-d9bd-4b7d-b18d-0c34aea02dc2.png)

This is caused by:
```tsx
// src/components/QuranReader/TranslationView/TranslationPage/index.tsx
const { data: verses } = useSWRImmutable(
  getTranslationViewRequestKey({
    quranReaderDataType,
    pageNumber,
    initialData,
    quranReaderStyles,
    selectedTranslations,
    isVerseData: quranReaderDataType === QuranReaderDataType.Verse,
    id: resourceId,
    reciter: reciterId,
    locale: lang,
    wordByWordLocale,
  }),
  verseFetcher,
  {
>>> fallbackData: shouldUseInitialData ? initialData.verses : null,
    revalidateOnMount: !shouldUseInitialData,
  },
);
```

Whenever `shouldUseInitialData` was `false`, data was being set to `null` and since we're using `swr/immutable`, SWR wasn't fetching again.

This PR fixes this issue by setting it to `undefined` instead of `null` so that SWR ignores the `fallbackData` option.