### PR TITLE
Fix chapter page CLS

### DIFF
--- a/src/components/QuranReader/QuranReader.module.scss
+++ b/src/components/QuranReader/QuranReader.module.scss
@@ -18,6 +18,7 @@ $virtual-scrolling-height-bandage: calc(
 }
 
 .readingView {
+  min-height: 100vh;
   @include breakpoints.smallerThanTablet {
     width: 85%;
   }

--- a/src/components/QuranReader/TranslationView/TranslationView.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationView.module.scss
@@ -8,3 +8,7 @@
   margin-inline-start: auto;
   margin-inline-end: auto;
 }
+
+.wrapper {
+  min-height: 100vh;
+}

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -11,6 +11,7 @@ import { getNumberOfPages } from '../utils/page';
 
 import useScrollToVirtualizedVerse from './hooks/useScrollToVirtualizedVerse';
 import TranslationPage from './TranslationPage';
+import styles from './TranslationView.module.scss';
 
 import Spinner from '@/dls/Spinner/Spinner';
 import useGetQueryParamOrReduxValue from '@/hooks/useGetQueryParamOrReduxValue';
@@ -95,7 +96,10 @@ const TranslationView = ({
         reciterQueryParamDifferent={reciterQueryParamDifferent}
         wordByWordLocaleQueryParamDifferent={wordByWordLocaleQueryParamDifferent}
       />
-      <div onCopy={(event) => onCopyQuranWords(event, verses, quranReaderStyles.quranFont)}>
+      <div
+        className={styles.wrapper}
+        onCopy={(event) => onCopyQuranWords(event, verses, quranReaderStyles.quranFont)}
+      >
         <Virtuoso
           ref={virtuosoRef}
           useWindowScroll


### PR DESCRIPTION
### Summary

Currently, the global footer causes CLS issues on the TranslationView and ReadingView due to [an issue](https://github.com/petyosi/react-virtuoso/issues/760) caused by `react-virtuoso`. This PR fixed this issue by setting a min-height to the TranslationView and ReadingView containers.


### TranslationView

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/58295120/213972630-6be45012-2a31-435d-9cf1-7cd7e2bb7a03.png) | ![image](https://user-images.githubusercontent.com/58295120/213972653-fee09167-78f8-47ff-b172-f1c6a25b051a.png) |


### ReadingView

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/58295120/213972818-588f61b6-0aca-4179-b020-b87cf449800f.png) | ![image](https://user-images.githubusercontent.com/58295120/213972745-41f1b7c1-6546-4855-b8da-7bd91093f550.png) |