### PR TITLE
Use dynamic min-height for reading view container

### DIFF
--- a/src/components/QuranReader/QuranReader.module.scss
+++ b/src/components/QuranReader/QuranReader.module.scss
@@ -18,7 +18,6 @@ $virtual-scrolling-height-bandage: calc(
 }
 
 .readingView {
-  min-height: 100vh;
   @include breakpoints.smallerThanTablet {
     width: 85%;
   }

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -13,6 +13,7 @@ import Notes from './Notes/Notes';
 import { getObservedVersePayload, getOptions, QURAN_READER_OBSERVER_ID } from './observer';
 import styles from './QuranReader.module.scss';
 import QuranReaderView from './QuranReaderView';
+import groupLinesByVerses from './ReadingView/groupLinesByVerses';
 import SidebarNavigation from './SidebarNavigation/SidebarNavigation';
 
 import FontPreLoader from '@/components/Fonts/FontPreLoader';
@@ -91,6 +92,16 @@ const QuranReader = ({
     QURAN_READER_OBSERVER_ID,
   );
 
+  const lines = useMemo(
+    () =>
+      Object.values(
+        initialData.verses && initialData.verses.length
+          ? groupLinesByVerses(initialData.verses)
+          : {},
+      ),
+    [initialData.verses],
+  );
+
   return (
     <>
       <FontPreLoader isQuranReader locale={lang} />
@@ -106,6 +117,9 @@ const QuranReader = ({
           className={classNames(styles.infiniteScroll, {
             [styles.readingView]: isReadingPreference,
           })}
+          style={{
+            minHeight: isReadingPreference ? `${Math.min(lines.length * 20, 100)}vh` : undefined,
+          }}
         >
           <QuranReaderView
             isReadingPreference={isReadingPreference}


### PR DESCRIPTION
### Summary

We currently specify a `min-height` for the reading view container to avoid CLS. However `100vh` doesn't seem to fit shorter chapters. This PR takes a dynamic approach by taking the minimum of either `the number of lines * 20vh` or `100vh`.


### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/58295120/214954741-9439fb52-13ae-4ff4-8dca-ba3a4ea7a43a.png) | ![image](https://user-images.githubusercontent.com/58295120/214954798-3a67f426-d559-4499-95bf-f4ed08da5791.png) |