### PR TITLE
Limit tarteel results to 10

### DIFF
--- a/src/components/TarteelVoiceSearch/BodyContainer/SearchResults.tsx
+++ b/src/components/TarteelVoiceSearch/BodyContainer/SearchResults.tsx
@@ -24,8 +24,13 @@ interface Props {
 const SearchResults: React.FC<Props> = ({ searchResult, isCommandBar }) => {
   const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
   const { t, lang } = useTranslation('common');
+
   const params = {
-    filters: searchResult.matches.map((match) => `${match.surahNum}:${match.ayahNum}`).join(','),
+    // only get the first 10 results
+    filters: searchResult.matches
+      .slice(0, 10)
+      .map((match) => `${match.surahNum}:${match.ayahNum}`)
+      .join(','),
     fields: 'text_uthmani',
     // when it's the search drawer
     ...(!isCommandBar && {


### PR DESCRIPTION
### Summary

Currently, an exception will throw if you open up the voice search and say "Allah". This is because there are a LOT of verse keys returned by tarteel, and when we try to use the QDC filter API, the request fails. 

This PR fixed this issue by taking only the first 10 verse keys.