### PR TITLE
fix: 🐛 changed tajweed word imgs to use height css property

### DIFF
--- a/src/components/dls/QuranWord/TajweedWordImage.module.scss
+++ b/src/components/dls/QuranWord/TajweedWordImage.module.scss
@@ -23,83 +23,83 @@ $light-theme-filter: contrast(100%) hue-rotate(50deg);
 
 .xs {
   img {
-    zoom: 0.4;
+    height: 40px;
     @include breakpoints.tablet {
-      zoom: 0.5;
+      height: 50px;
     }
   }
 }
 .sm {
   img {
-    zoom: 0.5;
+    height: 50px;
     @include breakpoints.tablet {
-      zoom: 0.65;
+      height: 65px;
     }
   }
 }
 .md {
   img {
-    zoom: 0.7;
+    height: 70px;
     @include breakpoints.tablet {
-      zoom: 0.75;
+      height: 75px;
     }
   }
 }
 .lg {
   img {
-    zoom: 0.8;
+    height: 80px;
     @include breakpoints.tablet {
-      zoom: 0.9;
+      height: 90px;
     }
   }
 }
 .xl {
   img {
-    zoom: 0.9;
+    height: 90px;
     @include breakpoints.tablet {
-      zoom: 0.92;
+      height: 92px;
     }
   }
 }
 
 .xl2 {
   img {
-    zoom: 1;
+    height: 100px;
   }
 }
 
 .xl3 {
   img {
-    zoom: 1.1;
+    height: 110px;
     @include breakpoints.tablet {
-      zoom: 1.02;
+      height: 102px;
     }
   }
 }
 
 .xl4 {
   img {
-    zoom: 1.2;
+    height: 120px;
     @include breakpoints.tablet {
-      zoom: 1.04;
+      height: 104px;
     }
   }
 }
 
 .xl5 {
   img {
-    zoom: 1.3;
+    height: 130px;
     @include breakpoints.tablet {
-      zoom: 1.06;
+      height: 106px;
     }
   }
 }
 
 .xl6 {
   img {
-    zoom: 1.4;
+    height: 140px;
     @include breakpoints.tablet {
-      zoom: 1.08;
+      height: 108px;
     }
   }
 }


### PR DESCRIPTION
### Issue
#1946 

### Summary
The font size for the Tajweed style was not updating on Firefox. Behind the scenes, the font for Tajweed is actually a png image retrieved from a CDN URL and then the size is adjusted with the CSS `zoom` property. However, the `zoom` property is [not supported](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom) by Firefox, hence why the font size adjustment was not working.

Each png image has a fixed height of `100px`, therefore I've changed the CSS `zoom` property to use `height` instead and have calculated the pixel values using the zoom values. Using this method works on all browsers including Firefox.

I did not use `transform: scale()` as this does not give the same result as zoom and causes further complications.

### Test Plan
1. Using Firefox, [open a Surah](http://localhost:3000/3)
2. Open the settings and change to the "Tajweed' Quran Font
3. Go through the font sizes on desktop and mobile view
4. Repeats steps 1-3 but using Chrome browser instead

### Screenshots

BEFORE

https://user-images.githubusercontent.com/84995410/233875423-05c014a4-4c1d-48f5-bfe9-6d02edd1232a.mov

AFTER

https://user-images.githubusercontent.com/84995410/233875433-8bc5c4fa-cbb2-4f8f-a675-0db91f2ef644.mov

