### PR TITLE
improve performance on areArraysEqual function

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,5 +1,3 @@
-import isEqual from 'lodash/isEqual';
-
 /**
  * Convert an array of numbers to an array of strings.
  *
@@ -27,8 +25,21 @@ export const stringsToNumbersArray = (stringsArray: string[]): number[] =>
  * @param {T[]} array2
  * @returns {boolean}
  */
-export const areArraysEqual = <T>(array1: T[], array2: T[]): boolean =>
-  isEqual([...array1].sort(), [...array2].sort());
+export const areArraysEqual = <T>(array1: T[], array2: T[]): boolean => {
+  if (array1?.length !== array2?.length) return false;
+
+  const array1Map = new Map();
+
+  array1.map((item) => array1Map.set(item, true));
+
+  for (let i = 0; i < array2.length; i += 1) {
+    if (array1Map.get(array2[i]) == null) return false;
+
+    array1Map.delete(array2[i]);
+  }
+
+  return array1Map.size === 0;
+};
 
 /**
  * Remove `itemToRemove` from `array`

--- a/src/utils/tests/array/areArraysEqual.test.ts
+++ b/src/utils/tests/array/areArraysEqual.test.ts
@@ -36,12 +36,3 @@ it('should not modify the original arrays', () => {
   expect(array1).toEqual([1, 2, 3]);
   expect(array2).toEqual([2, 3, 1]);
 });
-
-it('should return a new array instance', () => {
-  const array1 = [1, 2, 3];
-  const array2 = [2, 3, 1];
-  const result = areArraysEqual(array1, array2);
-
-  expect(result).not.toBe(array1);
-  expect(result).not.toBe(array2);
-});


### PR DESCRIPTION
### Summary
- remove the need to use lodash's isEqual function
- use map instead of sorting and comparing the two arrays which enhances performance from O(5(n+m)) to O(n+m)
- handles some edge cases and exit's early which also increases performance

### Test Plan
this is a fiddle with the test:

https://jsfiddle.net/elussich/4tv9cwjd/

### Screenshots
this is a screenshot showing the performance improvement , almost to 5x

![2023-04-24_18-44](https://user-images.githubusercontent.com/51799859/234076602-0aa79b76-18f3-4919-8bdc-a04ddaa13189.png)
