### PR TITLE
Improve performance for mergeTwoArraysUniquely

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -67,5 +67,10 @@ export const removeItemFromArray = <T>(itemToRemove: T, array: T[]): T[] =>
  * @param {T[]} array2
  * @returns {T[]}
  */
-export const mergeTwoArraysUniquely = <T>(array1: T[], array2: T[]): T[] =>
-  array1.filter((t) => !array2.includes(t)).concat(array2);
+export const mergeTwoArraysUniquely = <T>(array1: T[], array2: T[]): T[] => {
+  const array2Map = new Map();
+
+  array2.map((item) => array2Map.set(item, true));
+
+  return array1.filter((t) => array2Map.get(t) == null).concat(array2);
+};

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -68,12 +68,5 @@ export const removeItemFromArray = <T>(itemToRemove: T, array: T[]): T[] =>
  * @returns {T[]}
  */
 export const mergeTwoArraysUniquely = <T>(array1: T[], array2: T[]): T[] => {
-  // Create a Map object of the second array, with each element as a key and true as the value
-  const array2Map = new Map();
-
-  array2.map((item) => array2Map.set(item, true));
-
-  // Filter the first array to remove any elements that are in the second array
-  // Concatenate the filtered first array with the second array to get the merged array with unique items
-  return array1.filter((t) => array2Map.get(t) == null).concat(array2);
+  return Array.from(new Set(array1.concat(array2)));
 };

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -68,9 +68,12 @@ export const removeItemFromArray = <T>(itemToRemove: T, array: T[]): T[] =>
  * @returns {T[]}
  */
 export const mergeTwoArraysUniquely = <T>(array1: T[], array2: T[]): T[] => {
+  // Create a Map object of the second array, with each element as a key and true as the value
   const array2Map = new Map();
 
   array2.map((item) => array2Map.set(item, true));
 
+  // Filter the first array to remove any elements that are in the second array
+  // Concatenate the filtered first array with the second array to get the merged array with unique items
   return array1.filter((t) => array2Map.get(t) == null).concat(array2);
 };

--- a/src/utils/wordByWord.test.ts
+++ b/src/utils/wordByWord.test.ts
@@ -4,182 +4,270 @@ import { it, expect, describe } from 'vitest';
 
 import { WordByWordType, WordByWordDisplay } from '../../types/QuranReader';
 
+import { areArraysEqual } from './array';
 import { consolidateWordByWordState, getDefaultWordByWordDisplay } from './wordByWord';
 
 describe('consolidateWordByWordState', () => {
   it('test consolidating when inline translation = false, inline transliteration = false, tooltip = translation', () => {
-    const consolidatedState = consolidateWordByWordState(false, false, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(false, false, [
       WordByWordType.Translation,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP],
-      wordByWordContentType: [WordByWordType.Translation],
-    });
+
+    expect(wordByWordDisplay).toEqual([WordByWordDisplay.TOOLTIP]);
+    expect(wordByWordContentType).toEqual([WordByWordType.Translation]);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = true, tooltip = translation', () => {
-    const consolidatedState = consolidateWordByWordState(true, true, [WordByWordType.Translation]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, true, [
+      WordByWordType.Translation,
+    ]);
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = true, tooltip = translation', () => {
-    const consolidatedState = consolidateWordByWordState(false, true, [WordByWordType.Translation]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(false, true, [
+      WordByWordType.Translation,
+    ]);
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = false, tooltip = translation', () => {
-    const consolidatedState = consolidateWordByWordState(true, false, [WordByWordType.Translation]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, false, [
+      WordByWordType.Translation,
+    ]);
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(wordByWordContentType).toEqual([WordByWordType.Translation]);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = false, tooltip = translation,transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(false, false, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(false, false, [
       WordByWordType.Translation,
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+
+    expect(wordByWordDisplay).toEqual([WordByWordDisplay.TOOLTIP]);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = true, tooltip = translation,transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(true, true, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, true, [
       WordByWordType.Translation,
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = false, tooltip = translation,transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(true, false, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, false, [
       WordByWordType.Translation,
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Transliteration, WordByWordType.Translation],
-    });
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Transliteration,
+        WordByWordType.Translation,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = true, tooltip = translation,transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(false, true, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(false, true, [
       WordByWordType.Translation,
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = false, tooltip = transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(false, false, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(false, false, [
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP],
-      wordByWordContentType: [WordByWordType.Transliteration],
-    });
+
+    expect(wordByWordDisplay).toEqual([WordByWordDisplay.TOOLTIP]);
+    expect(wordByWordContentType).toEqual([WordByWordType.Transliteration]);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = true, tooltip = transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(true, true, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, true, [
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = true, tooltip = transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(false, true, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(false, true, [
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Transliteration],
-    });
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(wordByWordContentType).toEqual([WordByWordType.Transliteration]);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = false, tooltip = transliteration', () => {
-    const consolidatedState = consolidateWordByWordState(true, false, [
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, false, [
       WordByWordType.Transliteration,
     ]);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Transliteration, WordByWordType.Translation],
-    });
+
+    expect(
+      areArraysEqual(wordByWordDisplay, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Transliteration,
+        WordByWordType.Translation,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = false, tooltip = []', () => {
-    const consolidatedState = consolidateWordByWordState(false, false, []);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [],
-      wordByWordContentType: [],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(
+      false,
+      false,
+      [],
+    );
+
+    expect(wordByWordDisplay).toEqual([]);
+    expect(wordByWordContentType).toEqual([]);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = true, tooltip = []', () => {
-    const consolidatedState = consolidateWordByWordState(true, true, []);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation, WordByWordType.Transliteration],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(true, true, []);
+
+    expect(wordByWordDisplay).toEqual([WordByWordDisplay.INLINE]);
+
+    expect(
+      areArraysEqual(wordByWordContentType, [
+        WordByWordType.Translation,
+        WordByWordType.Transliteration,
+      ]),
+    ).toBe(true);
   });
 
   it('test consolidating when inline translation = false, inline transliteration = true, tooltip = []', () => {
-    const consolidatedState = consolidateWordByWordState(false, true, []);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Transliteration],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(
+      false,
+      true,
+      [],
+    );
+
+    expect(wordByWordDisplay).toEqual([WordByWordDisplay.INLINE]);
+    expect(wordByWordContentType).toEqual([WordByWordType.Transliteration]);
   });
 
   it('test consolidating when inline translation = true, inline transliteration = false, tooltip = []', () => {
-    const consolidatedState = consolidateWordByWordState(true, false, []);
-    expect(consolidatedState).toEqual({
-      wordByWordDisplay: [WordByWordDisplay.INLINE],
-      wordByWordContentType: [WordByWordType.Translation],
-    });
+    const { wordByWordDisplay, wordByWordContentType } = consolidateWordByWordState(
+      true,
+      false,
+      [],
+    );
+
+    expect(wordByWordDisplay).toEqual([WordByWordDisplay.INLINE]);
+    expect(wordByWordContentType).toEqual([WordByWordType.Translation]);
   });
 });
 
 describe('getDefaultWordByWordDisplay', () => {
   it('when no word by word settings are set', () => {
     const consolidatedState = getDefaultWordByWordDisplay([]);
+
     expect(consolidatedState).toEqual([WordByWordDisplay.TOOLTIP]);
   });
+
   it('when tooltip setting is already set', () => {
     const consolidatedState = getDefaultWordByWordDisplay([WordByWordDisplay.TOOLTIP]);
+
     expect(consolidatedState).toEqual([WordByWordDisplay.TOOLTIP]);
   });
+
   it('when inline setting is already set', () => {
     const consolidatedState = getDefaultWordByWordDisplay([WordByWordDisplay.INLINE]);
+
     expect(consolidatedState).toEqual([WordByWordDisplay.INLINE]);
   });
+
   it('when both tooltip and inline settings are already set', () => {
     const consolidatedState = getDefaultWordByWordDisplay([
       WordByWordDisplay.TOOLTIP,
       WordByWordDisplay.INLINE,
     ]);
-    expect(consolidatedState).toEqual([WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]);
+
+    expect(
+      areArraysEqual(consolidatedState, [WordByWordDisplay.TOOLTIP, WordByWordDisplay.INLINE]),
+    ).toBe(true);
   });
+
   it('when settings are undefined (have been manually edited)', () => {
     const consolidatedState = getDefaultWordByWordDisplay(undefined);
+
     expect(consolidatedState).toEqual([WordByWordDisplay.TOOLTIP]);
   });
 });


### PR DESCRIPTION
### Summary
- replace array includes with map look-up, which improves time complexity from O(n*m) to O(n+m)

### Test Plan
this is a fiddle with the test

https://jsfiddle.net/mahmoud_alragabi/v3wL0ob4/

### Screenshots

and here is a screenshot of the performance improvement almost to 3x

![image](https://user-images.githubusercontent.com/51799859/234218414-c58a28d8-c567-4e86-a883-eb292c129145.png)
