### PR TITLE
fix: 🐛 Surah icon order after sorting in Revelation Order tab

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,31 +1,26 @@
 {
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
-  },
-  "editor.formatOnSave": true,
-  "typescript.format.enable": false,
-  "javascript.format.enable": false,
-  "cssVariables.lookupFiles": [
-    "src/styles/theme.scss",
-    "src/styles/themes/_light.scss" // include one of the theme file
-  ],
-  "prettier.disableLanguages": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact",
-    "scss"
-  ],
-  "i18n-ally.localesPaths": [
-    "locales",
-    "public/fonts/lang",
-    "src/redux/defaultSettings/locales"
-  ]
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true,
+        "source.fixAll.stylelint": true,
+    },
+    "editor.formatOnSave": true,
+    "typescript.format.enable": false,
+    "javascript.format.enable": false,
+    "cssVariables.lookupFiles": [
+        "src/styles/theme.scss",
+        "src/styles/themes/_light.scss", // include one of the theme file
+    ],
+    "prettier.disableLanguages": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact",
+        "scss"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,26 +1,31 @@
 {
-    "eslint.validate": [
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact"
-    ],
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true,
-        "source.fixAll.stylelint": true,
-    },
-    "editor.formatOnSave": true,
-    "typescript.format.enable": false,
-    "javascript.format.enable": false,
-    "cssVariables.lookupFiles": [
-        "src/styles/theme.scss",
-        "src/styles/themes/_light.scss", // include one of the theme file
-    ],
-    "prettier.disableLanguages": [
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact",
-        "scss"
-    ],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true
+  },
+  "editor.formatOnSave": true,
+  "typescript.format.enable": false,
+  "javascript.format.enable": false,
+  "cssVariables.lookupFiles": [
+    "src/styles/theme.scss",
+    "src/styles/themes/_light.scss" // include one of the theme file
+  ],
+  "prettier.disableLanguages": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "scss"
+  ],
+  "i18n-ally.localesPaths": [
+    "locales",
+    "public/fonts/lang",
+    "src/redux/defaultSettings/locales"
+  ]
 }

--- a/src/components/chapters/RevelationOrderView.tsx
+++ b/src/components/chapters/RevelationOrderView.tsx
@@ -84,7 +84,7 @@ const RevelationOrderView = ({ isDescending, chapters }: RevelationOrderViewProp
           onKeyPress={() => onSurahClicked(chapter.id)}
         >
           <SurahPreviewRow
-            chapterId={REVELATION_ORDER[revelationOrderIndex]}
+            chapterId={+chapter.id}
             description={getChapterDescription(chapter, t)}
             surahName={`${chapter.transliteratedName}`}
             surahNumber={

--- a/src/components/chapters/RevelationOrderView.tsx
+++ b/src/components/chapters/RevelationOrderView.tsx
@@ -84,7 +84,7 @@ const RevelationOrderView = ({ isDescending, chapters }: RevelationOrderViewProp
           onKeyPress={() => onSurahClicked(chapter.id)}
         >
           <SurahPreviewRow
-            chapterId={+chapter.id}
+            chapterId={Number(chapter.id)}
             description={getChapterDescription(chapter, t)}
             surahName={`${chapter.transliteratedName}`}
             surahNumber={


### PR DESCRIPTION
Bismillah

### Issue
#1957 

### Summary
The Surah icons were not updating when changing the sorting order in the 'Revelation Order' tab. The incorrect index was being passed into the `SurahPreviewRow` component which is responsible for getting the chapter icon.
This PR fixes the issue by using the correct value for the chapter id.

### Unrelated changes
I have added additional config in the `settings.json` file which is being used by the [i18n Ally VS Code extension](https://marketplace.visualstudio.com/items?itemName=lokalise.i18n-ally). This extension makes using i18n easier.
If you would like me to remove this config from this PR, please let me know.

### Test Plan
1. Go to [localhost](http://localhost:3000/) and click on the 'Revelation Order' tab
2. Check the Arabic chapter icons are mapping correctly to the Surah
3. Change the sort by order to descending and again check if the icons have updated to the correct name

### Screenshots

BEFORE
![image](https://user-images.githubusercontent.com/84995410/234942653-1d5194fc-b1db-402d-82f3-7b01b9bf7cb3.png)


AFTER
![image](https://user-images.githubusercontent.com/84995410/234942764-e77662f9-7aae-45ec-99cc-6afac3876d97.png)
