### PR TITLE
Reset sidebar navigation inputs and sync their state

### DIFF
--- a/src/components/QuranReader/SidebarNavigation/SurahList.tsx
+++ b/src/components/QuranReader/SidebarNavigation/SurahList.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'react-redux';
 import styles from './SidebarNavigation.module.scss';
 
 import Link from '@/dls/Link/Link';
+import useChapterIdsByUrlPath from '@/hooks/useChapterId';
 import { SCROLL_TO_NEAREST_ELEMENT, useScrollToElement } from '@/hooks/useScrollToElement';
 import { selectLastReadVerseKey } from '@/redux/slices/QuranReader/readingTracker';
 import { selectIsReadingByRevelationOrder } from '@/redux/slices/revelationOrder';
@@ -20,8 +21,8 @@ import REVELATION_ORDER from '@/utils/revelationOrder';
 import DataContext from 'src/contexts/DataContext';
 import Chapter from 'types/Chapter';
 
-const filterSurah = (surah, searchQuery: string) => {
-  const fuse = new Fuse(surah, {
+const filterSurah = (surahs: Chapter[], searchQuery: string) => {
+  const fuse = new Fuse(surahs, {
     threshold: 0.3,
     keys: ['id', 'localizedId', 'transliteratedName'],
   });
@@ -32,6 +33,7 @@ const filterSurah = (surah, searchQuery: string) => {
   } else {
     logTextSearchQuery(searchQuery, SearchQuerySource.SidebarNavigationChaptersList);
   }
+
   return filteredSurah as Chapter[];
 };
 
@@ -39,11 +41,22 @@ const SurahList = () => {
   const { t, lang } = useTranslation('common');
   const lastReadVerseKey = useSelector(selectLastReadVerseKey);
   const isReadingByRevelationOrder = useSelector(selectIsReadingByRevelationOrder);
-
-  const currentChapterId = lastReadVerseKey.chapterId;
-
   const router = useRouter();
   const chaptersData = useContext(DataContext);
+
+  const chapterIds = useChapterIdsByUrlPath(lang);
+  const urlChapterId = chapterIds && chapterIds.length > 0 ? chapterIds[0] : null;
+
+  const [currentChapterId, setCurrentChapterId] = useState(urlChapterId);
+
+  useEffect(() => {
+    setCurrentChapterId(lastReadVerseKey.chapterId);
+  }, [lastReadVerseKey]);
+
+  useEffect(() => {
+    // when the user navigates to a new chapter, the current chapter id
+    setCurrentChapterId(urlChapterId);
+  }, [urlChapterId]);
 
   const [searchQuery, setSearchQuery] = useState('');
 

--- a/src/components/QuranReader/SidebarNavigation/VerseList.tsx
+++ b/src/components/QuranReader/SidebarNavigation/VerseList.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 import styles from './SidebarNavigation.module.scss';
 import VerseListItem from './VerseListItem';
 
+import useChapterIdsByUrlPath from '@/hooks/useChapterId';
 import { selectLastReadVerseKey } from '@/redux/slices/QuranReader/readingTracker';
 import SearchQuerySource from '@/types/SearchQuerySource';
 import { logEmptySearchResults, logTextSearchQuery } from '@/utils/eventLogger';
@@ -18,10 +19,24 @@ import DataContext from 'src/contexts/DataContext';
 const VerseList = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const { t, lang } = useTranslation('common');
-  const chaptersData = useContext(DataContext);
   const lastReadVerseKey = useSelector(selectLastReadVerseKey);
-  const currentChapterId = lastReadVerseKey.chapterId;
   const router = useRouter();
+  const chaptersData = useContext(DataContext);
+
+  const chapterIds = useChapterIdsByUrlPath(lang);
+  const urlChapterId = chapterIds && chapterIds.length > 0 ? chapterIds[0] : null;
+
+  const [currentChapterId, setCurrentChapterId] = useState(urlChapterId);
+
+  useEffect(() => {
+    setCurrentChapterId(lastReadVerseKey.chapterId);
+  }, [lastReadVerseKey]);
+
+  useEffect(() => {
+    // when the user navigates to a new chapter, reset the search query, and update the current chapter id
+    setSearchQuery('');
+    setCurrentChapterId(urlChapterId);
+  }, [urlChapterId]);
 
   const verseKeys = useMemo(
     () => (currentChapterId ? generateChapterVersesKeys(chaptersData, currentChapterId) : []),


### PR DESCRIPTION
### Summary

This PR fixes 2 problems:

1. When you search for a verse in the sidebar and navigate to a different chapter, the input is not being reset and the verse list is reflecting the old chapter:

<img src="https://github.com/quran/quran.com-frontend-next/assets/58295120/8de32cc3-c589-4c12-b0d3-9b33c8599861" height="350px" />

---

2.  When you navigate to a different chapter, the surah list was not being updated to reflect the new state:

<img src="https://github.com/quran/quran.com-frontend-next/assets/58295120/e96a7162-b51a-4cba-a6d3-71151e8475c4" height="350px" />
