### PR TITLE
Render Quran Reader footer using virtuoso

### DIFF
--- a/src/components/HomePage/ReadingStreak/index.tsx
+++ b/src/components/HomePage/ReadingStreak/index.tsx
@@ -38,8 +38,11 @@ const ReadingStreak: React.FC<ReadingStreakProps> = ({ layout = ReadingStreakLay
   const { t, lang } = useTranslation('reading-goal');
   const isQuranReader = layout === ReadingStreakLayout.QuranReader;
 
-  const { isLoading, error, streak, goal, weekData, currentActivityDay } =
-    useGetStreakWithMetadata();
+  const { isLoading, error, streak, goal, weekData, currentActivityDay } = useGetStreakWithMetadata(
+    {
+      disableIfNoGoalExists: isQuranReader,
+    },
+  );
   const { recentlyReadVerseKeys } = useGetRecentlyReadVerseKeys();
 
   const nextVerseToRead = goal?.progress?.nextVerseToRead ?? recentlyReadVerseKeys[0];
@@ -97,7 +100,7 @@ const ReadingStreak: React.FC<ReadingStreakProps> = ({ layout = ReadingStreakLay
     return null;
   }
 
-  if (error || (!isLoading && streak === 0 && !goal)) {
+  if (!isQuranReader && (error || (!isLoading && streak === 0 && !goal))) {
     return <StreakIntroductionWidget />;
   }
 
@@ -147,7 +150,7 @@ const ReadingStreak: React.FC<ReadingStreakProps> = ({ layout = ReadingStreakLay
   };
 
   // if this is QuranReader, don't render anything if there is no reading goal
-  if (isQuranReader && !goal) {
+  if (isQuranReader && (isLoading || !goal)) {
     return null;
   }
 

--- a/src/components/QuranReader/ReadingView/index.tsx
+++ b/src/components/QuranReader/ReadingView/index.tsx
@@ -154,19 +154,35 @@ const ReadingView = ({
   useHotkeys('Up', onUpClicked, { enabled: allowKeyboardNavigation }, [scrollToPreviousPage]);
   useHotkeys('Down', onDownClicked, { enabled: allowKeyboardNavigation }, [scrollToNextPage]);
 
-  const itemContentRenderer = (pageIndex: number) => (
-    <PageContainer
-      isUsingDefaultFont={isUsingDefaultFont}
-      pagesVersesRange={pagesVersesRange}
-      quranReaderStyles={quranReaderStyles}
-      reciterId={reciterId}
-      lang={lang}
-      wordByWordLocale={wordByWordLocale}
-      pageIndex={pageIndex}
-      setMushafPageToVersesMap={setMushafPageToVersesMap}
-      initialData={initialData}
-    />
-  );
+  const itemContentRenderer = (pageIndex: number) => {
+    if (pageIndex === pagesCount) {
+      const pageVerses = mushafPageToVersesMap[lastReadPageNumber];
+      const lastVerse = pageVerses?.[pageVerses.length - 1];
+      if (!lastVerse) return null;
+
+      return (
+        <EndOfScrollingControls
+          quranReaderDataType={quranReaderDataType}
+          lastVerse={lastVerse}
+          initialData={initialData}
+        />
+      );
+    }
+
+    return (
+      <PageContainer
+        isUsingDefaultFont={isUsingDefaultFont}
+        pagesVersesRange={pagesVersesRange}
+        quranReaderStyles={quranReaderStyles}
+        reciterId={reciterId}
+        lang={lang}
+        wordByWordLocale={wordByWordLocale}
+        pageIndex={pageIndex}
+        setMushafPageToVersesMap={setMushafPageToVersesMap}
+        initialData={initialData}
+      />
+    );
+  };
 
   if (hasError) {
     return <Error />;
@@ -197,24 +213,8 @@ const ReadingView = ({
             increaseViewportBy={INCREASE_VIEWPORT_BY_PIXELS}
             className={styles.virtuosoScroller}
             initialItemCount={1} // needed for SSR.
-            totalCount={pagesCount}
+            totalCount={pagesCount + 1}
             itemContent={itemContentRenderer}
-            components={{
-              Footer: () => {
-                const pageVerses = mushafPageToVersesMap[lastReadPageNumber];
-                const lastVerse = pageVerses?.[pageVerses.length - 1];
-                if (lastVerse) {
-                  return (
-                    <EndOfScrollingControls
-                      quranReaderDataType={quranReaderDataType}
-                      lastVerse={lastVerse}
-                      initialData={initialData}
-                    />
-                  );
-                }
-                return null;
-              },
-            }}
           />
         )}
       </div>

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -75,6 +75,16 @@ const TranslationView = ({
   useQcfFont(quranReaderStyles.quranFont, verses);
 
   const itemContentRenderer = (verseIdx: number) => {
+    if (verseIdx === initialData.metaData.numberOfVerses) {
+      return (
+        <EndOfScrollingControls
+          quranReaderDataType={quranReaderDataType}
+          lastVerse={verses[verses.length - 1]}
+          initialData={initialData}
+        />
+      );
+    }
+
     return (
       <TranslationViewVerse
         verseIdx={verseIdx}
@@ -105,19 +115,10 @@ const TranslationView = ({
         <Virtuoso
           ref={virtuosoRef}
           useWindowScroll
-          totalCount={initialData.metaData.numberOfVerses}
+          totalCount={initialData.metaData.numberOfVerses + 1}
           increaseViewportBy={INCREASE_VIEWPORT_BY_PIXELS}
           initialItemCount={1} // needed for SSR.
           itemContent={itemContentRenderer}
-          components={{
-            Footer: () => (
-              <EndOfScrollingControls
-                quranReaderDataType={quranReaderDataType}
-                lastVerse={verses[verses.length - 1]}
-                initialData={initialData}
-              />
-            ),
-          }}
         />
       </div>
     </>


### PR DESCRIPTION
### Summary

This PR prevents an extra HTTP request that gets triggered when reading to refresh the streak data. Instead of using Virtuoso's Footer, we add `1` to the list count and we render the footer as the last element.