### PR TITLE
Clear scroll timeout when setting a new one

### DIFF
--- a/src/components/QuranReader/TranslationView/hooks/useScrollToVirtualizedVerse.ts
+++ b/src/components/QuranReader/TranslationView/hooks/useScrollToVirtualizedVerse.ts
@@ -89,6 +89,10 @@ const useScrollToVirtualizedTranslationView = (
       //
       // otherwise, we use `scrollToBeginningOfVerseCell` to scroll near the beginning of the verse cell without setting `shouldReadjustScroll` to false so that this effect runs again when the data loads
       if (isDoneLoading) {
+        if (timeoutId.current !== null) {
+          clearTimeout(timeoutId.current);
+        }
+
         timeoutId.current = setTimeout(() => {
           scrollToBeginningOfVerseCell(startingVerseNumber);
         }, 1000);


### PR DESCRIPTION
### Summary

Currently, when you click on a lot of verses quickly in the sidebar navigation, you'll be scrolled to all of them respectively due to the `setTimeout` for each click. This PR clears the preview `setTimeout` before setting a new one.