### PR TITLE
fix: #1988 tightened router based searchQuery state update block

### DIFF
--- a/src/components/Search/SearchResults/SearchResultItem.tsx
+++ b/src/components/Search/SearchResults/SearchResultItem.tsx
@@ -47,7 +47,6 @@ const SearchResultItem: React.FC<Props> = ({ result, source }) => {
         <Link
           className={styles.verseKey}
           href={getChapterWithStartingVerseUrl(result.verseKey)}
-          shouldPassHref
           onClick={() => {
             logButtonClick(`${source}_result_item`);
           }}

--- a/src/components/Search/SearchResults/SearchResultItem.tsx
+++ b/src/components/Search/SearchResults/SearchResultItem.tsx
@@ -45,15 +45,14 @@ const SearchResultItem: React.FC<Props> = ({ result, source }) => {
     <div className={styles.container}>
       <div className={styles.itemContainer}>
         <Link
+          className={styles.verseKey}
           href={getChapterWithStartingVerseUrl(result.verseKey)}
           shouldPassHref
           onClick={() => {
             logButtonClick(`${source}_result_item`);
           }}
         >
-          <a className={styles.verseKey}>
-            {chapterData.transliteratedName} {localizedVerseKey}
-          </a>
+          {chapterData.transliteratedName} {localizedVerseKey}
         </Link>
         <div className={styles.quranTextContainer}>
           <div className={styles.quranTextResult} translate="no">

--- a/src/components/dls/Pagination/Pagination.tsx
+++ b/src/components/dls/Pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import React, { useMemo } from 'react';
 
 import classNames from 'classnames';
@@ -102,9 +103,9 @@ const Pagination: React.FC<Props> = ({
           <PreviousIcon />
         </Button>
       </div>
-      {paginationRange.map((pageNumber) => {
+      {paginationRange.map((pageNumber, index) => {
         if (pageNumber === DOTS) {
-          return <div>{DOTS}</div>;
+          return <div key={`${pageNumber}-${index}`}>{DOTS}</div>;
         }
 
         return (
@@ -112,7 +113,7 @@ const Pagination: React.FC<Props> = ({
             className={classNames(styles.buttonContainer, {
               [styles.selectedButton]: pageNumber === currentPage,
             })}
-            key={pageNumber}
+            key={`${pageNumber}-${index}`}
           >
             <Button
               variant={ButtonVariant.Ghost}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -84,19 +84,10 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
   // After hydration, Next.js will trigger an update to provide the route parameters
   // in the query object. @see https://nextjs.org/docs/routing/dynamic-routes#caveats
   useEffect(() => {
-    if (router.isReady) {
-      if (router.query.page) {
-        setCurrentPage(Number(router.query.page));
-      }
-      if (router.query.languages) {
-        setSelectedLanguages(router.query.languages as string);
-      }
-      if (router.query.translations) {
-        setSelectedTranslations(router.query.translations as string);
-      }
+    if (router.isReady && !isContentModalOpen) {
       focusInput();
     }
-  }, [focusInput, router]);
+  }, [focusInput, router, isContentModalOpen]);
 
   useEffect(() => {
     if (router.query.q || router.query.query) {
@@ -106,7 +97,23 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
       }
       setSearchQuery(query);
     }
-  }, [router?.query?.q, router?.query?.query]);
+
+    if (router.query.page) {
+      setCurrentPage(Number(router.query.page));
+    }
+    if (router.query.languages) {
+      setSelectedLanguages(router.query.languages as string);
+    }
+    if (router.query.translations) {
+      setSelectedTranslations(router.query.translations as string);
+    }
+  }, [
+    router?.query?.q,
+    router?.query?.query,
+    router?.query?.page,
+    router?.query?.languages,
+    router?.query?.translations,
+  ]);
 
   /**
    * Handle when the search query is changed.
@@ -202,7 +209,8 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
   const onTranslationChange = useCallback((translationIds: string[]) => {
     // convert the array into a string
     setSelectedTranslations((prevTranslationIds) => {
-      const newTranslationIds = translationIds.join(',');
+      // filter out the empty strings
+      const newTranslationIds = translationIds.filter((id) => id !== '').join(',');
       logValueChange('search_page_selected_translations', prevTranslationIds, newTranslationIds);
       return newTranslationIds;
     });

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -85,13 +85,6 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
   // in the query object. @see https://nextjs.org/docs/routing/dynamic-routes#caveats
   useEffect(() => {
     if (router.isReady) {
-      if (router.query.q || router.query.query) {
-        let query = router.query.q as string;
-        if (router.query.query) {
-          query = router.query.query as string;
-        }
-        setSearchQuery(query);
-      }
       if (router.query.page) {
         setCurrentPage(Number(router.query.page));
       }
@@ -104,6 +97,16 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
       focusInput();
     }
   }, [focusInput, router]);
+
+  useEffect(() => {
+    if (router.query.q || router.query.query) {
+      let query = router.query.q as string;
+      if (router.query.query) {
+        query = router.query.query as string;
+      }
+      setSearchQuery(query);
+    }
+  }, [router?.query?.q, router?.query?.query]);
 
   /**
    * Handle when the search query is changed.

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -84,6 +84,7 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
   // After hydration, Next.js will trigger an update to provide the route parameters
   // in the query object. @see https://nextjs.org/docs/routing/dynamic-routes#caveats
   useEffect(() => {
+    // we don't want to focus the main search input when the translation filter modal is open.
     if (router.isReady && !isContentModalOpen) {
       focusInput();
     }
@@ -108,11 +109,11 @@ const Search: NextPage<SearchProps> = ({ translations }): JSX.Element => {
       setSelectedTranslations(router.query.translations as string);
     }
   }, [
-    router?.query?.q,
-    router?.query?.query,
-    router?.query?.page,
-    router?.query?.languages,
-    router?.query?.translations,
+    router.query.q,
+    router.query.query,
+    router.query.page,
+    router.query.languages,
+    router.query.translations,
   ]);
 
   /**


### PR DESCRIPTION
### Summary
Salam Alaikoum,

This PR is an attempt to fix https://github.com/quran/quran.com-frontend-next/issues/1988

### Test Plan
1. Search for any word eg.. `ta` on home page search bar
2. Click on the first search result option
3. On the search page you should be able to change the search input, remove, backspace, etc..

### Screenshots

Before:
https://github.com/quran/quran.com-frontend-next/assets/26346408/1ba04708-a0c3-4bf4-9fe4-c4bcd01dc61a

After:
https://github.com/quran/quran.com-frontend-next/assets/26346408/60c0d752-0c1d-40a2-91d1-b0b51f101e6a
