### PR TITLE
Correct the Ayah's format for ayah counts greater than 10 and less than 10

### DIFF
--- a/src/components/chapters/ChapterAndJuzList.tsx
+++ b/src/components/chapters/ChapterAndJuzList.tsx
@@ -157,7 +157,7 @@ const ChapterAndJuzList: React.FC<ChapterAndJuzListProps> = ({
                 <SurahPreviewRow
                   chapterId={Number(chapter.id)}
                   description={`${toLocalizedNumber(chapter.versesCount, lang)} ${t(
-                    'common:ayahs',
+                    chapter.versesCount > 10 ? 'common:ayah' : 'common:ayahs',
                   )}`}
                   surahName={chapter.transliteratedName}
                   surahNumber={Number(chapter.id)}

--- a/src/components/chapters/JuzView.tsx
+++ b/src/components/chapters/JuzView.tsx
@@ -62,7 +62,7 @@ const JuzView = ({ isDescending }: JuzViewProps) => {
                     <SurahPreviewRow
                       chapterId={Number(chapterId)}
                       description={`${toLocalizedNumber(chapter.versesCount, lang)} ${t(
-                        'common:ayahs',
+                        chapter.versesCount > 10 ? 'common:ayah' : 'common:ayahs',
                       )}`}
                       surahName={chapter.transliteratedName}
                       surahNumber={Number(chapterId)}


### PR DESCRIPTION
### Summary

This PR deals with https://github.com/quran/quran.com-frontend-next/issues/1991 Issue, I used just the conditional ternary operator here due to the fact that, this issue only exists in two components on the website, I could easily create a function for this if necessary please let me know, -I'd also really appreciate where I would add this function too I initially thought `verse.ts` could be the right place for it so please let me know-

### Test Plan

1. Go to [localhost](http://localhost:3000/ar) scroll down to "سورة" view
2. You will find Surahs with verse count more than 10 to have the value "آية x" while those with verse counts less than 10 to have the value "آيات x"
3. You will find the same behaviour if you choose the "جزء" view


### Screenshots

| Before | After |
| ------ | ------ |
| ![a](https://github.com/quran/quran.com-frontend-next/assets/26578518/3a603f5f-2492-4525-8441-9d5933661121)| ![b](https://github.com/quran/quran.com-frontend-next/assets/26578518/658fb316-b987-44ca-8235-368ed9257978)|
| ![c](https://github.com/quran/quran.com-frontend-next/assets/26578518/19500877-e109-446b-9a73-830a0673b7f5) |![d](https://github.com/quran/quran.com-frontend-next/assets/26578518/2b0792a9-b1ea-422c-bd3f-893cf6e69563)|