### PR TITLE
Scrollbar: Hide when few items in firefox

### DIFF
--- a/src/components/HomePage/QuickLinks/QuickLinks.module.scss
+++ b/src/components/HomePage/QuickLinks/QuickLinks.module.scss
@@ -13,7 +13,7 @@ $link-shadow: 0px 3px 11px 1px rgb(0 0 0 / 3%);
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  overflow-x: scroll;
+  overflow-x: auto;
   margin-inline: auto;
   &::-webkit-scrollbar {
     -webkit-appearance: none;


### PR DESCRIPTION
### Summary
This PR change keep the scrollbar hidden when there are few items in the quick links container in Firefox.

### Screenshots

| Before | After |
| ------ | ------ |
| ![before](https://github.com/quran/quran.com-frontend-next/assets/83069563/c9a0d8d1-546f-46eb-a8f7-85b6ae966f22) | ![after](https://github.com/quran/quran.com-frontend-next/assets/83069563/c69b03b8-b4c5-4f4d-8ef7-e04859236023) |