### PR TITLE
Fix popover menu SVGs

### DIFF
--- a/src/components/dls/PopoverMenu/PopoverMenu.module.scss
+++ b/src/components/dls/PopoverMenu/PopoverMenu.module.scss
@@ -106,6 +106,7 @@ $separator-size: 1px;
   [dir="rtl"] & .iconWrapper.shouldFlipOnRTL {
     transform: scaleX(-1);
   }
+
   & .iconWrapper {
     margin-inline-end: var(--spacing-small);
     display: flex;
@@ -113,6 +114,11 @@ $separator-size: 1px;
     justify-content: center;
     height: var(--spacing-medium);
     width: var(--spacing-medium);
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
### Summary

This bug was caused due to that not all icons have pre-defined dimensions nor a browser default. This PR fixes this issue by setting width and height for popover item's SVG.


### Screenshots

| Before | After |
| ------ | ------ |
| ![CleanShot 2023-07-07 at 13 11 38@2x](https://github.com/quran/quran.com-frontend-next/assets/58295120/578ce92e-f917-4b24-9197-9068d037d7bf) | ![CleanShot 2023-07-07 at 13 10 15@2x](https://github.com/quran/quran.com-frontend-next/assets/58295120/1174549e-f8fb-4846-badc-1577985b9686) |