### PR TITLE
Added footnote number identifier: Feature #2004

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 
-import React, { MouseEvent, useMemo } from 'react';
+import React, { MouseEvent } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
@@ -11,7 +11,7 @@ import transStyles from './TranslationText.module.scss';
 import Button, { ButtonSize, ButtonShape, ButtonVariant } from '@/dls/Button/Button';
 import Spinner from '@/dls/Spinner/Spinner';
 import CloseIcon from '@/icons/close.svg';
-import { getLanguageDataById, findLanguageIdByLocale, toLocalizedNumber } from '@/utils/locale';
+import { getLanguageDataById, findLanguageIdByLocale } from '@/utils/locale';
 import Footnote from 'types/Footnote';
 
 interface FootnoteTextProps {
@@ -34,23 +34,11 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
   const languageId = footnote?.languageId || findLanguageIdByLocale(lang);
   const landData = getLanguageDataById(languageId);
 
-  const formattedFootnoteName = useMemo(() => {
-    if (!footnoteName) return null;
-
-    const footnoteNumber = Number(footnoteName);
-
-    // if footnoteName is not numeric, return it
-    if (Number.isNaN(footnoteNumber)) return footnoteName;
-
-    // otherwise, localize the footnote number
-    return toLocalizedNumber(footnoteNumber, lang);
-  }, [footnoteName, lang]);
-
   return (
     <div className={styles.footnoteContainer}>
       <div className={styles.header}>
         <p>
-          {t('footnote')} {formattedFootnoteName ? `- ${formattedFootnoteName}` : null}
+          {t('footnote')} {footnoteName ? `- ${footnoteName}` : null}
         </p>
         <Button
           size={ButtonSize.Small}

--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -11,11 +11,11 @@ import transStyles from './TranslationText.module.scss';
 import Button, { ButtonSize, ButtonShape, ButtonVariant } from '@/dls/Button/Button';
 import Spinner from '@/dls/Spinner/Spinner';
 import CloseIcon from '@/icons/close.svg';
-import { getLanguageDataById, findLanguageIdByLocale } from '@/utils/locale';
+import { getLanguageDataById, findLanguageIdByLocale, toLocalizedNumber } from '@/utils/locale';
 import Footnote from 'types/Footnote';
 
 interface FootnoteTextProps {
-  footnoteNumberStr: string;
+  footnoteNumber?: number | null;
   footnote: Footnote;
   onCloseClicked: () => void;
   onTextClicked?: (event: MouseEvent, isSubFootnote?: boolean) => void;
@@ -23,7 +23,7 @@ interface FootnoteTextProps {
 }
 
 const FootnoteText: React.FC<FootnoteTextProps> = ({
-  footnoteNumberStr,
+  footnoteNumber,
   footnote,
   onCloseClicked,
   onTextClicked,
@@ -37,7 +37,9 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
   return (
     <div className={styles.footnoteContainer}>
       <div className={styles.header}>
-        <p>{t(`footnote - ${footnoteNumberStr}`)}</p>
+        <p>
+          {t('footnote')} {footnoteNumber ? toLocalizedNumber(footnoteNumber, lang) : null}
+        </p>
         <Button
           size={ButtonSize.Small}
           variant={ButtonVariant.Ghost}

--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -15,6 +15,7 @@ import { getLanguageDataById, findLanguageIdByLocale } from '@/utils/locale';
 import Footnote from 'types/Footnote';
 
 interface FootnoteTextProps {
+  footnoteNumberStr: string;
   footnote: Footnote;
   onCloseClicked: () => void;
   onTextClicked?: (event: MouseEvent, isSubFootnote?: boolean) => void;
@@ -22,6 +23,7 @@ interface FootnoteTextProps {
 }
 
 const FootnoteText: React.FC<FootnoteTextProps> = ({
+  footnoteNumberStr,
   footnote,
   onCloseClicked,
   onTextClicked,
@@ -35,7 +37,7 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
   return (
     <div className={styles.footnoteContainer}>
       <div className={styles.header}>
-        <p>{t('footnote')}</p>
+        <p>{t(`footnote - ${footnoteNumberStr}`)}</p>
         <Button
           size={ButtonSize.Small}
           variant={ButtonVariant.Ghost}

--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 
-import React, { MouseEvent } from 'react';
+import React, { MouseEvent, useMemo } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
@@ -15,7 +15,7 @@ import { getLanguageDataById, findLanguageIdByLocale, toLocalizedNumber } from '
 import Footnote from 'types/Footnote';
 
 interface FootnoteTextProps {
-  footnoteNumber?: number | null;
+  footnoteName?: string; // can be a number or a string (e.g. "sg" or "pl")
   footnote: Footnote;
   onCloseClicked: () => void;
   onTextClicked?: (event: MouseEvent, isSubFootnote?: boolean) => void;
@@ -23,7 +23,7 @@ interface FootnoteTextProps {
 }
 
 const FootnoteText: React.FC<FootnoteTextProps> = ({
-  footnoteNumber,
+  footnoteName,
   footnote,
   onCloseClicked,
   onTextClicked,
@@ -34,11 +34,23 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
   const languageId = footnote?.languageId || findLanguageIdByLocale(lang);
   const landData = getLanguageDataById(languageId);
 
+  const formattedFootnoteName = useMemo(() => {
+    if (!footnoteName) return null;
+
+    const footnoteNumber = Number(footnoteName);
+
+    // if footnoteName is not numeric, return it
+    if (Number.isNaN(footnoteNumber)) return footnoteName;
+
+    // otherwise, localize the footnote number
+    return toLocalizedNumber(footnoteNumber, lang);
+  }, [footnoteName, lang]);
+
   return (
     <div className={styles.footnoteContainer}>
       <div className={styles.header}>
         <p>
-          {t('footnote')} {footnoteNumber ? toLocalizedNumber(footnoteNumber, lang) : null}
+          {t('footnote')} {formattedFootnoteName ? `- ${formattedFootnoteName}` : null}
         </p>
         <Button
           size={ButtonSize.Small}

--- a/src/components/QuranReader/TranslationView/TranslationText/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/index.tsx
@@ -33,6 +33,8 @@ const TranslationText: React.FC<Props> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showFootnote, setShowFootnote] = useState(true);
   const [footnote, setFootnote] = useState<Footnote>(null);
+  const [footnoteNumberStr, setFootnoteNumberStr] = useState("");
+  const [subFootnoteNumberStr, setSubFootnoteNumberStr] = useState("");
   const [subFootnote, setSubFootnote] = useState<Footnote>(null);
 
   const PRE_DEFINED_FOOTNOTES = {
@@ -70,7 +72,7 @@ const TranslationText: React.FC<Props> = ({
    *       is, we get the value from the pre-defined footnotes and assign it as the footnote
    *       text without having to call BE (only happens with Bridge's Foundation translation)
    * 2. If it's a sub-footnote it will only have pre-defined footnotes so we handle it the same
-   *    way as above (only happens with Bridge's Foundation translation).
+   *    way as above (only happens with Bridge's Foundation translation, ex: Surah 30, Verse 11).
    *
    * @param {MouseEvent} event
    * @param {boolean} isSubFootnote whether we are handling a footnote or a sub-footnote (only happens
@@ -83,6 +85,8 @@ const TranslationText: React.FC<Props> = ({
       // if it's the main footnote and not the sub footnote.
       if (!isSubFootnote) {
         const footNoteId = target.getAttribute('foot_note');
+        // Set the footnoteNumberStr to the current number of the footnote from the <sup> innerHTML
+        setFootnoteNumberStr(target.innerText.trim());
         // if it's the normal case that needs us to call BE and not a fixed footnote like the ones found for Bridge's translation.
         if (footNoteId) {
           // if this is the second time to click the footnote, close it
@@ -123,6 +127,8 @@ const TranslationText: React.FC<Props> = ({
       } else {
         // we get the text inside the sup element and trim the extra spaces.
         const footnoteText = target.innerText.trim();
+        // Set the subFootnoteNumberStr to the current number of the footnote from the <sup> innerHTML
+        setSubFootnoteNumberStr(footnoteText);
         const subFootnoteId = `${footnote.id} - ${footnoteText}`;
         // if this is the second time we are clicking on the sub footnote, we close it.
         if (subFootnote && subFootnote.id === subFootnoteId) {
@@ -151,6 +157,7 @@ const TranslationText: React.FC<Props> = ({
       />
       {shouldShowFootnote && (
         <FootnoteText
+          footnoteNumberStr={footnoteNumberStr}
           footnote={footnote}
           isLoading={isLoading}
           onCloseClicked={() => {
@@ -164,7 +171,7 @@ const TranslationText: React.FC<Props> = ({
           onTextClicked={(event) => onTextClicked(event, true)}
         />
       )}
-      {subFootnote && <FootnoteText footnote={subFootnote} onCloseClicked={resetSubFootnote} />}
+      {subFootnote && <FootnoteText footnoteNumberStr={subFootnoteNumberStr} footnote={subFootnote} onCloseClicked={resetSubFootnote} />}
       {resourceName && (
         <p
           className={classNames(

--- a/src/components/QuranReader/TranslationView/TranslationText/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/index.tsx
@@ -33,8 +33,8 @@ const TranslationText: React.FC<Props> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showFootnote, setShowFootnote] = useState(true);
   const [footnote, setFootnote] = useState<Footnote>(null);
-  const [activeFootnoteNumber, setActiveFootnoteNumber] = useState<number | null>(null);
-  const [activeSubFootnoteNumber, setActiveSubFootnoteNumber] = useState<number | null>(null);
+  const [activeFootnoteName, setActiveFootnoteName] = useState<string | null>(null);
+  const [activeSubFootnoteName, setActiveSubFootnoteName] = useState<string | null>(null);
   const [subFootnote, setSubFootnote] = useState<Footnote>(null);
 
   const PRE_DEFINED_FOOTNOTES = {
@@ -47,13 +47,13 @@ const TranslationText: React.FC<Props> = ({
     setFootnote(null);
     setSubFootnote(null);
     setIsLoading(false);
-    setActiveFootnoteNumber(null);
-    setActiveSubFootnoteNumber(null);
+    setActiveFootnoteName(null);
+    setActiveSubFootnoteName(null);
   };
 
   const resetSubFootnote = () => {
     setSubFootnote(null);
-    setActiveSubFootnoteNumber(null);
+    setActiveSubFootnoteName(null);
   };
 
   /**
@@ -96,7 +96,7 @@ const TranslationText: React.FC<Props> = ({
       const footNoteId = target.getAttribute('foot_note');
 
       // Set the activeFootnoteNumber to the current number of the footnote from the <sup> innerHTML
-      setActiveFootnoteNumber(Number(footnoteText));
+      setActiveFootnoteName(footnoteText);
 
       // if it's the normal case that needs us to call BE and not a fixed footnote like the ones found for Bridge's translation.
       if (footNoteId) {
@@ -133,7 +133,7 @@ const TranslationText: React.FC<Props> = ({
       }
     } else {
       // Set the activeSubFootnoteNumber to the current number of the footnote from the <sup> innerHTML
-      setActiveSubFootnoteNumber(Number(footnoteText));
+      setActiveSubFootnoteName(footnoteText);
 
       const subFootnoteId = `${footnote.id} - ${footnoteText}`;
       // if this is the second time we are clicking on the sub footnote, we close it.
@@ -162,7 +162,7 @@ const TranslationText: React.FC<Props> = ({
       />
       {shouldShowFootnote && (
         <FootnoteText
-          footnoteNumber={activeFootnoteNumber}
+          footnoteName={activeFootnoteName || undefined}
           footnote={footnote}
           isLoading={isLoading}
           onCloseClicked={() => {
@@ -178,7 +178,7 @@ const TranslationText: React.FC<Props> = ({
       )}
       {subFootnote && (
         <FootnoteText
-          footnoteNumber={activeSubFootnoteNumber}
+          footnoteName={activeSubFootnoteName || undefined}
           footnote={subFootnote}
           onCloseClicked={resetSubFootnote}
         />

--- a/src/components/QuranReader/TranslationView/TranslationText/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/index.tsx
@@ -33,8 +33,8 @@ const TranslationText: React.FC<Props> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showFootnote, setShowFootnote] = useState(true);
   const [footnote, setFootnote] = useState<Footnote>(null);
-  const [footnoteNumberStr, setFootnoteNumberStr] = useState("");
-  const [subFootnoteNumberStr, setSubFootnoteNumberStr] = useState("");
+  const [footnoteNumberStr, setFootnoteNumberStr] = useState('');
+  const [subFootnoteNumberStr, setSubFootnoteNumberStr] = useState('');
   const [subFootnote, setSubFootnote] = useState<Footnote>(null);
 
   const PRE_DEFINED_FOOTNOTES = {
@@ -171,7 +171,13 @@ const TranslationText: React.FC<Props> = ({
           onTextClicked={(event) => onTextClicked(event, true)}
         />
       )}
-      {subFootnote && <FootnoteText footnoteNumberStr={subFootnoteNumberStr} footnote={subFootnote} onCloseClicked={resetSubFootnote} />}
+      {subFootnote && (
+        <FootnoteText
+          footnoteNumberStr={subFootnoteNumberStr}
+          footnote={subFootnote}
+          onCloseClicked={resetSubFootnote}
+        />
+      )}
       {resourceName && (
         <p
           className={classNames(


### PR DESCRIPTION
### Summary
Feature: #2004
footnote number identifier
Every footnote should when clicked do the following:

- Should show the current clicked footnote number 
- Should also show the current clicked sub-footnote number if present

### Test Plan
1. Test footnote is number displaying correctly with the "footnote" text in any Surah
2. Test sub-footnote is number is correctly displaying in Bridge's Foundation translation (ex: Surah 30, Verse 11)

### Screenshots

**| Before:**
![image](https://github.com/quran/quran.com-frontend-next/assets/67660416/ad91770c-9bb2-480b-973d-630471015263)
 **| After:**
![image](https://github.com/quran/quran.com-frontend-next/assets/67660416/3a4b4803-32ed-4faa-a483-76822ade735c)
![image](https://github.com/quran/quran.com-frontend-next/assets/67660416/c843448e-67d8-471c-b130-01504bad6cfe)
