### PR TITLE
Add reading preference switch to navbar

### DIFF
--- a/src/components/GlobalScrollListener.tsx
+++ b/src/components/GlobalScrollListener.tsx
@@ -4,8 +4,8 @@ import { useDispatch } from 'react-redux';
 
 import useScrollDirection, { ScrollDirection } from '@/hooks/useScrollDirection';
 import { setIsVisible } from '@/redux/slices/navbar';
-import { 
-  setIsExpanded, 
+import {
+  setIsExpanded,
   setShowReadingPreferenceSwitcher,
 } from '@/redux/slices/QuranReader/contextMenu';
 

--- a/src/components/GlobalScrollListener.tsx
+++ b/src/components/GlobalScrollListener.tsx
@@ -4,7 +4,10 @@ import { useDispatch } from 'react-redux';
 
 import useScrollDirection, { ScrollDirection } from '@/hooks/useScrollDirection';
 import { setIsVisible } from '@/redux/slices/navbar';
-import { setIsExpanded } from '@/redux/slices/QuranReader/contextMenu';
+import { 
+  setIsExpanded, 
+  setShowReadingPreferenceSwitcher,
+} from '@/redux/slices/QuranReader/contextMenu';
 
 const GlobalScrollListener = () => {
   const dispatch = useDispatch();
@@ -22,6 +25,11 @@ const GlobalScrollListener = () => {
       } else if (newYPosition >= 0 && direction === ScrollDirection.Up) {
         dispatch({ type: setIsExpanded.type, payload: true });
         dispatch({ type: setIsVisible.type, payload: true });
+      }
+      if (newYPosition > 150 && direction === ScrollDirection.Down) {
+        dispatch({ type: setShowReadingPreferenceSwitcher.type, payload: true });
+      } else if (newYPosition <= 150 && direction === ScrollDirection.Up) {
+        dispatch({ type: setShowReadingPreferenceSwitcher.type, payload: false });
       }
     },
     [dispatch],

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -83,10 +83,6 @@
   width: calc(100% / 3);
 }
 
-.middleSection {
-  width: 180%; // arbitrary value to accomodate larger surah names on mobile
-}
-
 .alignStart {
   text-align: start;
 }

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -81,7 +81,7 @@
 
 .section {
   width: calc(100% / 3);
-  @include breakpoints.smallerThanMobileM {
+  @include breakpoints.smallerThanTablet {
     width: 50%;
   }
 }

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -14,6 +14,7 @@
   inset-block-start: -1px;
   min-height: var(--spacing-medium);
   will-change: transform;
+  transform: translate3d(0, calc(-100% + var(--spacing-micro)), 0); // '+ spacing micro' to accommodate progress bar
   &:after {
     display: block;
     content: "";

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -75,10 +75,16 @@
   }
 }
 
+.halfSection {
+  width: 50%; // when reading preference toggle is hidden
+}
+
 .section {
-  width: 50%;
-  display: flex;
-  align-items: center;
+  width: calc(100% / 3);
+}
+
+.middleSection {
+  width: 180%; // arbitrary value to accomodate larger surah names on mobile
 }
 
 .alignStart {

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -14,7 +14,6 @@
   inset-block-start: -1px;
   min-height: var(--spacing-medium);
   will-change: transform;
-  transform: translate3d(0, calc(-100% + var(--spacing-micro)), 0); // '+ spacing micro' to accommodate progress bar
   &:after {
     display: block;
     content: "";
@@ -82,6 +81,9 @@
 
 .section {
   width: calc(100% / 3);
+  @include breakpoints.smallerThanMobileM {
+    width: 50%;
+  }
 }
 
 .alignStart {

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -115,8 +115,8 @@ const ContextMenu = () => {
           </div>
         </div>
         {showReadingPreferenceSwitcher && (
-          <div className={styles.middleSection}>
-            <ReadingPreferenceSwitcher size={readingPreferenceSize} />
+          <div className={styles.halfSection}>
+            <ReadingPreferenceSwitcher size={readingPreferenceSize} iconsOnly={true} />
           </div>
         )}
         <div className={showReadingPreferenceSwitcher ? styles.section : styles.halfSection}>
@@ -127,7 +127,7 @@ const ContextMenu = () => {
               })}
             />
             <p className={classNames(styles.alignEnd)}>
-              {isExpanded && !(isMobile() && showReadingPreferenceSwitcher) && (
+              {isExpanded && (
                 <span className={styles.secondaryInfo}>
                   {/* eslint-disable-next-line i18next/no-literal-string */}
                   {t('juz')} {juzNumber} / {t('hizb')} {localizedHizb} -{' '}

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -116,7 +116,7 @@ const ContextMenu = () => {
         </div>
         {showReadingPreferenceSwitcher && (
           <div className={styles.halfSection}>
-            <ReadingPreferenceSwitcher size={readingPreferenceSize} iconsOnly={true} />
+            <ReadingPreferenceSwitcher size={readingPreferenceSize} isIconsOnly />
           </div>
         )}
         <div className={showReadingPreferenceSwitcher ? styles.section : styles.halfSection}>

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -61,15 +61,6 @@ const ContextMenu = () => {
   const verse = getVerseNumberFromKey(verseKey);
   const progress = getChapterReadingProgress(verse, chapterData.versesCount);
 
-  let readingPreferenceSize; // defaults to Normal
-  if (showReadingPreferenceSwitcher) {
-    if (isMobile()) {
-      readingPreferenceSize = SwitchSize.Small;
-    } else {
-      readingPreferenceSize = SwitchSize.Normal;
-    }
-  }
-
   return (
     <div
       className={classNames(styles.container, {
@@ -119,7 +110,7 @@ const ContextMenu = () => {
         {showReadingPreferenceSwitcher && (
           <div className={styles.halfSection}>
             <ReadingPreferenceSwitcher
-              size={readingPreferenceSize}
+              size={SwitchSize.XSmall}
               isIconsOnly
               type={ReadingPreferenceSwitcherType.ContextMenu}
             />

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -7,7 +7,9 @@ import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import styles from './ContextMenu.module.scss';
-import ReadingPreferenceSwitcher from './ReadingPreferenceSwitcher';
+import ReadingPreferenceSwitcher, {
+  ReadingPreferenceSwitcherType,
+} from './ReadingPreferenceSwitcher';
 
 import { SwitchSize } from '@/dls/Switch/Switch';
 import ChevronDownIcon from '@/icons/chevron-down.svg';
@@ -116,7 +118,11 @@ const ContextMenu = () => {
         </div>
         {showReadingPreferenceSwitcher && (
           <div className={styles.halfSection}>
-            <ReadingPreferenceSwitcher size={readingPreferenceSize} isIconsOnly />
+            <ReadingPreferenceSwitcher
+              size={readingPreferenceSize}
+              isIconsOnly
+              type={ReadingPreferenceSwitcherType.ContextMenu}
+            />
           </div>
         )}
         <div className={showReadingPreferenceSwitcher ? styles.section : styles.halfSection}>

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -33,10 +33,7 @@ const ContextMenu = () => {
   const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
   const { t, lang } = useTranslation('common');
   const isSideBarVisible = useSelector(selectNotes, shallowEqual).isVisible;
-  const { isExpanded, showReadingPreferenceSwitcher } = useSelector(
-    selectContextMenu,
-    shallowEqual,
-  );
+  const { isExpanded, showReadingPreferenceSwitcher } = useSelector(selectContextMenu, shallowEqual);
   const isNavbarVisible = useSelector(selectNavbar, shallowEqual).isVisible;
   const { verseKey, chapterId, page, hizb } = useSelector(selectLastReadVerseKey, shallowEqual);
   const chapterData = useMemo(() => {

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -33,7 +33,10 @@ const ContextMenu = () => {
   const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
   const { t, lang } = useTranslation('common');
   const isSideBarVisible = useSelector(selectNotes, shallowEqual).isVisible;
-  const { isExpanded, showReadingPreferenceSwitcher } = useSelector(selectContextMenu, shallowEqual);
+  const { isExpanded, showReadingPreferenceSwitcher } = useSelector(
+    selectContextMenu,
+    shallowEqual,
+  );
   const isNavbarVisible = useSelector(selectNavbar, shallowEqual).isVisible;
   const { verseKey, chapterId, page, hizb } = useSelector(selectLastReadVerseKey, shallowEqual);
   const chapterData = useMemo(() => {
@@ -55,7 +58,7 @@ const ContextMenu = () => {
   }
   const verse = getVerseNumberFromKey(verseKey);
   const progress = getChapterReadingProgress(verse, chapterData.versesCount);
- 
+
   let readingPreferenceSize; // defaults to Normal
   if (showReadingPreferenceSwitcher) {
     if (isMobile()) {
@@ -111,11 +114,11 @@ const ContextMenu = () => {
             </p>
           </div>
         </div>
-        {showReadingPreferenceSwitcher && 
+        {showReadingPreferenceSwitcher && (
           <div className={styles.middleSection}>
             <ReadingPreferenceSwitcher size={readingPreferenceSize} />
           </div>
-        }
+        )}
         <div className={showReadingPreferenceSwitcher ? styles.section : styles.halfSection}>
           <div className={classNames(styles.row)}>
             <p

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -7,7 +7,9 @@ import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import styles from './ContextMenu.module.scss';
+import ReadingPreferenceSwitcher from './ReadingPreferenceSwitcher';
 
+import { SwitchSize } from '@/dls/Switch/Switch';
 import ChevronDownIcon from '@/icons/chevron-down.svg';
 import { selectNavbar } from '@/redux/slices/navbar';
 import { selectContextMenu } from '@/redux/slices/QuranReader/contextMenu';
@@ -31,7 +33,10 @@ const ContextMenu = () => {
   const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
   const { t, lang } = useTranslation('common');
   const isSideBarVisible = useSelector(selectNotes, shallowEqual).isVisible;
-  const { isExpanded } = useSelector(selectContextMenu, shallowEqual);
+  const { isExpanded, showReadingPreferenceSwitcher } = useSelector(
+    selectContextMenu,
+    shallowEqual,
+  );
   const isNavbarVisible = useSelector(selectNavbar, shallowEqual).isVisible;
   const { verseKey, chapterId, page, hizb } = useSelector(selectLastReadVerseKey, shallowEqual);
   const chapterData = useMemo(() => {
@@ -53,6 +58,15 @@ const ContextMenu = () => {
   }
   const verse = getVerseNumberFromKey(verseKey);
   const progress = getChapterReadingProgress(verse, chapterData.versesCount);
+ 
+  let readingPreferenceSize; // defaults to Normal
+  if (showReadingPreferenceSwitcher) {
+    if (isMobile()) {
+      readingPreferenceSize = SwitchSize.Small;
+    } else {
+      readingPreferenceSize = SwitchSize.Normal;
+    }
+  }
 
   return (
     <div
@@ -66,7 +80,7 @@ const ContextMenu = () => {
       style={{ '--progress': `${progress}%` }} // this is to pass the value to css so it can be used to show the progress bar.
     >
       <div className={styles.sectionsContainer}>
-        <div className={styles.section}>
+        <div className={showReadingPreferenceSwitcher ? styles.section : styles.halfSection}>
           <div className={classNames(styles.row)}>
             <p
               className={classNames(styles.bold, styles.alignStart, styles.surahName, {
@@ -100,7 +114,12 @@ const ContextMenu = () => {
             </p>
           </div>
         </div>
-        <div className={classNames(styles.section, styles.leftSection)}>
+        {showReadingPreferenceSwitcher && 
+          <div className={styles.middleSection}>
+            <ReadingPreferenceSwitcher size={readingPreferenceSize} />
+          </div>
+        }
+        <div className={showReadingPreferenceSwitcher ? styles.section : styles.halfSection}>
           <div className={classNames(styles.row)}>
             <p
               className={classNames(styles.alignEnd, {
@@ -108,7 +127,7 @@ const ContextMenu = () => {
               })}
             />
             <p className={classNames(styles.alignEnd)}>
-              {isExpanded && (
+              {isExpanded && !(isMobile() && showReadingPreferenceSwitcher) && (
                 <span className={styles.secondaryInfo}>
                   {/* eslint-disable-next-line i18next/no-literal-string */}
                   {t('juz')} {juzNumber} / {t('hizb')} {localizedHizb} -{' '}

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
@@ -3,30 +3,26 @@
 .container {
   display: flex;
   align-items: center;
+  justify-content: center;
   width: 100%;
-  padding: 0 var(--spacing-large);
 }
 
 .spinner {
   margin-inline-end: var(--spacing-xsmall);
 }
-.iconsCenter {
-  padding-right: 0 !important;
-  margin-inline-start: var(--spacing-xxsmall);
-  margin-inline-end: var(--spacing-xxsmall);
+
+.preferenceTextContainer {
+  padding-left: var(--spacing-xsmall);
 }
 
 .iconContainer {
-  padding-top: 0.4rem;
-
   & > svg {
-    width: var(--spacing-medium);
-    -webkit-margin-end: var(--spacing-large);
-    margin-inline-end: var(--spacing-large);
+    width: var(--spacing-mega);
+    display: block;
+    margin: auto;
   }
 
   @include breakpoints.smallerThanTablet {
-    padding-right: var(--spacing-large);
     & > svg {
       width: var(--spacing-small);
       -webkit-margin-end: 0;

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
@@ -1,8 +1,36 @@
+@use "src/styles/breakpoints";
+
 .container {
   display: flex;
-  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 0 var(--spacing-large);
 }
 
 .spinner {
   margin-inline-end: var(--spacing-xsmall);
+}
+.iconsCenter {
+  padding-right: 0 !important;
+  margin-inline-start: var(--spacing-xxsmall);
+  margin-inline-end: var(--spacing-xxsmall);
+}
+
+.iconContainer {
+  padding-top: 0.4rem;
+
+  & > svg {
+    width: var(--spacing-medium);
+    -webkit-margin-end: var(--spacing-large);
+    margin-inline-end: var(--spacing-large);
+  }
+
+  @include breakpoints.smallerThanTablet {
+    padding-right: var(--spacing-large);
+    & > svg {
+      width: var(--spacing-small);
+      -webkit-margin-end: 0;
+      margin-inline-end: 0;
+    }
+  }
 }

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
@@ -12,19 +12,18 @@
 }
 
 .preferenceTextContainer {
-  padding-left: var(--spacing-xsmall);
+  padding-inline-start: var(--spacing-xsmall);
 }
 
 .iconContainer {
   & > svg {
-    width: var(--spacing-mega);
+    width: 15px;
     display: block;
     margin: auto;
   }
 
   @include breakpoints.smallerThanTablet {
     & > svg {
-      width: var(--spacing-small);
       -webkit-margin-end: 0;
       margin-inline-end: 0;
     }

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceOption.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceOption.tsx
@@ -1,36 +1,35 @@
 import React from 'react';
 
-import useTranslation from 'next-translate/useTranslation';
 import classNames from 'classnames';
+import useTranslation from 'next-translate/useTranslation';
 
 import styles from '@/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss';
 import Spinner from '@/dls/Spinner/Spinner';
-import { ReadingPreference } from 'types/QuranReader';
-import ReaderIcon from '@/icons/collection.svg';
 import BookOpen from '@/icons/book-open.svg';
+import ReaderIcon from '@/icons/collection.svg';
 import { isMobile } from '@/utils/responsive';
+import { ReadingPreference } from 'types/QuranReader';
 
 type Props = {
   readingPreference: ReadingPreference;
   selectedReadingPreference: ReadingPreference;
-  iconsOnly?: boolean;
+  isIconsOnly?: boolean;
   isLoading: boolean;
 };
-
 
 export const readingPreferenceIcons = {
   [ReadingPreference.Reading]: <BookOpen />,
   [ReadingPreference.Translation]: <ReaderIcon />,
-}
+};
 
 const LoadingSwitcher: React.FC<Props> = ({
   readingPreference,
   selectedReadingPreference,
-  iconsOnly = false,
+  isIconsOnly = false,
   isLoading,
 }) => {
   const { t } = useTranslation('common');
-  const showOnlyIconsOnMobile = isMobile() && iconsOnly
+  const showOnlyIconsOnMobile = isMobile() && isIconsOnly;
   return isLoading && readingPreference === selectedReadingPreference ? (
     <div className={styles.container}>
       <span>
@@ -39,18 +38,18 @@ const LoadingSwitcher: React.FC<Props> = ({
       <span>{t(`reading-preference.${readingPreference}`)}</span>
     </div>
   ) : (
-        <div className={styles.container}> 
-          <span
-             className={classNames(styles.iconContainer, showOnlyIconsOnMobile && styles.iconsCenter)}
-          >
-             {readingPreferenceIcons[selectedReadingPreference]}
-          </span>
-          {!showOnlyIconsOnMobile && (
-            <span className={styles.themeNameContainer}>
-                {t(`reading-preference.${selectedReadingPreference}`)}
-            </span>
-          )}
-        </div>
+    <div className={styles.container}>
+      <span
+        className={classNames(styles.iconContainer, showOnlyIconsOnMobile && styles.iconsCenter)}
+      >
+        {readingPreferenceIcons[selectedReadingPreference]}
+      </span>
+      {!showOnlyIconsOnMobile && (
+        <span className={styles.themeNameContainer}>
+          {t(`reading-preference.${selectedReadingPreference}`)}
+        </span>
+      )}
+    </div>
   );
 };
 

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceOption.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceOption.tsx
@@ -1,23 +1,36 @@
 import React from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
+import classNames from 'classnames';
 
 import styles from '@/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss';
 import Spinner from '@/dls/Spinner/Spinner';
 import { ReadingPreference } from 'types/QuranReader';
+import ReaderIcon from '@/icons/collection.svg';
+import BookOpen from '@/icons/book-open.svg';
+import { isMobile } from '@/utils/responsive';
 
 type Props = {
   readingPreference: ReadingPreference;
   selectedReadingPreference: ReadingPreference;
+  iconsOnly?: boolean;
   isLoading: boolean;
 };
+
+
+export const readingPreferenceIcons = {
+  [ReadingPreference.Reading]: <BookOpen />,
+  [ReadingPreference.Translation]: <ReaderIcon />,
+}
 
 const LoadingSwitcher: React.FC<Props> = ({
   readingPreference,
   selectedReadingPreference,
+  iconsOnly = false,
   isLoading,
 }) => {
   const { t } = useTranslation('common');
+  const showOnlyIconsOnMobile = isMobile() && iconsOnly
   return isLoading && readingPreference === selectedReadingPreference ? (
     <div className={styles.container}>
       <span>
@@ -26,7 +39,18 @@ const LoadingSwitcher: React.FC<Props> = ({
       <span>{t(`reading-preference.${readingPreference}`)}</span>
     </div>
   ) : (
-    t(`reading-preference.${selectedReadingPreference}`)
+        <div className={styles.container}> 
+          <span
+             className={classNames(styles.iconContainer, showOnlyIconsOnMobile && styles.iconsCenter)}
+          >
+             {readingPreferenceIcons[selectedReadingPreference]}
+          </span>
+          {!showOnlyIconsOnMobile && (
+            <span className={styles.themeNameContainer}>
+                {t(`reading-preference.${selectedReadingPreference}`)}
+            </span>
+          )}
+        </div>
   );
 };
 

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceOption.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceOption.tsx
@@ -5,9 +5,8 @@ import useTranslation from 'next-translate/useTranslation';
 
 import styles from '@/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss';
 import Spinner from '@/dls/Spinner/Spinner';
-import BookOpen from '@/icons/book-open.svg';
-import ReaderIcon from '@/icons/collection.svg';
-import { isMobile } from '@/utils/responsive';
+import BookIcon from '@/icons/book.svg';
+import ReaderIcon from '@/icons/reader.svg';
 import { ReadingPreference } from 'types/QuranReader';
 
 type Props = {
@@ -18,8 +17,8 @@ type Props = {
 };
 
 export const readingPreferenceIcons = {
-  [ReadingPreference.Reading]: <BookOpen />,
-  [ReadingPreference.Translation]: <ReaderIcon />,
+  [ReadingPreference.Reading]: <ReaderIcon />,
+  [ReadingPreference.Translation]: <BookIcon />,
 };
 
 const LoadingSwitcher: React.FC<Props> = ({
@@ -29,23 +28,24 @@ const LoadingSwitcher: React.FC<Props> = ({
   isLoading,
 }) => {
   const { t } = useTranslation('common');
-  const showOnlyIconsOnMobile = isMobile() && isIconsOnly;
   return isLoading && readingPreference === selectedReadingPreference ? (
     <div className={styles.container}>
       <span>
         <Spinner className={styles.spinner} />
       </span>
-      <span>{t(`reading-preference.${readingPreference}`)}</span>
+      {!isIconsOnly && (
+        <span className={styles.preferenceTextContainer}>
+          {t(`reading-preference.${selectedReadingPreference}`)}
+        </span>
+      )}
     </div>
   ) : (
     <div className={styles.container}>
-      <span
-        className={classNames(styles.iconContainer, showOnlyIconsOnMobile && styles.iconsCenter)}
-      >
+      <span className={classNames(styles.iconContainer, isIconsOnly && styles.iconsCenter)}>
         {readingPreferenceIcons[selectedReadingPreference]}
       </span>
-      {!showOnlyIconsOnMobile && (
-        <span className={styles.themeNameContainer}>
+      {!isIconsOnly && (
+        <span className={styles.preferenceTextContainer}>
           {t(`reading-preference.${selectedReadingPreference}`)}
         </span>
       )}

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceSwitcher.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceSwitcher.module.scss
@@ -1,3 +1,5 @@
+@use "src/styles/breakpoints";
+
 $readingPreferenceMaxWidth: calc(20 * var(--spacing-large));
 .container {
   max-width: $readingPreferenceMaxWidth;
@@ -9,4 +11,23 @@ $readingPreferenceMaxWidth: calc(20 * var(--spacing-large));
   padding-block-end: 0;
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
+
+  button {
+    max-height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @include breakpoints.smallerThanTablet {
+      max-height: 25px;
+
+      // To ensure active buttons aligns correctly
+      &:nth-child(1) {
+        margin-left: -7px
+      }
+      &:nth-child(2) {
+        margin-right: -7px;
+      }
+    }
+  }
 }

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceSwitcher.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceSwitcher.module.scss
@@ -1,39 +1,20 @@
-@use "src/styles/breakpoints";
-
 $readingPreferenceMaxWidth: calc(20 * var(--spacing-large));
+$contextMenuReadingPreferenceMaxWidth: calc(10 * var(--spacing-large));
 .container {
   max-width: $readingPreferenceMaxWidth;
-  margin-block-start: var(--spacing-small);
-  margin-block-end: var(--spacing-xxsmall);
   margin-inline-start: auto;
   margin-inline-end: auto;
   padding-block-start: 0;
   padding-block-end: 0;
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
+}
 
-  button {
-    max-height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    
-    // Open to suggestions to implement this in a better way
-    &:nth-child(1) {
-      margin-right: var(--spacing-small);
-    }
-    &:nth-child(2) {
-      margin-left: var(--spacing-micro);
-    }
-    
-    @include breakpoints.smallerThanTablet {
-      max-height: 25px;
-      &:nth-child(1) {
-        margin-right: var(--spacing-micro);
-      }
-      &:nth-child(2) {
-        margin-left: var(--spacing-micro);
-      }
-    }
-  }
+.surahHeaderContainer {
+  margin-block-start: var(--spacing-small);
+  margin-block-end: var(--spacing-xxsmall);
+}
+
+.contextMenuContainer {
+  max-width: $contextMenuReadingPreferenceMaxWidth;
 }

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceSwitcher.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreferenceSwitcher.module.scss
@@ -17,16 +17,22 @@ $readingPreferenceMaxWidth: calc(20 * var(--spacing-large));
     display: flex;
     align-items: center;
     justify-content: center;
-
+    
+    // Open to suggestions to implement this in a better way
+    &:nth-child(1) {
+      margin-right: var(--spacing-small);
+    }
+    &:nth-child(2) {
+      margin-left: var(--spacing-micro);
+    }
+    
     @include breakpoints.smallerThanTablet {
       max-height: 25px;
-
-      // To ensure active buttons aligns correctly
       &:nth-child(1) {
-        margin-left: -7px
+        margin-right: var(--spacing-micro);
       }
       &:nth-child(2) {
-        margin-right: -7px;
+        margin-left: var(--spacing-micro);
       }
     }
   }

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -15,12 +15,22 @@ import { logValueChange } from '@/utils/eventLogger';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
 import { ReadingPreference } from 'types/QuranReader';
 
+export enum ReadingPreferenceSwitcherType {
+  SurahHeader = 'surah_header',
+  ContextMenu = 'context_menu',
+}
+
 interface Props {
   size?: SwitchSize;
   isIconsOnly?: boolean;
+  type: ReadingPreferenceSwitcherType;
 }
 
-const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, isIconsOnly = false }) => {
+const ReadingPreferenceSwitcher: React.FC<Props> = ({
+  size,
+  isIconsOnly = false,
+  type = ReadingPreferenceSwitcherType.SurahHeader,
+}) => {
   const readingPreferences = useSelector(selectReadingPreferences);
   const lastReadVerseKey = useSelector(selectLastReadVerseKey);
   const lastReadVerse = lastReadVerseKey.verseKey?.split(':')[1];
@@ -57,14 +67,17 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, isIconsOnly = false 
   ];
 
   const onViewSwitched = (view: ReadingPreference) => {
-    logValueChange('reading_preference', readingPreference, view);
+    logValueChange(`${type}.reading_preference`, readingPreference, view);
 
     const newQueryParams = { ...router.query };
 
     // Track `startingVerse` once we're past the start of the page so we can
     // continue from the same ayah when switching views. Without the > 1 check,
     // switching views at the start of the page causes unnecessary scrolls
-    if (parseInt(lastReadVerse, 10) > 1) {
+
+    if (type === ReadingPreferenceSwitcherType.SurahHeader) {
+      delete newQueryParams.startingVerse;
+    } else if (parseInt(lastReadVerse, 10) > 1) {
       newQueryParams.startingVerse = lastReadVerse;
     }
 

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import LoadingSwitcher from './ReadingPreferenceOption';
 import styles from './ReadingPreferenceSwitcher.module.scss';
 
-import Switch from '@/dls/Switch/Switch';
+import Switch, { SwitchSize } from '@/dls/Switch/Switch';
 import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
 import { selectLastReadVerseKey } from "@/redux/slices/QuranReader/readingTracker";
 import {
@@ -15,7 +15,11 @@ import { logValueChange } from '@/utils/eventLogger';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
 import { ReadingPreference } from 'types/QuranReader';
 
-const ReadingPreferenceSwitcher = ({ size }) => {
+interface Props {
+  size?: SwitchSize;
+}
+
+const ReadingPreferenceSwitcher: React.FC<Props> = ({ size }) => {
   const readingPreferences = useSelector(selectReadingPreferences);
   const lastReadVerseKey = useSelector(selectLastReadVerseKey);
   const lastReadVerse = lastReadVerseKey.verseKey?.split(':')[1];

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -6,11 +6,11 @@ import styles from './ReadingPreferenceSwitcher.module.scss';
 
 import Switch, { SwitchSize } from '@/dls/Switch/Switch';
 import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
-import { selectLastReadVerseKey } from "@/redux/slices/QuranReader/readingTracker";
 import {
   selectReadingPreferences,
   setReadingPreference,
 } from '@/redux/slices/QuranReader/readingPreferences';
+import { selectLastReadVerseKey } from '@/redux/slices/QuranReader/readingTracker';
 import { logValueChange } from '@/utils/eventLogger';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
 import { ReadingPreference } from 'types/QuranReader';

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
@@ -98,7 +99,12 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({
   };
 
   return (
-    <div className={styles.container}>
+    <div
+      className={classNames(styles.container, {
+        [styles.surahHeaderContainer]: type === ReadingPreferenceSwitcherType.SurahHeader,
+        [styles.contextMenuContainer]: type === ReadingPreferenceSwitcherType.ContextMenu,
+      })}
+    >
       <Switch
         items={readingPreferencesOptions}
         selected={readingPreference}

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -6,6 +6,7 @@ import styles from './ReadingPreferenceSwitcher.module.scss';
 
 import Switch from '@/dls/Switch/Switch';
 import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
+import { selectLastReadVerseKey } from "@/redux/slices/QuranReader/readingTracker";
 import {
   selectReadingPreferences,
   setReadingPreference,
@@ -14,8 +15,10 @@ import { logValueChange } from '@/utils/eventLogger';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
 import { ReadingPreference } from 'types/QuranReader';
 
-const ReadingPreferenceSwitcher = () => {
+const ReadingPreferenceSwitcher = ({ size }) => {
   const readingPreferences = useSelector(selectReadingPreferences);
+  const lastReadVerseKey = useSelector(selectLastReadVerseKey);
+  const lastReadVerse = lastReadVerseKey.verseKey?.split(':')[1];
   const { readingPreference } = readingPreferences;
   const {
     actions: { onSettingsChange },
@@ -50,8 +53,7 @@ const ReadingPreferenceSwitcher = () => {
     logValueChange('reading_preference', readingPreference, view);
 
     // drop `startingVerse` from query params
-    const newQueryParams = { ...router.query };
-    delete newQueryParams.startingVerse;
+    const newQueryParams = { ...router.query, startingVerse: lastReadVerse };
     const newUrlObject = {
       pathname: router.pathname,
       query: newQueryParams,
@@ -74,6 +76,7 @@ const ReadingPreferenceSwitcher = () => {
         items={readingPreferencesOptions}
         selected={readingPreference}
         onSelect={onViewSwitched}
+        size={size}
       />
     </div>
   );

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -17,10 +17,10 @@ import { ReadingPreference } from 'types/QuranReader';
 
 interface Props {
   size?: SwitchSize;
-  iconsOnly?: boolean;
+  isIconsOnly?: boolean;
 }
 
-const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, iconsOnly = false }) => {
+const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, isIconsOnly = false }) => {
   const readingPreferences = useSelector(selectReadingPreferences);
   const lastReadVerseKey = useSelector(selectLastReadVerseKey);
   const lastReadVerse = lastReadVerseKey.verseKey?.split(':')[1];
@@ -38,7 +38,7 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, iconsOnly = false })
           readingPreference={readingPreference}
           selectedReadingPreference={ReadingPreference.Translation}
           isLoading={isLoading}
-          iconsOnly={iconsOnly}
+          isIconsOnly={isIconsOnly}
         />
       ),
       value: ReadingPreference.Translation,
@@ -48,7 +48,8 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, iconsOnly = false })
         <LoadingSwitcher
           readingPreference={readingPreference}
           selectedReadingPreference={ReadingPreference.Reading}
-          iconsOnly={iconsOnly}
+          isLoading={isLoading}
+          isIconsOnly={isIconsOnly}
         />
       ),
       value: ReadingPreference.Reading,
@@ -60,11 +61,11 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, iconsOnly = false })
 
     const newQueryParams = { ...router.query };
 
-    // Track `startingVerse` once we're past the start of the page so we can 
+    // Track `startingVerse` once we're past the start of the page so we can
     // continue from the same ayah when switching views. Without the > 1 check,
     // switching views at the start of the page causes unnecessary scrolls
-    if (parseInt(lastReadVerse) > 1) {
-      newQueryParams.startingVerse = lastReadVerse 
+    if (parseInt(lastReadVerse, 10) > 1) {
+      newQueryParams.startingVerse = lastReadVerse;
     }
 
     const newUrlObject = {

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -68,7 +68,7 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({
   ];
 
   const onViewSwitched = (view: ReadingPreference) => {
-    logValueChange(`${type}.reading_preference`, readingPreference, view);
+    logValueChange(`${type}_reading_preference`, readingPreference, view);
 
     const newQueryParams = { ...router.query };
 

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -17,9 +17,10 @@ import { ReadingPreference } from 'types/QuranReader';
 
 interface Props {
   size?: SwitchSize;
+  iconsOnly?: boolean;
 }
 
-const ReadingPreferenceSwitcher: React.FC<Props> = ({ size }) => {
+const ReadingPreferenceSwitcher: React.FC<Props> = ({ size, iconsOnly = false }) => {
   const readingPreferences = useSelector(selectReadingPreferences);
   const lastReadVerseKey = useSelector(selectLastReadVerseKey);
   const lastReadVerse = lastReadVerseKey.verseKey?.split(':')[1];
@@ -37,6 +38,7 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size }) => {
           readingPreference={readingPreference}
           selectedReadingPreference={ReadingPreference.Translation}
           isLoading={isLoading}
+          iconsOnly={iconsOnly}
         />
       ),
       value: ReadingPreference.Translation,
@@ -46,7 +48,7 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size }) => {
         <LoadingSwitcher
           readingPreference={readingPreference}
           selectedReadingPreference={ReadingPreference.Reading}
-          isLoading={isLoading}
+          iconsOnly={iconsOnly}
         />
       ),
       value: ReadingPreference.Reading,
@@ -56,8 +58,15 @@ const ReadingPreferenceSwitcher: React.FC<Props> = ({ size }) => {
   const onViewSwitched = (view: ReadingPreference) => {
     logValueChange('reading_preference', readingPreference, view);
 
-    // drop `startingVerse` from query params
-    const newQueryParams = { ...router.query, startingVerse: lastReadVerse };
+    const newQueryParams = { ...router.query };
+
+    // Track `startingVerse` once we're past the start of the page so we can 
+    // continue from the same ayah when switching views. Without the > 1 check,
+    // switching views at the start of the page causes unnecessary scrolls
+    if (parseInt(lastReadVerse) > 1) {
+      newQueryParams.startingVerse = lastReadVerse 
+    }
+
     const newUrlObject = {
       pathname: router.pathname,
       query: newQueryParams,

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/index.tsx
@@ -23,7 +23,7 @@ export enum ReadingPreferenceSwitcherType {
 interface Props {
   size?: SwitchSize;
   isIconsOnly?: boolean;
-  type: ReadingPreferenceSwitcherType;
+  type?: ReadingPreferenceSwitcherType;
 }
 
 const ReadingPreferenceSwitcher: React.FC<Props> = ({

--- a/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss
+++ b/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss
@@ -25,7 +25,7 @@
   position: fixed;
   inset-block-start: 0;
   inset-inline-start: 0;
-  padding-block-start: calc(1.5 * var(--spacing-mega));
+  padding-block-start: calc(2.5 * var(--spacing-mega));
   background-color: var(--color-background-elevated);
   overflow-x: hidden;
   z-index: var(--z-index-default);
@@ -137,7 +137,7 @@
 }
 
 .spaceOnTop {
-  padding-block-start: calc(3.5 * var(--spacing-mega));
+  padding-block-start: calc(4.5 * var(--spacing-mega));
 }
 
 .chapterNumber {

--- a/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss
+++ b/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss
@@ -25,7 +25,7 @@
   position: fixed;
   inset-block-start: 0;
   inset-inline-start: 0;
-  padding-block-start: calc(2.5 * var(--spacing-mega));
+  padding-block-start: calc(1.5 * var(--spacing-mega));
   background-color: var(--color-background-elevated);
   overflow-x: hidden;
   z-index: var(--z-index-default);
@@ -137,7 +137,7 @@
 }
 
 .spaceOnTop {
-  padding-block-start: calc(4.5 * var(--spacing-mega));
+  padding-block-start: calc(3.5 * var(--spacing-mega));
 }
 
 .chapterNumber {

--- a/src/components/dls/Switch/Switch.module.scss
+++ b/src/components/dls/Switch/Switch.module.scss
@@ -17,6 +17,13 @@ $separatorOpacity: 0.2;
   ); // use grid to prevent layout shift when `font-family: bold` on item selected https://css-tricks.com/bold-on-hover-without-the-layout-shift/
 }
 
+.xSmallContainer {
+  padding-block-start: 0;
+  padding-block-end: 0;
+  padding-inline-start: 0;
+  padding-inline-end: 0;
+}
+
 .item {
   cursor: pointer;
   color: var(--color-text-default);
@@ -93,4 +100,11 @@ $background-container: calc(0.8 * var(--spacing-xxsmall));
   padding-block-end: var(--spacing-xxsmall);
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
+}
+
+.itemXSmall {
+  padding-block-start: var(--spacing-micro);
+  padding-block-end: var(--spacing-micro);
+  padding-inline-start: var(--spacing-micro);
+  padding-inline-end: var(--spacing-micro);
 }

--- a/src/components/dls/Switch/Switch.tsx
+++ b/src/components/dls/Switch/Switch.tsx
@@ -14,6 +14,7 @@ type Item = {
   disabled?: boolean;
 };
 export enum SwitchSize {
+  XSmall = 'xsmall',
   Small = 'small',
   Normal = 'normal',
   Large = 'large',
@@ -29,7 +30,11 @@ const Switch = ({ items, onSelect, selected, size = SwitchSize.Normal }: SwitchP
   const selectedIndex = items.findIndex((item) => item.value === selected);
   const { locale } = useRouter();
   return (
-    <div className={styles.container}>
+    <div
+      className={classNames(styles.container, {
+        [styles.xSmallContainer]: size === SwitchSize.XSmall,
+      })}
+    >
       {items.map((item) => (
         <button
           disabled={item.disabled}
@@ -38,6 +43,7 @@ const Switch = ({ items, onSelect, selected, size = SwitchSize.Normal }: SwitchP
             [styles.itemLarge]: size === SwitchSize.Large,
             [styles.itemNormal]: size === SwitchSize.Normal,
             [styles.itemSmall]: size === SwitchSize.Small,
+            [styles.itemXSmall]: size === SwitchSize.XSmall,
           })}
           key={item.value}
           onClick={() => onSelect(item.value)}

--- a/src/redux/slices/QuranReader/contextMenu.ts
+++ b/src/redux/slices/QuranReader/contextMenu.ts
@@ -5,6 +5,7 @@ import SliceName from '@/redux/types/SliceName';
 
 export type ContextMenu = {
   isExpanded: boolean;
+  showReadingPreferenceSwitcher: boolean;
 };
 
 const initialState: ContextMenu = { isExpanded: true };
@@ -17,10 +18,14 @@ export const contextMenuSlice = createSlice({
       ...state,
       isExpanded: action.payload,
     }),
+    setShowReadingPreferenceSwitcher: (state: ContextMenu, action: PayloadAction<boolean>) => ({
+      ...state,
+      showReadingPreferenceSwitcher: action.payload,
+    })
   },
 });
 
-export const { setIsExpanded } = contextMenuSlice.actions;
+export const { setIsExpanded, setShowReadingPreferenceSwitcher } = contextMenuSlice.actions;
 
 export const selectContextMenu = (state: RootState) => state.contextMenu;
 

--- a/src/redux/slices/QuranReader/contextMenu.ts
+++ b/src/redux/slices/QuranReader/contextMenu.ts
@@ -8,7 +8,7 @@ export type ContextMenu = {
   showReadingPreferenceSwitcher: boolean;
 };
 
-const initialState: ContextMenu = { isExpanded: true };
+const initialState: ContextMenu = { isExpanded: true, showReadingPreferenceSwitcher: false };
 
 export const contextMenuSlice = createSlice({
   name: SliceName.CONTEXT_MENU,

--- a/src/redux/slices/QuranReader/contextMenu.ts
+++ b/src/redux/slices/QuranReader/contextMenu.ts
@@ -21,7 +21,7 @@ export const contextMenuSlice = createSlice({
     setShowReadingPreferenceSwitcher: (state: ContextMenu, action: PayloadAction<boolean>) => ({
       ...state,
       showReadingPreferenceSwitcher: action.payload,
-    })
+    }),
   },
 });
 


### PR DESCRIPTION
### Summary
Attempt to fix #1924 . Add reading preference switch to header.

- Show preference toggle in header if the default one disappears
- Remember the verse when switching
- Adjusts sizing for desktop / mobile devices
- Hides Juz / Hizb info on the header on mobile once user has scrolled past the beginning of the page (noticed otherwise the header occupies more than 1/3 of the screen

### Test Plan


### Screenshots

| Before | After |
| ------ | ------ |
| ![Before - desktop](https://github.com/quran/quran.com-frontend-next/assets/32406853/fbc91b27-6d1c-4e17-a50e-34bc9a12506a) | ![After - desktop](https://github.com/quran/quran.com-frontend-next/assets/32406853/f1c57dbb-8f1f-415d-a83c-5ae18aebee48) |
| ![Before - mobile](https://github.com/quran/quran.com-frontend-next/assets/32406853/29071169-7211-4a26-8cd1-429241f31e59) | ![After - mobile](https://github.com/quran/quran.com-frontend-next/assets/32406853/c63ccb82-fffb-4cf9-924a-41f0c0fa7288) |