### PR TITLE
Fix Quran reader when switching languages

### DIFF
--- a/src/components/QuranReader/ReadingView/PageContainer.tsx
+++ b/src/components/QuranReader/ReadingView/PageContainer.tsx
@@ -1,7 +1,5 @@
-import React, { useEffect, useMemo, useContext } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
-import { useSelector as useXstateSelector } from '@xstate/react';
-import { useSelector } from 'react-redux';
 import useSWRImmutable from 'swr/immutable';
 
 import { getPageNumberByPageIndex } from '../utils/page';
@@ -10,10 +8,8 @@ import Page from './Page';
 import ReadingViewSkeleton from './ReadingViewSkeleton';
 
 import { getReaderViewRequestKey, verseFetcher } from '@/components/QuranReader/api';
-import { selectIsUsingDefaultWordByWordLocale } from '@/redux/slices/QuranReader/readingPreferences';
+import useIsUsingDefaultSettings from '@/hooks/useIsUsingDefaultSettings';
 import QuranReaderStyles from '@/redux/types/QuranReaderStyles';
-import { selectIsUsingDefaultReciter } from 'src/xstate/actors/audioPlayer/selectors';
-import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
 import { VersesResponse } from 'types/ApiResponses';
 import LookupRecord from 'types/LookupRecord';
 import Verse from 'types/Verse';
@@ -27,7 +23,6 @@ type Props = {
   pageIndex: number;
   setMushafPageToVersesMap: (data: Record<number, Verse[]>) => void;
   initialData: VersesResponse;
-  isUsingDefaultFont: boolean;
 };
 
 const getPageVersesRange = (
@@ -75,7 +70,6 @@ const PageContainer: React.FC<Props> = ({
   pageIndex,
   setMushafPageToVersesMap,
   initialData,
-  isUsingDefaultFont,
 }: Props): JSX.Element => {
   const pageNumber = useMemo(
     () => getPageNumberByPageIndex(pageIndex, pagesVersesRange),
@@ -86,16 +80,8 @@ const PageContainer: React.FC<Props> = ({
     [initialData.verses, pageIndex, pageNumber],
   );
 
-  const audioService = useContext(AudioPlayerMachineContext);
-  const isUsingDefaultReciter = useXstateSelector(audioService, (state) =>
-    selectIsUsingDefaultReciter(state),
-  );
-  const isUsingDefaultWordByWordLocale = useSelector(selectIsUsingDefaultWordByWordLocale);
-  const shouldUseInitialData =
-    pageIndex === 0 &&
-    isUsingDefaultFont &&
-    isUsingDefaultReciter &&
-    isUsingDefaultWordByWordLocale;
+  const isUsingDefaultSettings = useIsUsingDefaultSettings();
+  const shouldUseInitialData = pageIndex === 0 && isUsingDefaultSettings;
   const { data: verses, isValidating } = useSWRImmutable(
     getReaderViewRequestKey({
       pageNumber,

--- a/src/components/QuranReader/ReadingView/index.tsx
+++ b/src/components/QuranReader/ReadingView/index.tsx
@@ -171,7 +171,6 @@ const ReadingView = ({
 
     return (
       <PageContainer
-        isUsingDefaultFont={isUsingDefaultFont}
         pagesVersesRange={pagesVersesRange}
         quranReaderStyles={quranReaderStyles}
         reciterId={reciterId}

--- a/src/hooks/useIsUsingDefaultSettings.tsx
+++ b/src/hooks/useIsUsingDefaultSettings.tsx
@@ -15,7 +15,7 @@ import { areArraysEqual } from '@/utils/array';
 import { selectIsUsingDefaultReciter } from '@/xstate/actors/audioPlayer/selectors';
 import { AudioPlayerMachineContext } from '@/xstate/AudioPlayerMachineContext';
 
-const useIsUsingDefaultSettings = ({ translations }: { translations?: number[] }) => {
+const useIsUsingDefaultSettings = ({ translations }: { translations?: number[] } = {}) => {
   const { lang } = useTranslation();
   const audioService = useContext(AudioPlayerMachineContext);
   const isUsingDefaultReciter = useXstateSelector(audioService, (state) =>
@@ -39,16 +39,21 @@ const useIsUsingDefaultSettings = ({ translations }: { translations?: number[] }
     defaultState.quranReaderStyles.mushafLines === mushafLines;
 
   const areTranslationsEqual = useMemo(() => {
+    if (!translations) {
+      return false;
+    }
+
     return areArraysEqual(defaultState.translations.selectedTranslations, translations);
   }, [translations, defaultState.translations.selectedTranslations]);
 
-  return (
-    isUsingDefaultFont &&
-    isUsingDefaultReciter &&
-    isUsingDefaultWordByWordLocale &&
-    isUsingDefaultTranslations &&
-    areTranslationsEqual
-  );
+  const isUsingDefaultSettings =
+    isUsingDefaultFont && isUsingDefaultReciter && isUsingDefaultWordByWordLocale;
+
+  if (translations) {
+    return isUsingDefaultSettings && isUsingDefaultTranslations && areTranslationsEqual;
+  }
+
+  return isUsingDefaultSettings;
 };
 
 export default useIsUsingDefaultSettings;

--- a/src/hooks/useIsUsingDefaultSettings.tsx
+++ b/src/hooks/useIsUsingDefaultSettings.tsx
@@ -1,0 +1,54 @@
+import { useContext, useMemo } from 'react';
+
+import { useSelector as useXstateSelector } from '@xstate/react';
+import useTranslation from 'next-translate/useTranslation';
+import { useSelector } from 'react-redux';
+
+import {
+  getQuranReaderStylesInitialState,
+  getTranslationsInitialState,
+} from '@/redux/defaultSettings/util';
+import { selectIsUsingDefaultWordByWordLocale } from '@/redux/slices/QuranReader/readingPreferences';
+import { selectQuranFont, selectQuranMushafLines } from '@/redux/slices/QuranReader/styles';
+import { selectIsUsingDefaultTranslations } from '@/redux/slices/QuranReader/translations';
+import { areArraysEqual } from '@/utils/array';
+import { selectIsUsingDefaultReciter } from '@/xstate/actors/audioPlayer/selectors';
+import { AudioPlayerMachineContext } from '@/xstate/AudioPlayerMachineContext';
+
+const useIsUsingDefaultSettings = ({ translations }: { translations?: number[] }) => {
+  const { lang } = useTranslation();
+  const audioService = useContext(AudioPlayerMachineContext);
+  const isUsingDefaultReciter = useXstateSelector(audioService, (state) =>
+    selectIsUsingDefaultReciter(state),
+  );
+  const isUsingDefaultWordByWordLocale = useSelector(selectIsUsingDefaultWordByWordLocale);
+  const isUsingDefaultTranslations = useSelector(selectIsUsingDefaultTranslations);
+
+  const quranFont = useSelector(selectQuranFont);
+  const mushafLines = useSelector(selectQuranMushafLines);
+
+  const defaultState = useMemo(() => {
+    return {
+      quranReaderStyles: getQuranReaderStylesInitialState(lang),
+      translations: getTranslationsInitialState(lang),
+    };
+  }, [lang]);
+
+  const isUsingDefaultFont =
+    defaultState.quranReaderStyles.quranFont === quranFont &&
+    defaultState.quranReaderStyles.mushafLines === mushafLines;
+
+  const areTranslationsEqual = useMemo(() => {
+    return areArraysEqual(defaultState.translations.selectedTranslations, translations);
+  }, [translations, defaultState.translations.selectedTranslations]);
+
+  return (
+    isUsingDefaultFont &&
+    isUsingDefaultReciter &&
+    isUsingDefaultWordByWordLocale &&
+    isUsingDefaultTranslations &&
+    areTranslationsEqual
+  );
+};
+
+export default useIsUsingDefaultSettings;

--- a/src/redux/slices/QuranReader/styles.ts
+++ b/src/redux/slices/QuranReader/styles.ts
@@ -110,11 +110,14 @@ export const quranReaderStylesSlice = createSlice({
         PreferenceGroup.QURAN_READER_STYLES
       ] as QuranReaderStyles;
       if (remotePreferences) {
-        const { quranFont: defaultQuranFont } = getQuranReaderStylesInitialState(locale);
+        const { quranFont: defaultQuranFont, mushafLines: defaultMushafLines } =
+          getQuranReaderStylesInitialState(locale);
         return {
           ...state,
           ...remotePreferences,
-          isUsingDefaultFont: defaultQuranFont === remotePreferences.quranFont,
+          isUsingDefaultFont:
+            defaultQuranFont === remotePreferences.quranFont &&
+            defaultMushafLines === remotePreferences.mushafLines,
         };
       }
       return state;


### PR DESCRIPTION
### Summary

This PR fixes #1960 along with other reported issues on [feedback.quran.com](https://feedback.quran.com/bugs/p/the-quranic-text-appears-as-gibberish).

This issue is caused due to how we detect if the user is using the default settings for their language in order to use the first 9 verses passed by the server (`initialData`). Currently, `isUsingDefaultFont` for an example is a piece of state and not a computed property. This resulted in a wrong value when the user is defaulted to a language (i.e. english), and then changes to another language with different settings (i.e. bengali). 

### Solution

This PR adds a new hook (`useIsUsingDefaultSettings`) that manually checks is default font settings match the current settings.