### PR TITLE
Select first Tafsir on language change

### DIFF
--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -33,7 +33,11 @@ import {
 } from '@/utils/eventLogger';
 import { getLanguageDataById } from '@/utils/locale';
 import { fakeNavigate, getVerseSelectedTafsirNavigationUrl } from '@/utils/navigation';
-import { getSelectedTafsirLanguage, getTafsirsLanguageOptions } from '@/utils/tafsir';
+import {
+  getFirstTafsirOfLanguage,
+  getSelectedTafsirLanguage,
+  getTafsirsLanguageOptions,
+} from '@/utils/tafsir';
 import {
   getVerseNumberFromKey,
   getFirstAndLastVerseKeys,
@@ -151,6 +155,26 @@ const TafsirBody = ({
     ? getTafsirsLanguageOptions(tafsirSelectionList.tafsirs)
     : [];
 
+  /**
+   * Handle when the language of the Tafsir is changed. When it does,
+   * we auto-select the first Tafsir of the new language based on the
+   * response from BE.
+   *
+   * @param {string} newLang
+   */
+  const onLanguageSelected = (newLang: string) => {
+    logValueChange('tafsir_locale', selectedLanguage, newLang);
+    setSelectedLanguage(newLang);
+
+    if (tafsirSelectionList) {
+      const firstTafsirOfLanguage = getFirstTafsirOfLanguage(tafsirSelectionList, newLang);
+      if (firstTafsirOfLanguage) {
+        const { id, slug } = firstTafsirOfLanguage;
+        onTafsirSelected(id, slug);
+      }
+    }
+  };
+
   const renderTafsir = useCallback(
     (data: TafsirContentResponse) => {
       if (!data || !data.tafsir) return <TafsirSkeleton />;
@@ -230,35 +254,35 @@ const TafsirBody = ({
     [chaptersData, lang, scrollToTop, selectedChapterId, selectedTafsirIdOrSlug, t],
   );
 
+  const onChapterIdChange = (newChapterId) => {
+    logItemSelectionChange('tafsir_chapter_id', newChapterId);
+    fakeNavigate(
+      getVerseSelectedTafsirNavigationUrl(Number(newChapterId), Number(1), selectedTafsirIdOrSlug),
+      lang,
+    );
+    setSelectedChapterId(newChapterId.toString());
+    setSelectedVerseNumber('1'); // reset verse number to 1 every time chapter changes
+  };
+
+  const onVerseNumberChange = (newVerseNumber) => {
+    logItemSelectionChange('tafsir_verse_number', newVerseNumber);
+    setSelectedVerseNumber(newVerseNumber);
+    fakeNavigate(
+      getVerseSelectedTafsirNavigationUrl(
+        Number(selectedChapterId),
+        Number(newVerseNumber),
+        selectedTafsirIdOrSlug,
+      ),
+      lang,
+    );
+  };
+
   const surahAndAyahSelection = (
     <SurahAndAyahSelection
       selectedChapterId={selectedChapterId}
       selectedVerseNumber={selectedVerseNumber}
-      onChapterIdChange={(newChapterId) => {
-        logItemSelectionChange('tafsir_chapter_id', newChapterId);
-        fakeNavigate(
-          getVerseSelectedTafsirNavigationUrl(
-            Number(newChapterId),
-            Number(1),
-            selectedTafsirIdOrSlug,
-          ),
-          lang,
-        );
-        setSelectedChapterId(newChapterId.toString());
-        setSelectedVerseNumber('1'); // reset verse number to 1 every time chapter changes
-      }}
-      onVerseNumberChange={(newVerseNumber) => {
-        logItemSelectionChange('tafsir_verse_number', newVerseNumber);
-        setSelectedVerseNumber(newVerseNumber);
-        fakeNavigate(
-          getVerseSelectedTafsirNavigationUrl(
-            Number(selectedChapterId),
-            Number(newVerseNumber),
-            selectedTafsirIdOrSlug,
-          ),
-          lang,
-        );
-      }}
+      onChapterIdChange={onChapterIdChange}
+      onVerseNumberChange={onVerseNumberChange}
     />
   );
 
@@ -267,10 +291,7 @@ const TafsirBody = ({
       selectedTafsirIdOrSlug={selectedTafsirIdOrSlug}
       selectedLanguage={selectedLanguage}
       onTafsirSelected={onTafsirSelected}
-      onSelectLanguage={(newLang) => {
-        logValueChange('tafsir_locale', selectedLanguage, newLang);
-        setSelectedLanguage(newLang);
-      }}
+      onSelectLanguage={onLanguageSelected}
       languageOptions={languageOptions}
       data={tafsirSelectionList}
       isLoading={isLoading}

--- a/src/utils/tafsir.ts
+++ b/src/utils/tafsir.ts
@@ -1,5 +1,6 @@
 import uniq from 'lodash/uniq';
 
+import TafsirInfo from '@/types/TafsirInfo';
 import { TafsirsResponse } from 'types/ApiResponses';
 import Tafsir from 'types/Tafsir';
 
@@ -19,6 +20,21 @@ export const getSelectedTafsirLanguage = (
       tafsir.slug === selectedTafsirIdOrSlug || tafsir.id === Number(selectedTafsirIdOrSlug),
   );
   return selectedTafsir?.languageName;
+};
+
+/**
+ * Get the first Tafsir of a language.
+ *
+ * @param {TafsirsResponse} tafsirListData
+ * @param {string} language
+ * @returns {TafsirInfo}
+ */
+export const getFirstTafsirOfLanguage = (
+  tafsirListData: TafsirsResponse,
+  language: string,
+): TafsirInfo => {
+  const selectedTafsir = tafsirListData?.tafsirs.find((tafsir) => tafsir.languageName === language);
+  return selectedTafsir;
 };
 
 /**


### PR DESCRIPTION
### Summary
This PR auto-selects first Tafsir when the language changes to solve the issue when the same Tafsir name exists in the old and new languages and old Tafisr still shows.


### Screenshots

| Before | After |
| ------ | ------ |
| ![after](https://github.com/quran/quran.com-frontend-next/assets/15169499/47ba9487-da34-4d1d-98cc-f5a22f885244) | ![before](https://github.com/quran/quran.com-frontend-next/assets/15169499/c4114dbb-a8d7-4a5b-bb54-405e4be69377) |