### PR TITLE
Made Al-Nur spelling consistent (Al-Noor => An-Nur)

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -172,7 +172,7 @@
     "text_uthmani": "Uthmani"
   },
   "footer": {
-    "description": "Quran.com is a Sadaqah Jariyah. We hope to make it easy for everyone to read, study, and learn The Noble Quran. The Noble Quran has many names including Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr, and Al-Noor.",
+    "description": "Quran.com is a Sadaqah Jariyah. We hope to make it easy for everyone to read, study, and learn The Noble Quran. The Noble Quran has many names including Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr, and An-Nur.",
     "rights": "All Rights Reserved",
     "title": "Read, study, and learn The Noble Quran."
   },

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "Uthmani"
     },
     "footer": {
-        "description": "Quran.com est une Sadaqah Jariyah. Nous espérons faciliter la lecture, l'étude et l'apprentissage du Noble Coran pour tous. Le Noble Coran a de nombreux noms dont Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr et Al-Noor.",
+        "description": "Quran.com est une Sadaqah Jariyah. Nous espérons faciliter la lecture, l'étude et l'apprentissage du Noble Coran pour tous. Le Noble Coran a de nombreux noms dont Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr et Al-Nur.",
         "rights": "Tous les droits sont réservés",
         "title": "Lisez, étudiez et apprenez Le Noble Coran."
     },

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "Uthmani"
     },
     "footer": {
-        "description": "Quran.com è un Sadaqah Jariyah. Speriamo di rendere facile per tutti la lettura, lo studio e l'apprendimento del Nobile Corano. Il Nobile Corano ha molti nomi tra cui Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr e Al-Noor.",
+        "description": "Quran.com è un Sadaqah Jariyah. Speriamo di rendere facile per tutti la lettura, lo studio e l'apprendimento del Nobile Corano. Il Nobile Corano ha molti nomi tra cui Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr e Al-Nur.",
         "rights": "Tutti i diritti riservati",
         "title": "Leggi, studia e impara Il Nobile Corano."
     },

--- a/locales/nl/common.json
+++ b/locales/nl/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "Uthmani"
     },
     "footer": {
-        "description": "Quran.com is een Sadaqah Jariyah. We hopen het voor iedereen gemakkelijk te maken om de Edele Koran te lezen, te bestuderen en te leren. De Edele Koran heeft vele namen, waaronder Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr en Al-Noor.",
+        "description": "Quran.com is een Sadaqah Jariyah. We hopen het voor iedereen gemakkelijk te maken om de Edele Koran te lezen, te bestuderen en te leren. De Edele Koran heeft vele namen, waaronder Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr en Al-Nur.",
         "rights": "Alle rechten voorbehouden",
         "title": "Lees, bestudeer en leer de Edele Koran."
     },

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "Uthmani"
     },
     "footer": {
-        "description": "Quran.com é um Sadaqah Jariyah. Esperamos tornar mais fácil para todos ler, estudar e aprender o Nobre Alcorão. O Nobre Alcorão tem muitos nomes, incluindo Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr e Al-Noor.",
+        "description": "Quran.com é um Sadaqah Jariyah. Esperamos tornar mais fácil para todos ler, estudar e aprender o Nobre Alcorão. O Nobre Alcorão tem muitos nomes, incluindo Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr e Al-Nur.",
         "rights": "Todos os direitos reservados",
         "title": "Leia, estude e aprenda O Nobre Alcorão."
     },

--- a/locales/sq/common.json
+++ b/locales/sq/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "Osmani"
     },
     "footer": {
-        "description": "Quran.com është një Jariyah Sadakah. Shpresojmë t'ua bëjmë të lehtë të gjithëve leximin, studimin dhe mësimin e Kuranit Fisnik. Kurani Fisnik ka shumë emra duke përfshirë Al-Kuran Al-Kareem, Al-Ketab, Al-Furkan, Al-Maw'itha, Al-Thikr dhe Al-Noor.",
+        "description": "Quran.com është një Jariyah Sadakah. Shpresojmë t'ua bëjmë të lehtë të gjithëve leximin, studimin dhe mësimin e Kuranit Fisnik. Kurani Fisnik ka shumë emra duke përfshirë Al-Kuran Al-Kareem, Al-Ketab, Al-Furkan, Al-Maw'itha, Al-Thikr dhe Al-Nur.",
         "rights": "Të gjitha të drejtat e rezervuara",
         "title": "Lexoni, studioni dhe mësoni Kuranin Fisnik."
     },

--- a/locales/tr/common.json
+++ b/locales/tr/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "Osmanca"
     },
     "footer": {
-        "description": "Kuran.com bir sadaka-i cariyedir. Herkesin Kur'an-ı Kerim'i okumasını, incelemesini ve öğrenmesini kolaylaştırmayı umuyoruz. Kur'an-ı Kerim'in Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr ve Al-Noor gibi birçok ismi vardır.",
+        "description": "Kuran.com bir sadaka-i cariyedir. Herkesin Kur'an-ı Kerim'i okumasını, incelemesini ve öğrenmesini kolaylaştırmayı umuyoruz. Kur'an-ı Kerim'in Al-Quran Al-Kareem, Al-Ketab, Al-Furqan, Al-Maw'itha, Al-Thikr ve Al-Nur gibi birçok ismi vardır.",
         "rights": "Her hakkı saklıdır",
         "title": "Kur'an-ı Kerim'i okuyun, inceleyin ve öğrenin."
     },

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -166,7 +166,7 @@
         "text_uthmani": "纳斯赫体"
     },
     "footer": {
-        "description": "Quran.com是一项持久的施舍。我们希望每个人都能轻松地阅读和学习尊贵的《古兰经》。尊贵的古兰经有很多名字，包括 Al-Quran Al-Kareem、Al-Ketab、Al-Furqan、Al-Maw'itha、Al-Thikr 和 Al-Noor。",
+        "description": "Quran.com是一项持久的施舍。我们希望每个人都能轻松地阅读和学习尊贵的《古兰经》。尊贵的古兰经有很多名字，包括 Al-Quran Al-Kareem、Al-Ketab、Al-Furqan、Al-Maw'itha、Al-Thikr 和 Al-Nur。",
         "rights": "版权所有",
         "title": "阅读、学习和学习《古兰经》。"
     },


### PR DESCRIPTION
### Summary
In the paragraph imaged below An-Nur was incorrectly spelled as Al-Noor. There were multiplie instances of this in different languages, they have also been replaced.

### Test Plan
### Screenshots

| Before |
<img width="1440" alt="Screenshot 2023-11-26 at 4 11 03 PM" src="https://github.com/quran/quran.com-frontend-next/assets/145882437/0d77681f-a933-4ad9-ae40-c3e7e71081a4">
| After |
<img width="1440" alt="Screenshot 2023-11-26 at 4 19 52 PM" src="https://github.com/quran/quran.com-frontend-next/assets/145882437/d298463a-69f3-4d37-bf58-9430267b087b">

