### PR TITLE
Force-remove translations depending on user preferences

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/hooks/useDedupedFetchVerse.ts
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/hooks/useDedupedFetchVerse.ts
@@ -112,8 +112,16 @@ const useDedupedFetchVerse = ({
         )
       : null;
 
+  const verse = verses ? verses[idxInPage] : null;
+
+  // This part handles an edge case where the user has no selected translations but the `initialData` sent from server-side rendering has a default translation.
+  // So, we need to remove the translations from the verse if the user has no selected translations.
+  if (verse && selectedTranslations.length === 0) {
+    verse.translations = [];
+  }
+
   return {
-    verse: verses ? verses[idxInPage] : null,
+    verse,
     firstVerseInPage: verses ? verses[0] : null,
     bookmarksRangeUrl,
     notesRange: verses


### PR DESCRIPTION
### Summary
This PR fixes a bug caused in the translations view where the default translation would still show up even if the user specified no translations in their preferences.


### Screenshots

![CleanShot 2023-11-29 at 13 56 50](https://github.com/quran/quran.com-frontend-next/assets/58295120/84254fcf-9ada-45ce-92e9-7b99bfa28489)