### PR TITLE
Add redirect param to login page

### DIFF
--- a/src/components/Login/EmailLogin.tsx
+++ b/src/components/Login/EmailLogin.tsx
@@ -80,8 +80,8 @@ const EmailLogin = ({ back, onSubmit }: EmailLoginProps) => {
   );
 };
 
-export const sendMagicLink = async (email) => {
-  const response = await fetch(makeSendMagicLinkUrl(), {
+export const sendMagicLink = async (email: string, redirect?: string) => {
+  const response = await fetch(makeSendMagicLinkUrl(redirect), {
     method: 'post',
     headers: {
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
+import { useRouter } from 'next/router';
 
 import { SubmissionResult } from '../FormBuilder/FormBuilder';
 
@@ -22,13 +23,15 @@ enum LoginType {
 const LoginContainer = () => {
   const [loginType, setLoginType] = useState(LoginType.Social);
   const { t } = useTranslation();
+  const { query } = useRouter();
+  const redirect = query.r ? decodeURIComponent(query.r.toString()) : undefined;
 
   const [magicLinkVerificationCode, setMagicLinkVerificationCode] = useState('');
   const [email, setEmail] = useState('');
 
   const onEmailLoginSubmit = ({ email: emailInput }): SubmissionResult<EmailLoginData> => {
     setEmail(emailInput);
-    return sendMagicLink(emailInput)
+    return sendMagicLink(emailInput, redirect)
       .then(setMagicLinkVerificationCode)
       .catch(() => {
         return {

--- a/src/utils/auth/apiPaths.ts
+++ b/src/utils/auth/apiPaths.ts
@@ -30,7 +30,8 @@ export const makeSyncLocalDataUrl = (): string => makeUrl('users/syncLocalData')
 
 export const makeVerificationCodeUrl = (): string => makeUrl('users/verificationCode');
 
-export const makeSendMagicLinkUrl = (): string => makeUrl('auth/magiclogin');
+export const makeSendMagicLinkUrl = (redirect?: string): string =>
+  makeUrl('auth/magiclogin', redirect ? { redirect } : undefined);
 
 export const makeGoogleLoginUrl = (): string => makeUrl('auth/google');
 


### PR DESCRIPTION
### Summary

This PR adds the ability to pass a redirect (`r`) query param for magic login, and the user will be redirected to it after clicking the link.