### PR TITLE
Fix translations

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/hooks/useDedupedFetchVerse.ts
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/hooks/useDedupedFetchVerse.ts
@@ -67,7 +67,10 @@ const useDedupedFetchVerse = ({
 
   const idxInPage = verseIdx % initialData.pagination.perPage;
 
-  const isUsingDefaultSettings = useIsUsingDefaultSettings({ translations: translationParams });
+  const isUsingDefaultSettings = useIsUsingDefaultSettings({
+    translationParams,
+    selectedTranslations,
+  });
   const shouldUseInitialData = pageNumber === 1 && isUsingDefaultSettings;
   const { data: verses } = useSWRImmutable(
     getTranslationViewRequestKey({

--- a/src/hooks/useIsUsingDefaultSettings.tsx
+++ b/src/hooks/useIsUsingDefaultSettings.tsx
@@ -11,11 +11,17 @@ import {
 import { selectIsUsingDefaultWordByWordLocale } from '@/redux/slices/QuranReader/readingPreferences';
 import { selectQuranFont, selectQuranMushafLines } from '@/redux/slices/QuranReader/styles';
 import { selectIsUsingDefaultTranslations } from '@/redux/slices/QuranReader/translations';
-import { areArraysEqual } from '@/utils/array';
+import { areArraysEqual, mergeTwoArraysUniquely } from '@/utils/array';
 import { selectIsUsingDefaultReciter } from '@/xstate/actors/audioPlayer/selectors';
 import { AudioPlayerMachineContext } from '@/xstate/AudioPlayerMachineContext';
 
-const useIsUsingDefaultSettings = ({ translations }: { translations?: number[] } = {}) => {
+const useIsUsingDefaultSettings = ({
+  translationParams,
+  selectedTranslations,
+}: {
+  translationParams?: number[];
+  selectedTranslations?: number[];
+} = {}) => {
   const { lang } = useTranslation();
   const audioService = useContext(AudioPlayerMachineContext);
   const isUsingDefaultReciter = useXstateSelector(audioService, (state) =>
@@ -39,17 +45,22 @@ const useIsUsingDefaultSettings = ({ translations }: { translations?: number[] }
     defaultState.quranReaderStyles.mushafLines === mushafLines;
 
   const areTranslationsEqual = useMemo(() => {
-    if (!translations) {
+    if (!translationParams && !selectedTranslations) {
       return false;
     }
 
+    const translations = mergeTwoArraysUniquely(
+      translationParams ?? [],
+      selectedTranslations ?? [],
+    );
+
     return areArraysEqual(defaultState.translations.selectedTranslations, translations);
-  }, [translations, defaultState.translations.selectedTranslations]);
+  }, [translationParams, selectedTranslations, defaultState.translations.selectedTranslations]);
 
   const isUsingDefaultSettings =
     isUsingDefaultFont && isUsingDefaultReciter && isUsingDefaultWordByWordLocale;
 
-  if (translations) {
+  if (translationParams || selectedTranslations) {
     return isUsingDefaultSettings && isUsingDefaultTranslations && areTranslationsEqual;
   }
 


### PR DESCRIPTION
### Summary

The first couple of verses ( loaded in `initialData`) were not showing user selected translations if they're not present in the URL params.

![Feb-02-2024_10-30-58_pm](https://github.com/quran/quran.com-frontend-next/assets/58295120/387bc1b5-2ab1-43ca-b520-961e88fcb536)

This bug was caused by `useIsUsingDefaultSettings` only checking for translations in the URL params and not in the user settings as well. 