### PR TITLE
Disable tafsir browser translation

### DIFF
--- a/src/components/QuranReader/TafsirView/TafsirBody.tsx
+++ b/src/components/QuranReader/TafsirView/TafsirBody.tsx
@@ -304,6 +304,9 @@ const TafsirBody = ({
         styles.tafsirContainer,
         styles[`tafsir-font-size-${quranReaderStyles.tafsirFontScale}`],
       )}
+      // disable browser translation for tafsir content
+      // @see {https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate}
+      translate="no"
     >
       <DataFetcher
         loading={TafsirSkeleton}


### PR DESCRIPTION
### Summary

This PR disables the browser's translation for tafsir content which was causing in-accurate content not intended by the author.

![Jul-14-2023 09-14-36](https://github.com/quran/quran.com-frontend-next/assets/58295120/77d5480f-38a3-43d7-a16e-32b887f5a86b)
