### PR TITLE
Fixed typo for port number in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We trust that you will not copy this idea/project, this is at the end for the sa
 - Clone this repo
 - Run `yarn` on the repo to install `node_modules`
 - Run `yarn dev` to start the app. If you wish to run on a different port, run `yarn dev -p 8000`
-- Open `localhost:3000` in your browser
+- Open `localhost:8000` in your browser
 
 The app runs on Next.js and will automatically hot reload when you make changes.
 


### PR DESCRIPTION
### Summary
- The README says to run `yarn dev -p 8000` and then to open `localhost:3000`
- Fix: Changed `localhost:3000` to `localhost:8000`

### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://github.com/quran/quran.com-frontend-next/assets/55910194/7953d21c-3361-4df0-b05a-ba1fd086b55f) | ![image](https://github.com/quran/quran.com-frontend-next/assets/55910194/2ec1b7f5-ccf5-43a8-9ddc-999ba8bc47d5) |