### PR TITLE
Add hoc to redirect to login page

### DIFF
--- a/src/components/Auth/RedirectToLoginPage.tsx
+++ b/src/components/Auth/RedirectToLoginPage.tsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+
+import { useRouter } from 'next/router';
+
+import { getLoginNavigationUrl } from '@/utils/navigation';
+
+const RedirectToLoginPage = () => {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace(getLoginNavigationUrl());
+  }, [router]);
+
+  return <></>;
+};
+
+export default RedirectToLoginPage;

--- a/src/components/Auth/withAuth.tsx
+++ b/src/components/Auth/withAuth.tsx
@@ -1,0 +1,14 @@
+import RedirectToLoginPage from './RedirectToLoginPage';
+
+import { isLoggedIn } from '@/utils/auth/login';
+
+// This HOC is used to check if the user is logged in or not.
+const withAuth = (WrappedComponent) => {
+  const WithAuth = (props) => {
+    return isLoggedIn() ? <WrappedComponent {...props} /> : <RedirectToLoginPage />;
+  };
+
+  return WithAuth;
+};
+
+export default withAuth;

--- a/src/pages/collections/all/index.tsx
+++ b/src/pages/collections/all/index.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { GetStaticProps } from 'next';
 import useTranslation from 'next-translate/useTranslation';
 
+import withAuth from '@/components/Auth/withAuth';
 import CollectionDetailContainer from '@/components/Collection/CollectionDetailContainer/CollectionDetailContainer';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import { isLoggedIn } from '@/utils/auth/login';
 import { logValueChange } from '@/utils/eventLogger';
 import { makeAllCollectionsItemsUrl } from 'src/utils/auth/apiPaths';
@@ -12,7 +12,6 @@ import { getAllChaptersData } from 'src/utils/chapter';
 import { CollectionDetailSortOption } from 'types/CollectionSortOptions';
 
 const CollectionDetailPage = () => {
-  useRequireAuth();
   const [sortBy, setSortBy] = useState(CollectionDetailSortOption.VerseKey);
   const { t } = useTranslation();
 
@@ -70,4 +69,4 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   };
 };
 
-export default CollectionDetailPage;
+export default withAuth(CollectionDetailPage);

--- a/src/pages/learning-plans/[slug]/lessons/[lessonSlugOrId]/index.tsx
+++ b/src/pages/learning-plans/[slug]/lessons/[lessonSlugOrId]/index.tsx
@@ -6,13 +6,13 @@ import useTranslation from 'next-translate/useTranslation';
 
 import styles from './lessons.module.scss';
 
+import withAuth from '@/components/Auth/withAuth';
 import LessonView from '@/components/Course/LessonView';
 import DataFetcher from '@/components/DataFetcher';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
 import PageContainer from '@/components/PageContainer';
 import Link, { LinkVariant } from '@/dls/Link/Link';
 import Spinner from '@/dls/Spinner/Spinner';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import layoutStyles from '@/pages/index.module.scss';
 import ApiErrorMessage from '@/types/ApiErrorMessage';
 import { Lesson } from '@/types/auth/Course';
@@ -37,7 +37,6 @@ const Loading = () => (
 );
 
 const LessonPage: NextPage<Props> = () => {
-  useRequireAuth();
   const { lang } = useTranslation('learn');
   const router = useRouter();
   const { slug, lessonSlugOrId } = router.query;
@@ -106,4 +105,4 @@ const LessonPage: NextPage<Props> = () => {
   );
 };
 
-export default LessonPage;
+export default withAuth(LessonPage);

--- a/src/pages/my-learning-plans/index.tsx
+++ b/src/pages/my-learning-plans/index.tsx
@@ -1,17 +1,15 @@
 import { NextPage, GetStaticProps } from 'next';
 import useTranslation from 'next-translate/useTranslation';
 
+import withAuth from '@/components/Auth/withAuth';
 import CoursesPageLayout from '@/components/Course/CoursesPageLayout';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import { getAllChaptersData } from '@/utils/chapter';
 import { getLanguageAlternates } from '@/utils/locale';
 import { getCanonicalUrl, getMyCoursesNavigationUrl } from '@/utils/navigation';
 
 const MyLearningPlanPage: NextPage = () => {
   const { t, lang } = useTranslation('learn');
-  useRequireAuth();
-
   return (
     <>
       <NextSeoWrapper
@@ -36,4 +34,4 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   };
 };
 
-export default MyLearningPlanPage;
+export default withAuth(MyLearningPlanPage);

--- a/src/pages/notes-and-reflections/index.tsx
+++ b/src/pages/notes-and-reflections/index.tsx
@@ -3,9 +3,9 @@
 import { GetStaticProps } from 'next';
 import useTranslation from 'next-translate/useTranslation';
 
+import withAuth from '@/components/Auth/withAuth';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
 import NotesTabs from '@/components/Notes/NotesPage/Tabs';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import layoutStyles from '@/pages/index.module.scss';
 import { getAllChaptersData } from '@/utils/chapter';
 import { getLanguageAlternates } from '@/utils/locale';
@@ -13,8 +13,6 @@ import { getCanonicalUrl, getNotesNavigationUrl } from '@/utils/navigation';
 
 const NotesAndReflectionsPage = () => {
   const { t, lang } = useTranslation();
-  useRequireAuth();
-
   const navigationUrl = getNotesNavigationUrl();
 
   return (
@@ -47,4 +45,4 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   };
 };
 
-export default NotesAndReflectionsPage;
+export default withAuth(NotesAndReflectionsPage);

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -7,6 +7,7 @@ import useTranslation from 'next-translate/useTranslation';
 import layoutStyle from './index.module.scss';
 import styles from './profile.module.scss';
 
+import withAuth from '@/components/Auth/withAuth';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
 import DeleteAccountButton from '@/components/Profile/DeleteAccountButton';
 import BookmarksAndCollectionsSection from '@/components/Verses/BookmarksAndCollectionsSection';
@@ -14,7 +15,6 @@ import RecentReadingSessions from '@/components/Verses/RecentReadingSessions';
 import Button from '@/dls/Button/Button';
 import Skeleton from '@/dls/Skeleton/Skeleton';
 import useCurrentUser from '@/hooks/auth/useCurrentUser';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import { logoutUser } from '@/utils/auth/api';
 import { DEFAULT_PHOTO_URL } from '@/utils/auth/constants';
 import { isLoggedIn } from '@/utils/auth/login';
@@ -37,8 +37,6 @@ interface Props {
 const nameSample = 'Mohammad Ali';
 const emailSample = 'mohammadali@quran.com';
 const ProfilePage: NextPage<Props> = () => {
-  // we don't want to show the profile page if the user is not logged in
-  useRequireAuth();
   const { t, lang } = useTranslation();
   const router = useRouter();
   const { user, isLoading, error } = useCurrentUser();
@@ -157,4 +155,4 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   };
 };
 
-export default ProfilePage;
+export default withAuth(ProfilePage);

--- a/src/pages/reading-goal/index.tsx
+++ b/src/pages/reading-goal/index.tsx
@@ -9,19 +9,17 @@ import layoutStyles from '../index.module.scss';
 
 import styles from './reading-goal.module.scss';
 
+import withAuth from '@/components/Auth/withAuth';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
 import ReadingGoalOnboarding from '@/components/ReadingGoalPage';
 import Spinner from '@/dls/Spinner/Spinner';
 import useGetStreakWithMetadata from '@/hooks/auth/useGetStreakWithMetadata';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import { getAllChaptersData } from '@/utils/chapter';
 import { getLanguageAlternates } from '@/utils/locale';
 import { getCanonicalUrl, getReadingGoalNavigationUrl } from '@/utils/navigation';
 
 const ReadingGoalPage: NextPage = () => {
   // we don't want to show the reading goal page if the user is not logged in
-  useRequireAuth();
-
   const { t, lang } = useTranslation('reading-goal');
   const router = useRouter();
 
@@ -64,4 +62,4 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   };
 };
 
-export default ReadingGoalPage;
+export default withAuth(ReadingGoalPage);

--- a/src/pages/reading-goal/progress.tsx
+++ b/src/pages/reading-goal/progress.tsx
@@ -1,16 +1,14 @@
 import { NextPage } from 'next';
 
+import withAuth from '@/components/Auth/withAuth';
 import ReadingProgressPage from '@/components/ReadingProgressPage';
-import useRequireAuth from '@/hooks/auth/useRequireAuth';
 import { chaptersDataGetStaticProps } from '@/utils/ssg';
 
 const ReadingGoalProgressPage: NextPage = () => {
   // we don't want to show the reading goal page if the user is not logged in
-  useRequireAuth();
-
   return <ReadingProgressPage />;
 };
 
 export const getStaticProps = chaptersDataGetStaticProps;
 
-export default ReadingGoalProgressPage;
+export default withAuth(ReadingGoalProgressPage);


### PR DESCRIPTION
### Summary
Currently, we are using `useRequireAuth` hook as a way to redirect to login page when a non-logged in user is trying to access authenticated components. But issue is at least 1 request is sent to backend that fails while Frontend already knows the user is not logged in. So This PR is introducing a Higher-Order-Component `withAuth` that will not render authenticated components except when the user is logged in, otherwise redirects the user to login page.