### PR TITLE
fix side navbar page list tajweed

### DIFF
--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -13,6 +13,7 @@ const PAGES_MUSHAF_MAP = {
   [Mushaf.UthmaniHafs]: 604,
   [Mushaf.Indopak16Lines]: 548,
   [Mushaf.Indopak15Lines]: 610,
+  [Mushaf.Tajweeed]: 604,
 };
 
 /**


### PR DESCRIPTION
### Summary
This fixes the bug #2124 where selecting Tajweed fonts only showed 1 page in the side navbar page selection 

### Test Plan
1 - Open any surah in reading or translation mode
2 - From setting select Tajweed fonts
3 - From sidebar navigation open the list of pages

### Screenshots

| Before | After |
| ------ | ------ |
| ![image](https://github.com/quran/quran.com-frontend-next/assets/42354272/df927831-c923-4088-9f70-b80655e43d55) | ![image](https://github.com/quran/quran.com-frontend-next/assets/42354272/6a138583-9bae-46e0-bac5-f1f6ecfdc9f4) |