### PR TITLE
Fixing the layout shift that happens in the home page and chapterId page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -164,7 +164,7 @@ const config = {
     ];
   },
 };
-
+/* eslint-disable max-lines */
 module.exports = withPlugins(
   [withBundleAnalyzer, withPWA, withFonts, nextTranslate, withSentryConfig],
   config,

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -1,6 +1,16 @@
 @use "src/styles/constants";
 @use "src/styles/breakpoints";
 
+body[data-scroll-locked] {
+  .container {
+    width: calc(100% - var(--scrollbar-width)) !important;
+  }
+}
+
+.noScrollbarWidth {
+  width: calc(100% - var(--scrollbar-width)) !important;
+}
+
 .emptySpacePlaceholder {
   height: var(--navbar-container-height);
 }
@@ -10,7 +20,7 @@
   position: fixed;
   height: var(--navbar-height);
   width: 100%;
-  transition: var(--transition-regular);
+  transition: transform var(--transition-regular);
   background: var(--color-background-elevated);
   z-index: var(--z-index-header);
   will-change: transform;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import classNames from 'classnames';
 import { useSelector, shallowEqual } from 'react-redux';
@@ -7,6 +7,7 @@ import styles from './Navbar.module.scss';
 import NavbarBody from './NavbarBody';
 
 import { useOnboarding } from '@/components/Onboarding/OnboardingProvider';
+import useScrollBarWidth from '@/hooks/useScrollBarWidth';
 import { selectNavbar } from '@/redux/slices/navbar';
 
 const Navbar = () => {
@@ -19,24 +20,7 @@ const Navbar = () => {
   } = useSelector(selectNavbar, shallowEqual);
   const showNavbar = isNavbarVisible || isActive;
 
-  useEffect(() => {
-    const getScrollbarWidth = () => {
-      return window.innerWidth - document.documentElement.clientWidth;
-    };
-
-    const setScrollbarWidth = () => {
-      const scrollbarWidth = getScrollbarWidth();
-      document.documentElement.style.setProperty('--scrollbar-width', `${scrollbarWidth}px`);
-    };
-
-    setScrollbarWidth(); // Set the scrollbar width initially
-
-    window.addEventListener('resize', setScrollbarWidth); // Update the scrollbar width when the window is resized
-
-    return () => {
-      window.removeEventListener('resize', setScrollbarWidth);
-    };
-  }, []);
+  useScrollBarWidth();
 
   return (
     <>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import classNames from 'classnames';
 import { useSelector, shallowEqual } from 'react-redux';
@@ -11,13 +11,43 @@ import { selectNavbar } from '@/redux/slices/navbar';
 
 const Navbar = () => {
   const { isActive } = useOnboarding();
-  const { isVisible: isNavbarVisible } = useSelector(selectNavbar, shallowEqual);
+  const {
+    isVisible: isNavbarVisible,
+    isSettingsDrawerOpen,
+    isNavigationDrawerOpen,
+    isSearchDrawerOpen,
+  } = useSelector(selectNavbar, shallowEqual);
   const showNavbar = isNavbarVisible || isActive;
+
+  useEffect(() => {
+    const getScrollbarWidth = () => {
+      return window.innerWidth - document.documentElement.clientWidth;
+    };
+
+    const setScrollbarWidth = () => {
+      const scrollbarWidth = getScrollbarWidth();
+      document.documentElement.style.setProperty('--scrollbar-width', `${scrollbarWidth}px`);
+    };
+
+    setScrollbarWidth(); // Set the scrollbar width initially
+
+    window.addEventListener('resize', setScrollbarWidth); // Update the scrollbar width when the window is resized
+
+    return () => {
+      window.removeEventListener('resize', setScrollbarWidth);
+    };
+  }, []);
 
   return (
     <>
       <div className={styles.emptySpacePlaceholder} />
-      <nav className={classNames(styles.container, { [styles.hiddenNav]: !showNavbar })}>
+      <nav
+        className={classNames(styles.container, {
+          [styles.hiddenNav]: !showNavbar,
+          [styles.noScrollbarWidth]:
+            isSettingsDrawerOpen || isNavigationDrawerOpen || isSearchDrawerOpen,
+        })}
+      >
         <NavbarBody />
       </nav>
     </>

--- a/src/components/Navbar/NavbarBody/index.tsx
+++ b/src/components/Navbar/NavbarBody/index.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
+import { createPortal } from 'react-dom';
 import { useDispatch } from 'react-redux';
 
 import LanguageSelector from '../LanguageSelector';
@@ -85,7 +86,7 @@ const NavbarBody: React.FC = () => {
             >
               <IconSettings />
             </Button>
-            <SettingsDrawer />
+            {createPortal(<SettingsDrawer />, document.body)}
           </>
           <>
             <Button
@@ -98,7 +99,7 @@ const NavbarBody: React.FC = () => {
             >
               <IconSearch />
             </Button>
-            <SearchDrawer />
+            {createPortal(<SearchDrawer />, document.body)}
           </>
         </div>
       </div>

--- a/src/components/Navbar/NavbarBody/index.tsx
+++ b/src/components/Navbar/NavbarBody/index.tsx
@@ -52,6 +52,8 @@ const NavbarBody: React.FC = () => {
     dispatch({ type: setIsSettingsDrawerOpen.type, payload: true });
   };
 
+  const isClient = typeof document !== 'undefined';
+
   return (
     <div className={styles.itemsContainer}>
       <div className={styles.centerVertically}>
@@ -86,7 +88,7 @@ const NavbarBody: React.FC = () => {
             >
               <IconSettings />
             </Button>
-            {createPortal(<SettingsDrawer />, document.body)}
+            {isClient && createPortal(<SettingsDrawer />, document.body)}
           </>
           <>
             <Button
@@ -99,7 +101,7 @@ const NavbarBody: React.FC = () => {
             >
               <IconSearch />
             </Button>
-            {createPortal(<SearchDrawer />, document.body)}
+            {isClient && createPortal(<SearchDrawer />, document.body)}
           </>
         </div>
       </div>

--- a/src/components/Onboarding/OnboardingChecklist/OnboardingChecklist.module.scss
+++ b/src/components/Onboarding/OnboardingChecklist/OnboardingChecklist.module.scss
@@ -1,5 +1,15 @@
 @use "src/styles/breakpoints";
 
+body[data-scroll-locked] {
+  .checklistPosition {
+    margin-right: var(--scrollbar-width);
+  }
+}
+
+.marginRight {
+  margin-right: var(--scrollbar-width);
+}
+
 .checklistPosition {
   position: fixed;
   inset-block-end: var(--spacing-medium);

--- a/src/components/Onboarding/OnboardingChecklist/index.tsx
+++ b/src/components/Onboarding/OnboardingChecklist/index.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import Trans from 'next-translate/Trans';
 import useTranslation from 'next-translate/useTranslation';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 
 import OnboardingProgress from '../OnboardingProgress';
 import { onboardingChecklist } from '../steps';
@@ -16,6 +16,7 @@ import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
 import CheckIcon from '@/icons/check.svg';
 import IconClose from '@/icons/close.svg';
 import IconQuestionMark from '@/icons/question-mark-icon.svg';
+import { selectNavbar } from '@/redux/slices/navbar';
 import {
   dismissChecklist,
   selectOnboarding,
@@ -41,6 +42,11 @@ const OnboardingChecklist = () => {
   const { startTour, isActive } = useOnboarding();
   const { isChecklistVisible, checklistDismissals, completedGroups } =
     useSelector(selectOnboarding);
+
+  const { isSearchDrawerOpen, isNavigationDrawerOpen, isSettingsDrawerOpen } = useSelector(
+    selectNavbar,
+    shallowEqual,
+  );
 
   const readingPreferences = useSelector(selectReadingPreferences);
   const { readingPreference } = readingPreferences;
@@ -70,7 +76,10 @@ const OnboardingChecklist = () => {
       return (
         <Button
           shape={ButtonShape.Circle}
-          className={classNames(styles.checklistPosition)}
+          className={classNames(styles.checklistPosition, {
+            [styles.marginRight]:
+              isSearchDrawerOpen || isNavigationDrawerOpen || isSettingsDrawerOpen,
+          })}
           tooltip={t('onboarding:onboarding-checklist')}
           onClick={openChecklist}
           size={ButtonSize.Large}
@@ -112,7 +121,11 @@ const OnboardingChecklist = () => {
   };
 
   return (
-    <div className={classNames(styles.checklist, styles.checklistPosition)}>
+    <div
+      className={classNames(styles.checklist, styles.checklistPosition, {
+        [styles.marginRight]: isSearchDrawerOpen || isNavigationDrawerOpen || isSettingsDrawerOpen,
+      })}
+    >
       <div className={styles.checklistHeader}>
         <h4>
           <Trans
@@ -161,5 +174,5 @@ const OnboardingChecklist = () => {
     </div>
   );
 };
-
+// eslint-disable-next-line max-lines
 export default OnboardingChecklist;

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -1,6 +1,16 @@
 @use "src/styles/constants";
 @use "src/styles/breakpoints";
 
+body[data-scroll-locked] {
+  .container {
+    width: calc(100% - var(--scrollbar-width)) !important;
+  }
+}
+
+.noScrollbarWidth {
+  width: calc(100% - var(--scrollbar-width)) !important;
+}
+
 .container {
   background: var(--color-background-default);
   background: var(--color-background-elevated);

--- a/src/components/QuranReader/ContextMenu.tsx
+++ b/src/components/QuranReader/ContextMenu.tsx
@@ -40,7 +40,12 @@ const ContextMenu = () => {
     useSelector(selectContextMenu, shallowEqual);
 
   const { isActive } = useOnboarding();
-  const { isVisible: isNavbarVisible } = useSelector(selectNavbar, shallowEqual);
+  const {
+    isVisible: isNavbarVisible,
+    isSettingsDrawerOpen,
+    isNavigationDrawerOpen,
+    isSearchDrawerOpen,
+  } = useSelector(selectNavbar, shallowEqual);
   const showNavbar = isNavbarVisible || isActive;
   const showReadingPreferenceSwitcher = isReadingPreferenceSwitcherVisible && !isActive;
 
@@ -71,6 +76,8 @@ const ContextMenu = () => {
         [styles.visibleContainer]: showNavbar,
         [styles.expandedContainer]: isExpanded,
         [styles.withVisibleSideBar]: isSideBarVisible,
+        [styles.noScrollbarWidth]:
+          isSettingsDrawerOpen || isNavigationDrawerOpen || isSearchDrawerOpen,
       })}
       // @ts-ignore
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/hooks/usePreventBodyScrolling.ts
+++ b/src/hooks/usePreventBodyScrolling.ts
@@ -18,11 +18,16 @@ const usePreventBodyScrolling = (shouldDisableScrolling = false) => {
     }
     // Save the initial body style
     const originalOverflow = document.body.style.overflow;
-    // disable body scrolling bt setting overflow to hidden on the body
+    const originalWidth = document.body.style.width;
+
+    // leave space for the scrollbar to avoid causing a layout shift
+    document.body.style.width = 'calc(100% - var(--scrollbar-width))';
+    // disable body scrolling by setting overflow to hidden on the body
     document.body.style.overflow = 'hidden';
     return () => {
-      // revert it back
+      // revert them back
       document.body.style.overflow = originalOverflow;
+      document.body.style.width = originalWidth;
     };
   }, [shouldDisableScrolling]);
 };

--- a/src/hooks/useScrollBarWidth.ts
+++ b/src/hooks/useScrollBarWidth.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+const useScrollBarWidth = () => {
+  useEffect(() => {
+    const getScrollbarWidth = () => {
+      return window.innerWidth - document.documentElement.clientWidth;
+    };
+
+    const setScrollbarWidth = () => {
+      const scrollbarWidth = getScrollbarWidth();
+      document.documentElement.style.setProperty('--scrollbar-width', `${scrollbarWidth}px`);
+    };
+
+    function throttle(fn: () => void, time: number) {
+      let timeout = null;
+      return () => {
+        if (timeout) return;
+        timeout = setTimeout(() => {
+          fn();
+          timeout = null;
+        }, time);
+      };
+    }
+
+    const handleResizeThrottled = throttle(setScrollbarWidth, 500); // Throttle the resize event
+
+    setScrollbarWidth(); // Set the scrollbar width initially
+
+    window.addEventListener('resize', handleResizeThrottled); // Update the scrollbar width when the window is resized
+
+    return () => {
+      window.removeEventListener('resize', handleResizeThrottled);
+    };
+  }, []);
+};
+
+export default useScrollBarWidth;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -63,6 +63,8 @@
   --transition-regular: 0.4s;
   --transition-slow: 0.6s;
 
+  --scrollbar-width: 0px;
+
   @include shades.shades-dangerous;
   @include light.mode;
 


### PR DESCRIPTION
### Summary

fixed the layout shift that happens when you open the language dropdown, and when you open any of the drawers available on the navbar. the first one is caused by a library used by radix ui under the hood called: react-remove-scroll, and the second one is caused by the usePreventBodyScrolling hook.

Here is the [Before](https://www.loom.com/share/a48d73440c4142e9a5fa2f7f08c6aee5?sid=29360acc-bd1e-4b55-8dc7-dbb9ddf6209c) and [After](https://www.loom.com/share/d9cc43a9b81341fc8b73ccae2dd30e5c?sid=d35d61e2-d69c-4535-ade1-17d8b23541ff)