### PR TITLE
Change bookmarks and reading sessions buttons UI

### DIFF
--- a/src/components/Verses/BookmarkPill.module.scss
+++ b/src/components/Verses/BookmarkPill.module.scss
@@ -2,19 +2,12 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  margin-inline-end: var(--spacing-small);
-  white-space: nowrap;
-  background-color: var(--color-success-medium);
-  border-radius: var(--border-radius-pill);
-  padding-inline-start: var(--spacing-small);
-  padding-block: var(--spacing-xsmall);
+  margin-inline-end: var(--spacing-xsmall);
 }
 
 .linkButtonContainer {
-  color: var(--shade-0);
-  text-decoration: none;
-  background-color: transparent;
   font-weight: var(--font-weight-semibold);
+  text-decoration: underline;
 }
 
 .closeIconContainer {
@@ -24,17 +17,15 @@
   box-sizing: border-box;
   justify-content: center;
   padding-inline-start: var(--spacing-small);
-  padding-inline-end: var(--spacing-large);
+  padding-inline-end: var(--spacing-small);
   background-color: transparent;
   align-items: center;
-  color: var(--shade-0);
   & > span {
     display: flex;
     align-items: center;
     justify-content: center;
   }
   & svg {
-    fill: var(--shade-0);
     width: var(--spacing-medium);
     height: var(--spacing-medium);
   }

--- a/src/components/Verses/RecentReadingSessionsList/ReadingSessionPill/ReadingSessionPill.module.scss
+++ b/src/components/Verses/RecentReadingSessionsList/ReadingSessionPill/ReadingSessionPill.module.scss
@@ -1,18 +1,9 @@
-.bookmarkItem {
-    box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    margin-inline-end: var(--spacing-small);
+.readingSessionItem {
+    margin-inline-end: var(--spacing-xsmall);
     white-space: nowrap;
-    background-color: var(--color-success-medium);
-    border-radius: var(--border-radius-pill);
-    padding-inline: var(--spacing-small);
-    padding-block: var(--spacing-xsmall);
 }
 
 .linkButtonContainer {
-    color: var(--shade-0);
-    text-decoration: none;
-    background-color: transparent;
     font-weight: var(--font-weight-semibold);
+    text-decoration: underline;
 }

--- a/src/components/Verses/RecentReadingSessionsList/ReadingSessionPill/index.tsx
+++ b/src/components/Verses/RecentReadingSessionsList/ReadingSessionPill/index.tsx
@@ -5,7 +5,7 @@ import useTranslation from 'next-translate/useTranslation';
 import styles from './ReadingSessionPill.module.scss';
 
 import DataContext from '@/contexts/DataContext';
-import Link from '@/dls/Link/Link';
+import Button, { ButtonSize, ButtonType, ButtonVariant } from '@/dls/Button/Button';
 import { getChapterData } from '@/utils/chapter';
 import { logButtonClick } from '@/utils/eventLogger';
 import { toLocalizedVerseKey } from '@/utils/locale';
@@ -27,16 +27,22 @@ const ReadingSessionPill: React.FC<Props> = ({ verseKey }) => {
     logButtonClick('recent_sessions_list_item_link');
   };
 
-  const bookmarkText = `${chapterData.transliteratedName} ${toLocalizedVerseKey(verseKey, lang)}`;
+  const readingSessionText = `${chapterData.transliteratedName} ${toLocalizedVerseKey(
+    verseKey,
+    lang,
+  )}`;
   return (
-    <div className={styles.bookmarkItem}>
-      <Link
-        href={getChapterWithStartingVerseUrl(verseKey)}
+    <div className={styles.readingSessionItem}>
+      <Button
         onClick={onLinkClicked}
+        href={getChapterWithStartingVerseUrl(verseKey)}
+        type={ButtonType.Primary}
+        variant={ButtonVariant.Compact}
         className={styles.linkButtonContainer}
+        size={ButtonSize.Small}
       >
-        {bookmarkText}
-      </Link>
+        {readingSessionText}
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
### Summary
This PR updates bookmarks and reading session pills in the homepage to make them smaller and not look like call-to-action buttons.

### Screenshots

| Before | After |
| ------ | ------ |
|<img width="1445" alt="Screenshot 2024-04-14 at 2 03 07 PM" src="https://github.com/quran/quran.com-frontend-next/assets/15169499/3fb6c48f-84cb-4385-bc06-309e2709bfcc">|<img width="1280" alt="Screenshot 2024-04-14 at 2 02 53 PM" src="https://github.com/quran/quran.com-frontend-next/assets/15169499/df520c2d-af5d-4d93-9b3e-9389eb9c381c">|