### PR TITLE
Only allow Joyride on client side

### DIFF
--- a/src/components/Onboarding/OnboardingProvider.tsx
+++ b/src/components/Onboarding/OnboardingProvider.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable max-lines */
 import React, { useMemo, useCallback, useState } from 'react';
 
+import dynamic from 'next/dynamic';
 import useTranslation from 'next-translate/useTranslation';
-import Joyride, { ACTIONS, Callback, EVENTS, STATUS, StoreHelpers } from 'react-joyride';
+import { ACTIONS, Callback, EVENTS, STATUS, StoreHelpers } from 'react-joyride';
 import { useSelector, useDispatch } from 'react-redux';
 
 // eslint-disable-next-line import/no-cycle
@@ -14,6 +15,7 @@ import { selectOnboardingActiveStep, setActiveStepIndex } from '@/redux/slices/o
 import OnboardingGroup from '@/types/OnboardingGroup';
 import { isLoggedIn } from '@/utils/auth/login';
 
+const Joyride = dynamic(() => import('react-joyride'), { ssr: false });
 interface OnboardingContextType {
   startTour: (group?: OnboardingGroup, startIndex?: number) => void;
   stopTour: () => void;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 
 import { DirectionProvider } from '@radix-ui/react-direction';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
-import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { DefaultSeo } from 'next-seo';
@@ -16,6 +15,7 @@ import FontPreLoader from '@/components/Fonts/FontPreLoader';
 import GlobalListeners from '@/components/GlobalListeners';
 import Navbar from '@/components/Navbar/Navbar';
 import OnboardingChecklist from '@/components/Onboarding/OnboardingChecklist';
+import { OnboardingProvider } from '@/components/Onboarding/OnboardingProvider';
 import SessionIncrementor from '@/components/SessionIncrementor';
 import ThirdPartyScripts from '@/components/ThirdPartyScripts/ThirdPartyScripts';
 import Footer from '@/dls/Footer/Footer';
@@ -38,13 +38,6 @@ import 'src/styles/fonts.scss';
 import 'src/styles/theme.scss';
 import 'src/styles/global.scss';
 import 'src/styles/variables.scss';
-
-const OnboardingProvider = dynamic(
-  () => import('@/components/Onboarding/OnboardingProvider').then((a) => a.OnboardingProvider),
-  {
-    ssr: false,
-  },
-);
 
 function MyApp({ Component, pageProps }): JSX.Element {
   const router = useRouter();


### PR DESCRIPTION
### Summary
This PR fixes an issue that was preventing the server from rendering the HTML correctly resulting in missing all meta tags including preview links etc by only loading `Joyride` package on the client side.

`curl "https://localhost:3000/1"` Before vs after:
<img width="1715" alt="Screenshot 2024-05-04 at 7 22 54 PM" src="https://github.com/quran/quran.com-frontend-next/assets/15169499/3c9c1bb0-29ce-44d8-80d9-ad9203ef2dd2">