### PR TITLE
QF-352: Update translation view initial data with the api data

### DIFF
--- a/src/components/QuranReader/TranslationView/hooks/useGetVersesCount.ts
+++ b/src/components/QuranReader/TranslationView/hooks/useGetVersesCount.ts
@@ -1,0 +1,48 @@
+import { useContext, useMemo } from 'react';
+
+import { useSelector } from 'react-redux';
+
+import useFetchPagesLookup from '../../hooks/useFetchPagesLookup';
+
+import DataContext from '@/contexts/DataContext';
+import { selectIsUsingDefaultFont } from '@/redux/slices/QuranReader/styles';
+import { generateVerseKeysBetweenTwoVerseKeys } from '@/utils/verseKeys';
+
+/**
+ * This hooks calculates the total number of verses based on the verses range
+ * and the current Mushaf settings
+ *
+ * @param {number|string} resourceId
+ * @param {QuranReaderDataType} quranReaderDataType
+ * @param {VersesResponse} initialData
+ * @param {QuranReaderStyles} quranReaderStyles
+ *
+ * @returns {number} versesCount
+ */
+
+const useGetVersesCount = ({
+  resourceId,
+  quranReaderDataType,
+  initialData,
+  quranReaderStyles,
+}): number => {
+  const isUsingDefaultFont = useSelector(selectIsUsingDefaultFont);
+  const { lookupRange } = useFetchPagesLookup(
+    resourceId,
+    quranReaderDataType,
+    initialData,
+    quranReaderStyles,
+    isUsingDefaultFont,
+  );
+
+  const chaptersData = useContext(DataContext);
+
+  const versesCount = useMemo(() => {
+    return generateVerseKeysBetweenTwoVerseKeys(chaptersData, lookupRange.from, lookupRange.to)
+      .length;
+  }, [chaptersData, lookupRange.from, lookupRange.to]);
+
+  return versesCount;
+};
+
+export default useGetVersesCount;

--- a/src/components/QuranReader/TranslationView/hooks/useGetVersesCount.ts
+++ b/src/components/QuranReader/TranslationView/hooks/useGetVersesCount.ts
@@ -2,8 +2,7 @@ import { useContext, useMemo } from 'react';
 
 import { useSelector } from 'react-redux';
 
-import useFetchPagesLookup from '../../hooks/useFetchPagesLookup';
-
+import useFetchPagesLookup from '@/components/QuranReader/hooks/useFetchPagesLookup';
 import DataContext from '@/contexts/DataContext';
 import { selectIsUsingDefaultFont } from '@/redux/slices/QuranReader/styles';
 import { generateVerseKeysBetweenTwoVerseKeys } from '@/utils/verseKeys';

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 /* eslint-disable react/no-multi-comp */
-import React, { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import dynamic from 'next/dynamic';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
@@ -8,6 +8,7 @@ import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import onCopyQuranWords from '../onCopyQuranWords';
 import QueryParamMessage from '../QueryParamMessage';
 
+import useGetVersesCount from './hooks/useGetVersesCount';
 import useScrollToVirtualizedVerse from './hooks/useScrollToVirtualizedVerse';
 import styles from './TranslationView.module.scss';
 import TranslationViewVerse from './TranslationViewVerse';
@@ -63,6 +64,14 @@ const TranslationView = ({
   }: { value: string; isQueryParamDifferent: boolean } = useGetQueryParamOrReduxValue(
     QueryParam.WBW_LOCALE,
   );
+
+  const versesCount = useGetVersesCount({
+    resourceId,
+    quranReaderDataType,
+    initialData,
+    quranReaderStyles,
+  });
+
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   useScrollToVirtualizedVerse(
     quranReaderDataType,
@@ -75,7 +84,7 @@ const TranslationView = ({
   useQcfFont(quranReaderStyles.quranFont, verses);
 
   const itemContentRenderer = (verseIdx: number) => {
-    if (verseIdx === initialData.metaData.numberOfVerses) {
+    if (verseIdx === versesCount) {
       return (
         <EndOfScrollingControls
           quranReaderDataType={quranReaderDataType}
@@ -88,7 +97,7 @@ const TranslationView = ({
     return (
       <TranslationViewVerse
         verseIdx={verseIdx}
-        totalVerses={initialData.metaData.numberOfVerses}
+        totalVerses={versesCount}
         quranReaderDataType={quranReaderDataType}
         quranReaderStyles={quranReaderStyles}
         setApiPageToVersesMap={setApiPageToVersesMap}
@@ -123,7 +132,7 @@ const TranslationView = ({
         <Virtuoso
           ref={virtuosoRef}
           useWindowScroll
-          totalCount={initialData.metaData.numberOfVerses + 1}
+          totalCount={versesCount + 1}
           increaseViewportBy={INCREASE_VIEWPORT_BY_PIXELS}
           initialItemCount={1} // needed for SSR.
           itemContent={itemContentRenderer}


### PR DESCRIPTION
# Summary

Fixes  #QF-352
Updated translation view initial data with the API data.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test plan

I have tested the Quran reader, in both translation view and reader view, in different Mushaf settings like the Madani and Idopack in different routes, the following are some of which:

- https://quran.com/rub/1
- https://quran.com/1:1
- https://quran.com/1:1-2:20
- https://quran.com/1/1
- https://quran.com/14
- https://quran.com/hizb/30


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Screenshots or videos

| Before | After |
| ------ | ------ |
| ![Capture-2024-05-13-112821](https://github.com/quran/quran.com-frontend-next/assets/8735775/4ad95087-4193-4825-b6ad-bb88fbeb2191) | ![Capture-2024-05-13-112912](https://github.com/quran/quran.com-frontend-next/assets/8735775/1c24e461-c03b-4ebf-b0a9-f484c678fcad) |