### PR TITLE
QF-369: fix pages routes with pageId greater than 604

### DIFF
--- a/src/pages/page/[pageId].tsx
+++ b/src/pages/page/[pageId].tsx
@@ -1,14 +1,13 @@
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
-import { shallowEqual, useSelector } from 'react-redux';
 
 import { getPagesLookup, getPageVerses } from '@/api';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
 import QuranReader from '@/components/QuranReader';
+import useGetMushaf from '@/hooks/useGetMushaf';
 import Error from '@/pages/_error';
 import { getQuranReaderStylesInitialState } from '@/redux/defaultSettings/util';
-import { selectQuranFont, selectQuranMushafLines } from '@/redux/slices/QuranReader/styles';
 import { getDefaultWordFields, getMushafId } from '@/utils/api';
 import { getAllChaptersData } from '@/utils/chapter';
 import { getLanguageAlternates, toLocalizedNumber } from '@/utils/locale';
@@ -36,9 +35,7 @@ const QuranicPage: NextPage<Props> = ({ hasError, pageVerses }) => {
     query: { pageId },
   } = useRouter();
 
-  const quranFont = useSelector(selectQuranFont, shallowEqual);
-  const mushafLines = useSelector(selectQuranMushafLines, shallowEqual);
-  const mushafId = getMushafId(quranFont, mushafLines).mushaf;
+  const mushafId = useGetMushaf();
 
   if (hasError || pageId > PAGES_MUSHAF_MAP[Number(mushafId)]) {
     return <Error statusCode={500} />;
@@ -64,23 +61,29 @@ const QuranicPage: NextPage<Props> = ({ hasError, pageVerses }) => {
 
 // eslint-disable-next-line react-func/max-lines-per-function
 export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
+  const pageIdNumber = Number(params.pageId);
+  // we need to validate the pageId first to save calling BE since we haven't set the valid paths inside getStaticPaths to avoid pre-rendering them at build time.
+  if (!isValidPageId(pageIdNumber)) {
+    return {
+      notFound: true,
+    };
+  }
+
   const defaultMushafId = getMushafId(
     getQuranReaderStylesInitialState(locale).quranFont,
     getQuranReaderStylesInitialState(locale).mushafLines,
   ).mushaf;
 
+  // The defaultMushafId is 2 representing the Madinah Mushaf
+  // PAGES_MUSHAF_MAP will return the mushaf total number of pages when passed a mushafId
+  // Mushaf ID: 2 (Madinah) -> Pages Count: 604 pages
   const defaultMushafPagesCount = PAGES_MUSHAF_MAP[Number(defaultMushafId)];
+  // In case the requested page/[pageId] is greater than the SSR loaded default mushaf total pages count
+  // we set the pageId to the last available page, otherwise we load the passed pageID
   const pageId =
-    Number(params.pageId) > defaultMushafPagesCount
+    pageIdNumber > defaultMushafPagesCount
       ? String(defaultMushafPagesCount)
       : String(params.pageId);
-
-  // we need to validate the pageId first to save calling BE since we haven't set the valid paths inside getStaticPaths to avoid pre-rendering them at build time.
-  if (!isValidPageId(pageId)) {
-    return {
-      notFound: true,
-    };
-  }
 
   try {
     const pageVersesResponse = await getPageVerses(pageId, locale, {

--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -5,7 +5,7 @@ import { Mushaf, MushafLines, QuranFont, QuranFontMushaf } from 'types/QuranRead
 const DEFAULT_NUMBER_OF_PAGES = 604;
 
 // a map between the mushafId and the number of pages it has
-const PAGES_MUSHAF_MAP = {
+export const PAGES_MUSHAF_MAP = {
   [Mushaf.Indopak]: 604,
   [Mushaf.KFGQPCHAFS]: 604,
   [Mushaf.QCFV1]: 604,

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,6 +1,8 @@
 import { getChapterData } from './chapter';
+import { PAGES_MUSHAF_MAP } from './page';
 import { parseVerseRange } from './verseKeys';
 
+import { Mushaf } from '@/types/QuranReader';
 import ChaptersData from 'types/ChaptersData';
 
 /**
@@ -130,7 +132,11 @@ export const isValidHizbId = (hizbId: string): boolean => {
 export const isValidPageId = (pageId: string | number): boolean => {
   const pageIdNumber = Number(pageId);
   // if it's not a numeric string or it's numeric but out of the range of chapter 1->604
-  if (Number.isNaN(pageIdNumber) || pageIdNumber > 604 || pageIdNumber < 1) {
+  if (
+    Number.isNaN(pageIdNumber) ||
+    pageIdNumber > PAGES_MUSHAF_MAP[Mushaf.Indopak15Lines] ||
+    pageIdNumber < 1
+  ) {
     return false;
   }
   return true;

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -2,8 +2,8 @@ import { getChapterData } from './chapter';
 import { PAGES_MUSHAF_MAP } from './page';
 import { parseVerseRange } from './verseKeys';
 
-import { Mushaf } from '@/types/QuranReader';
 import ChaptersData from 'types/ChaptersData';
+import { Mushaf } from 'types/QuranReader';
 
 /**
  * Validate a chapterId which can be in-valid in 2 cases:

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -131,12 +131,10 @@ export const isValidHizbId = (hizbId: string): boolean => {
  */
 export const isValidPageId = (pageId: string | number): boolean => {
   const pageIdNumber = Number(pageId);
+  const LONGEST_MUSHAF = Mushaf.Indopak15Lines;
+  const LONGEST_MUSHAF_COUNT = PAGES_MUSHAF_MAP[LONGEST_MUSHAF];
   // if it's not a numeric string or it's numeric but out of the range of chapter 1->604
-  if (
-    Number.isNaN(pageIdNumber) ||
-    pageIdNumber > PAGES_MUSHAF_MAP[Mushaf.Indopak15Lines] ||
-    pageIdNumber < 1
-  ) {
+  if (Number.isNaN(pageIdNumber) || pageIdNumber > LONGEST_MUSHAF_COUNT || pageIdNumber < 1) {
     return false;
   }
   return true;


### PR DESCRIPTION
# Summary

Fixes  #QF-369

Fixes `page/[pageId]` when `pageId` is greater than 604


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Test plan

I have tested the Quran reader, in different Mushaf settings like the Madani and Indopack in different routes from 604 to 610.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Screenshots or videos

| Before | After |
| ------ | ------ |
| ![Quran_com](https://github.com/quran/quran.com-frontend-next/assets/8735775/fafa201e-6c29-4b9c-b967-ef8be8cb60da) | ![localhost](https://github.com/quran/quran.com-frontend-next/assets/8735775/4c45b0d2-7225-4192-bfa1-d9f6569ef829) |
