### PR TITLE
validate page id by the selected mushaf id

### DIFF
--- a/src/components/ReadingGoal/UpdateReadingGoalModal/index.tsx
+++ b/src/components/ReadingGoal/UpdateReadingGoalModal/index.tsx
@@ -175,12 +175,16 @@ const UpdateReadingGoalModal = ({ isDisabled, goal }: UpdateReadingGoalButtonPro
   };
 
   const getIsUpdateDisabled = () => {
-    return !validateReadingGoalData(chaptersData, {
-      type,
-      pages,
-      seconds,
-      range,
-    });
+    return !validateReadingGoalData(
+      chaptersData,
+      {
+        type,
+        pages,
+        seconds,
+        range,
+      },
+      mushaf,
+    );
   };
 
   return (

--- a/src/components/ReadingGoal/UpdateReadingGoalModal/index.tsx
+++ b/src/components/ReadingGoal/UpdateReadingGoalModal/index.tsx
@@ -2,7 +2,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
-import { useSelector, shallowEqual } from 'react-redux';
 import { useSWRConfig } from 'swr';
 
 import ReadingGoalInput from '../ReadingGoalInput';
@@ -17,15 +16,14 @@ import { RadioRootOrientation } from '@/dls/Forms/RadioGroup/Root';
 import Select, { SelectSize } from '@/dls/Forms/Select';
 import Modal from '@/dls/Modal/Modal';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
-import { selectQuranFont, selectQuranMushafLines } from '@/redux/slices/QuranReader/styles';
+import useGetMushaf from '@/hooks/useGetMushaf';
 import {
   Goal,
-  QuranGoalPeriod,
-  GoalType,
-  UpdateGoalRequest,
   GoalCategory,
+  GoalType,
+  QuranGoalPeriod,
+  UpdateGoalRequest,
 } from '@/types/auth/Goal';
-import { getMushafId } from '@/utils/api';
 import { updateReadingGoal } from '@/utils/auth/api';
 import { makeStreakUrl } from '@/utils/auth/apiPaths';
 import { logButtonClick, logFormSubmission, logValueChange } from '@/utils/eventLogger';
@@ -70,9 +68,7 @@ const UpdateReadingGoalModal = ({ isDisabled, goal }: UpdateReadingGoalButtonPro
   const chaptersData = useContext(DataContext);
   const [isModalVisible, setIsModalVisible] = useState(false);
 
-  const quranFont = useSelector(selectQuranFont, shallowEqual);
-  const mushafLines = useSelector(selectQuranMushafLines, shallowEqual);
-  const { mushaf } = getMushafId(quranFont, mushafLines);
+  const mushaf = useGetMushaf();
   const dayOptions = useMemo(() => generateDurationDaysOptions(t, lang), [t, lang]);
 
   const [isContinuous, setIsContinuous] = useState(!!goal.duration);

--- a/src/components/ReadingGoalPage/index.tsx
+++ b/src/components/ReadingGoalPage/index.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable react-func/max-lines-per-function */
 /* eslint-disable max-lines */
-import { useState, useContext, useCallback } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
-import { shallowEqual, useSelector } from 'react-redux';
 import { useSWRConfig } from 'swr';
 
 import useReadingGoalReducer, { ReadingGoalTabProps } from './hooks/useReadingGoalReducer';
@@ -18,12 +17,11 @@ import Button, { ButtonSize, ButtonType } from '@/dls/Button/Button';
 import Progress from '@/dls/Progress';
 import Spinner, { SpinnerSize } from '@/dls/Spinner/Spinner';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
+import useGetMushaf from '@/hooks/useGetMushaf';
 import ChevronLeftIcon from '@/icons/chevron-left.svg';
 import ChevronRightIcon from '@/icons/chevron-right.svg';
 import layoutStyle from '@/pages/index.module.scss';
-import { selectQuranFont, selectQuranMushafLines } from '@/redux/slices/QuranReader/styles';
-import { CreateGoalRequest, QuranGoalPeriod, GoalType, GoalCategory } from '@/types/auth/Goal';
-import { getMushafId } from '@/utils/api';
+import { CreateGoalRequest, GoalCategory, GoalType, QuranGoalPeriod } from '@/types/auth/Goal';
 import { addReadingGoal } from '@/utils/auth/api';
 import { makeStreakUrl } from '@/utils/auth/apiPaths';
 import { logFormSubmission } from '@/utils/eventLogger';
@@ -32,10 +30,7 @@ const ReadingGoalOnboarding: React.FC = () => {
   const { t } = useTranslation('reading-goal');
   const router = useRouter();
   const chaptersData = useContext(DataContext);
-
-  const quranFont = useSelector(selectQuranFont, shallowEqual);
-  const mushafLines = useSelector(selectQuranMushafLines, shallowEqual);
-  const { mushaf } = getMushafId(quranFont, mushafLines);
+  const mushaf = useGetMushaf();
 
   const [loading, setLoading] = useState(false);
   const [tabIdx, setTabIdx] = useState(0);
@@ -124,12 +119,16 @@ const ReadingGoalOnboarding: React.FC = () => {
     if (Tab.key === TabKey.ExamplesTab && !state.exampleKey) return true;
 
     if (Tab.key === TabKey.AmountTab) {
-      return !validateReadingGoalData(chaptersData, {
-        type: state.type,
-        pages: state.pages,
-        seconds: state.seconds,
-        range: { startVerse: state.rangeStartVerse, endVerse: state.rangeEndVerse },
-      });
+      return !validateReadingGoalData(
+        chaptersData,
+        {
+          type: state.type,
+          pages: state.pages,
+          seconds: state.seconds,
+          range: { startVerse: state.rangeStartVerse, endVerse: state.rangeEndVerse },
+        },
+        mushaf,
+      );
     }
 
     return false;

--- a/src/components/ReadingGoalPage/utils/validator.ts
+++ b/src/components/ReadingGoalPage/utils/validator.ts
@@ -1,9 +1,9 @@
 /* eslint-disable import/prefer-default-export */
-import { Mushaf } from '@/types/QuranReader';
 import { isValidPageIdBySelectedMushafId, isValidVerseKey } from '@/utils/validator';
 import { getVerseAndChapterNumbersFromKey } from '@/utils/verse';
 import { GoalType } from 'types/auth/Goal';
 import ChaptersData from 'types/ChaptersData';
+import { Mushaf } from 'types/QuranReader';
 
 const SECONDS_LIMIT = 4 * 60 * 60; // 4 hours
 const MIN_SECONDS = 60; // 1 minute

--- a/src/components/ReadingGoalPage/utils/validator.ts
+++ b/src/components/ReadingGoalPage/utils/validator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import { isValidPageIdBySelectedMushafId, isValidVerseKey } from '@/utils/validator';
+import { isValidPageNumber, isValidVerseKey } from '@/utils/validator';
 import { getVerseAndChapterNumbersFromKey } from '@/utils/verse';
 import { GoalType } from 'types/auth/Goal';
 import ChaptersData from 'types/ChaptersData';
@@ -30,10 +30,10 @@ interface ReadingGoalPayload {
 export const validateReadingGoalData = (
   chaptersData: ChaptersData,
   { type, pages, seconds, range }: ReadingGoalPayload,
-  mushafId: Mushaf = Mushaf.QCFV1,
+  mushafId: Mushaf,
 ): boolean => {
   // if the user selected a pages goal and didn't enter a valid amount of pages, disable the next button
-  if (type === GoalType.PAGES && !isValidPageIdBySelectedMushafId(pages, mushafId)) return false;
+  if (type === GoalType.PAGES && !isValidPageNumber(pages, mushafId)) return false;
 
   // if the user selected a time goal and didn't enter a valid amount of seconds, disable the next button
   // in theory, this should never happen because the input is a select, but just in case

--- a/src/components/ReadingGoalPage/utils/validator.ts
+++ b/src/components/ReadingGoalPage/utils/validator.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
-import { isValidPageId, isValidVerseKey } from '@/utils/validator';
+import { Mushaf } from '@/types/QuranReader';
+import { isValidPageIdBySelectedMushafId, isValidVerseKey } from '@/utils/validator';
 import { getVerseAndChapterNumbersFromKey } from '@/utils/verse';
 import { GoalType } from 'types/auth/Goal';
 import ChaptersData from 'types/ChaptersData';
@@ -29,9 +30,10 @@ interface ReadingGoalPayload {
 export const validateReadingGoalData = (
   chaptersData: ChaptersData,
   { type, pages, seconds, range }: ReadingGoalPayload,
+  mushafId: Mushaf = Mushaf.QCFV1,
 ): boolean => {
   // if the user selected a pages goal and didn't enter a valid amount of pages, disable the next button
-  if (type === GoalType.PAGES && !isValidPageId(pages)) return false;
+  if (type === GoalType.PAGES && !isValidPageIdBySelectedMushafId(pages, mushafId)) return false;
 
   // if the user selected a time goal and didn't enter a valid amount of seconds, disable the next button
   // in theory, this should never happen because the input is a select, but just in case

--- a/src/pages/page/[pageId].tsx
+++ b/src/pages/page/[pageId].tsx
@@ -21,7 +21,7 @@ import {
 import { isValidPageNumber } from '@/utils/validator';
 import { VersesResponse } from 'types/ApiResponses';
 import ChaptersData from 'types/ChaptersData';
-import { QuranReaderDataType } from 'types/QuranReader';
+import { Mushaf, QuranReaderDataType } from 'types/QuranReader';
 
 interface Props {
   pageVerses: VersesResponse;
@@ -66,9 +66,10 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
     getQuranReaderStylesInitialState(locale).quranFont,
     getQuranReaderStylesInitialState(locale).mushafLines,
   ).mushaf;
+  const LONGEST_MUSHAF_ID = Mushaf.Indopak15Lines;
 
   // we need to validate the pageId first to save calling BE since we haven't set the valid paths inside getStaticPaths to avoid pre-rendering them at build time.
-  if (!isValidPageNumber(pageIdNumber, defaultMushafId)) {
+  if (!isValidPageNumber(pageIdNumber, LONGEST_MUSHAF_ID)) {
     return {
       notFound: true,
     };

--- a/src/pages/page/[pageId].tsx
+++ b/src/pages/page/[pageId].tsx
@@ -18,7 +18,7 @@ import {
   ONE_WEEK_REVALIDATION_PERIOD_SECONDS,
   REVALIDATION_PERIOD_ON_ERROR_SECONDS,
 } from '@/utils/staticPageGeneration';
-import { isValidPageId } from '@/utils/validator';
+import { isValidPageNumber } from '@/utils/validator';
 import { VersesResponse } from 'types/ApiResponses';
 import ChaptersData from 'types/ChaptersData';
 import { QuranReaderDataType } from 'types/QuranReader';
@@ -62,22 +62,22 @@ const QuranicPage: NextPage<Props> = ({ hasError, pageVerses }) => {
 // eslint-disable-next-line react-func/max-lines-per-function
 export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
   const pageIdNumber = Number(params.pageId);
-  // we need to validate the pageId first to save calling BE since we haven't set the valid paths inside getStaticPaths to avoid pre-rendering them at build time.
-  if (!isValidPageId(pageIdNumber)) {
-    return {
-      notFound: true,
-    };
-  }
-
   const defaultMushafId = getMushafId(
     getQuranReaderStylesInitialState(locale).quranFont,
     getQuranReaderStylesInitialState(locale).mushafLines,
   ).mushaf;
 
+  // we need to validate the pageId first to save calling BE since we haven't set the valid paths inside getStaticPaths to avoid pre-rendering them at build time.
+  if (!isValidPageNumber(pageIdNumber, defaultMushafId)) {
+    return {
+      notFound: true,
+    };
+  }
+
   // The defaultMushafId is 2 representing the Madinah Mushaf
   // PAGES_MUSHAF_MAP will return the mushaf total number of pages when passed a mushafId
   // Mushaf ID: 2 (Madinah) -> Pages Count: 604 pages
-  const defaultMushafPagesCount = PAGES_MUSHAF_MAP[Number(defaultMushafId)];
+  const defaultMushafPagesCount = PAGES_MUSHAF_MAP[defaultMushafId];
   // In case the requested page/[pageId] is greater than the SSR loaded default mushaf total pages count
   // we set the pageId to the last available page, otherwise we load the passed pageID
   const pageId =

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -124,35 +124,12 @@ export const isValidHizbId = (hizbId: string): boolean => {
  * Validate a pageId which can be in-valid in 2 cases:
  *
  * 1. if it's a string that is not numeric e.g. "test".
- * 2. if it's a numeric string but lies outside the range 1->610.
- *
- * @param {string | number} pageId
- * @returns {boolean}
- */
-export const isValidPageId = (pageId: string | number): boolean => {
-  const pageIdNumber = Number(pageId);
-  const LONGEST_MUSHAF = Mushaf.Indopak15Lines;
-  const LONGEST_MUSHAF_COUNT = PAGES_MUSHAF_MAP[LONGEST_MUSHAF];
-  // if it's not a numeric string or it's numeric but out of the range of chapter 1->610
-  if (Number.isNaN(pageIdNumber) || pageIdNumber > LONGEST_MUSHAF_COUNT || pageIdNumber < 1) {
-    return false;
-  }
-  return true;
-};
-
-/**
- * Validate a pageId which can be in-valid in 2 cases:
- *
- * 1. if it's a string that is not numeric e.g. "test".
  * 2. if it's a numeric string but lies outside the range of the selected Mushaf.
  *
  * @param {string | number} pageId
  * @returns {boolean}
  */
-export const isValidPageIdBySelectedMushafId = (
-  pageId: string | number,
-  mushafId: Mushaf,
-): boolean => {
+export const isValidPageNumber = (pageId: string | number, mushafId: Mushaf): boolean => {
   const pageIdNumber = Number(pageId);
   const MUSHAF_COUNT = PAGES_MUSHAF_MAP[mushafId];
   // if it's not a numeric string or it's numeric but out of the range of the selected Mushaf

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -124,7 +124,7 @@ export const isValidHizbId = (hizbId: string): boolean => {
  * Validate a pageId which can be in-valid in 2 cases:
  *
  * 1. if it's a string that is not numeric e.g. "test".
- * 2. if it's a numeric string but lies outside the range 1->604.
+ * 2. if it's a numeric string but lies outside the range 1->610.
  *
  * @param {string | number} pageId
  * @returns {boolean}
@@ -133,8 +133,30 @@ export const isValidPageId = (pageId: string | number): boolean => {
   const pageIdNumber = Number(pageId);
   const LONGEST_MUSHAF = Mushaf.Indopak15Lines;
   const LONGEST_MUSHAF_COUNT = PAGES_MUSHAF_MAP[LONGEST_MUSHAF];
-  // if it's not a numeric string or it's numeric but out of the range of chapter 1->604
+  // if it's not a numeric string or it's numeric but out of the range of chapter 1->610
   if (Number.isNaN(pageIdNumber) || pageIdNumber > LONGEST_MUSHAF_COUNT || pageIdNumber < 1) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Validate a pageId which can be in-valid in 2 cases:
+ *
+ * 1. if it's a string that is not numeric e.g. "test".
+ * 2. if it's a numeric string but lies outside the range of the selected Mushaf.
+ *
+ * @param {string | number} pageId
+ * @returns {boolean}
+ */
+export const isValidPageIdBySelectedMushafId = (
+  pageId: string | number,
+  mushafId: Mushaf,
+): boolean => {
+  const pageIdNumber = Number(pageId);
+  const MUSHAF_COUNT = PAGES_MUSHAF_MAP[mushafId];
+  // if it's not a numeric string or it's numeric but out of the range of the selected Mushaf
+  if (Number.isNaN(pageIdNumber) || pageIdNumber > MUSHAF_COUNT || pageIdNumber < 1) {
     return false;
   }
   return true;


### PR DESCRIPTION
# Summary

Fixes #QF-433

In creating or updating a goal the button will be disabled if the page number is outside the range of the selected Mushaf settings 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

I created and updated a goal using different Mushaf settings and the button is disabled when I type a page number that is greater than the Mushaf pages count:

- Indopak 15 lines
- Indopak 16 lines
- Uthmani

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
