### PR TITLE
Fix withAuth

### DIFF
--- a/src/components/Auth/withAuth.tsx
+++ b/src/components/Auth/withAuth.tsx
@@ -1,10 +1,37 @@
+import { JSX, useEffect, useState } from 'react';
+
 import RedirectToLoginPage from './RedirectToLoginPage';
 
 import { isLoggedIn } from '@/utils/auth/login';
+/**
+ * withAuth is a Higher-Order Component (HOC) that wraps a component and checks if the user is authenticated.
+ * If the user is authenticated, it renders the wrapped component.
+ * If the user is not authenticated, it redirects the user to the login page.
+ *
+ * @param {React.ComponentType} WrappedComponent - The component to wrap and protect with authentication check.
+ *
+ * @returns {React.ComponentType} If the user is authenticated, returns the WrappedComponent.
+ * If not, returns RedirectToLoginPage component.
+ *
+ * @example
+ * const ProtectedComponent = withAuth(MyComponent);
+ */
+const withAuth = (WrappedComponent: React.ComponentType): React.ComponentType => {
+  const WithAuth = (props: JSX.IntrinsicAttributes) => {
+    const [isReady, setIsReady] = useState(false);
 
-// This HOC is used to check if the user is logged in or not.
-const withAuth = (WrappedComponent) => {
-  const WithAuth = (props) => {
+    /**
+     * we need to wait for the initial render to check if the user is authenticated
+     * because when it's server-side rendered, the user is not authenticated yet
+     */
+    useEffect(() => {
+      setIsReady(true);
+    }, []);
+
+    if (!isReady) {
+      return null; // or return a loading spinner
+    }
+
     return isLoggedIn() ? <WrappedComponent {...props} /> : <RedirectToLoginPage />;
   };
 


### PR DESCRIPTION
# Summary

Fixes #QF-440

This PR fixes issue with pages wrapped with HOC `withAuth` that causes them to be blank when accessed directly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

1. Open your [Your Progress](https://quran.com/reading-goal/progress) page directly or open it from user dropdown then refresh the page.
2. The page should be rendered as expected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="1728" alt="cce7bc77-08ca-41e9-84cd-a6a03a2a5c23" src="https://github.com/quran/quran.com-frontend-next/assets/15169499/50773889-2be4-419b-998f-947e72f5e450"> | <img width="1724" alt="Screenshot 2024-05-18 at 11 09 40 AM" src="https://github.com/quran/quran.com-frontend-next/assets/15169499/095a4436-c835-47cc-ba6b-8b509c24d4b0"> |