### PR TITLE
migrate tajweed mushaf to the latest version

### DIFF
--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -234,7 +234,7 @@ export default {
     ...state,
     quranReaderStyles: {
       ...state.quranReaderStyles,
-      quranFont: QuranFont.TajweedV4,
+      quranFont: state.quranFont === QuranFont.Tajweed ? QuranFont.TajweedV4 : state.quranFont,
     },
   }),
 };

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -234,7 +234,9 @@ export default {
     ...state,
     quranReaderStyles: {
       ...state.quranReaderStyles,
-      quranFont: state.quranFont === QuranFont.Tajweed ? QuranFont.TajweedV4 : state.quranFont,
+      ...(state.quranFont === QuranFont.Tajweed && {
+        quranFont: QuranFont.TajweedV4,
+      }),
     },
   }),
 };

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -234,7 +234,7 @@ export default {
     ...state,
     quranReaderStyles: {
       ...state.quranReaderStyles,
-      ...(state.quranFont === QuranFont.Tajweed && {
+      ...(state.quranReaderStyles.quranFont === QuranFont.Tajweed && {
         quranFont: QuranFont.TajweedV4,
       }),
     },

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -5,7 +5,7 @@ import { initialSidebarIsVisible } from './slices/QuranReader/sidebarNavigation'
 import { initialState as welcomeMessageInitialState } from './slices/welcomeMessage';
 
 import { consolidateWordByWordState, getDefaultWordByWordDisplay } from '@/utils/wordByWord';
-import { MushafLines } from 'types/QuranReader';
+import { MushafLines, QuranFont } from 'types/QuranReader';
 
 export default {
   3: (state) => ({
@@ -228,6 +228,13 @@ export default {
     quranReaderStyles: {
       ...state.quranReaderStyles,
       wordByWordFontScale: initialState.quranReaderStyles.wordByWordFontScale,
+    },
+  }),
+  31: (state) => ({
+    ...state,
+    quranReaderStyles: {
+      ...state.quranReaderStyles,
+      quranFont: QuranFont.TajweedV4,
     },
   }),
 };

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -45,7 +45,7 @@ import SliceName from './types/SliceName';
 
 const persistConfig = {
   key: 'root',
-  version: 30,
+  version: 31,
   storage,
   migrate: createMigrate(migrations, {
     debug: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development',


### PR DESCRIPTION
# Summary

Fixes #482

Update redux persist migrations to overwrite `tajweed` quran font to `tajweed_v4`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

I have checked the local storage and redux devtools to make sure that the `quranFont` property is set to the newer version but still showing the old version if I selected the `tajweed` mushaf from the settings.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
