### PR TITLE
prevent decimal and show numberic input on mobile

### DIFF
--- a/src/components/ReadingGoal/ReadingGoalInput/index.tsx
+++ b/src/components/ReadingGoal/ReadingGoalInput/index.tsx
@@ -69,6 +69,8 @@ const ReadingGoalInput: React.FC<ReadingGoalInputProps> = ({
           value={pages.toString()}
           fixedWidth={false}
           htmlType="number"
+          onKeyDown={(e) => e.key === '.' && e.preventDefault()}
+          inputMode="numeric"
           onChange={(p) => {
             const parsedPages = Number(p);
             onPagesChange(parsedPages);

--- a/src/components/ReadingGoal/ReadingGoalInput/index.tsx
+++ b/src/components/ReadingGoal/ReadingGoalInput/index.tsx
@@ -69,6 +69,7 @@ const ReadingGoalInput: React.FC<ReadingGoalInputProps> = ({
           value={pages.toString()}
           fixedWidth={false}
           htmlType="number"
+          // prevent users from entering decimal value
           onKeyDown={(e) => e.key === '.' && e.preventDefault()}
           inputMode="numeric"
           onChange={(p) => {

--- a/src/components/dls/Forms/Input/index.tsx
+++ b/src/components/dls/Forms/Input/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import React, {
   ReactNode,
   useState,

--- a/src/components/dls/Forms/Input/index.tsx
+++ b/src/components/dls/Forms/Input/index.tsx
@@ -45,7 +45,7 @@ interface Props {
   onClearClicked?: () => void;
   onChange?: (value: string) => void;
   onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
-  inputMode: HTMLAttributes<HTMLInputElement>['inputMode'];
+  inputMode?: HTMLAttributes<HTMLInputElement>['inputMode'];
   value?: string;
   label?: string | JSX.Element;
   type?: InputType;

--- a/src/components/dls/Forms/Input/index.tsx
+++ b/src/components/dls/Forms/Input/index.tsx
@@ -1,4 +1,12 @@
-import React, { ReactNode, useState, useEffect, ChangeEvent, RefObject } from 'react';
+import React, {
+  ReactNode,
+  useState,
+  useEffect,
+  ChangeEvent,
+  RefObject,
+  KeyboardEvent,
+  HTMLAttributes,
+} from 'react';
 
 import classNames from 'classnames';
 
@@ -36,6 +44,8 @@ interface Props {
   suffix?: ReactNode;
   onClearClicked?: () => void;
   onChange?: (value: string) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
+  inputMode: HTMLAttributes<HTMLInputElement>['inputMode'];
   value?: string;
   label?: string | JSX.Element;
   type?: InputType;
@@ -62,6 +72,8 @@ const Input: React.FC<Props> = ({
   suffix,
   onClearClicked,
   onChange,
+  onKeyDown,
+  inputMode,
   value = '',
   shouldFlipOnRTL = true,
   containerClassName,
@@ -117,6 +129,8 @@ const Input: React.FC<Props> = ({
           disabled={disabled}
           onChange={onValueChange}
           value={inputValue}
+          onKeyDown={onKeyDown}
+          inputMode={inputMode}
           {...(placeholder && { placeholder })}
           {...(name && { name })}
         />


### PR DESCRIPTION
# Summary

Fixes #QF-470

prevent decimal values on create/edit goal input and show numeric keyboard on mobiles.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

This has been tested on chrome.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
