### PR TITLE
Fix indopak translation mode missing ayahs

### DIFF
--- a/src/components/QuranReader/hooks/useFetchPageVerses.ts
+++ b/src/components/QuranReader/hooks/useFetchPageVerses.ts
@@ -4,6 +4,7 @@ import useSWRImmutable from 'swr/immutable';
 
 import { getPageVerses } from '@/api';
 import useGetMushaf from '@/hooks/useGetMushaf';
+import getPageVersesParams from '@/pages/page/utils/getPageVersesParams';
 import { selectIsUsingDefaultFont, selectQuranFont } from '@/redux/slices/QuranReader/styles';
 import { VersesResponse } from '@/types/ApiResponses';
 import { getDefaultWordFields } from '@/utils/api';
@@ -23,13 +24,7 @@ const useFetchPageVerses = (pageId: string, initialData: VersesResponse) => {
   const quranFont = useSelector(selectQuranFont, shallowEqual);
   const isUsingDefaultFont = useSelector(selectIsUsingDefaultFont);
   const mushafId = useGetMushaf();
-
-  const params = {
-    perPage: 'all',
-    mushaf: mushafId,
-    filterPageWords: true,
-    ...getDefaultWordFields(quranFont),
-  };
+  const params = getPageVersesParams(mushafId, getDefaultWordFields(quranFont));
 
   const { data, isValidating, error } = useSWRImmutable(
     makePageVersesUrl(pageId, locale, params),

--- a/src/components/QuranReader/hooks/useFetchPageVerses.ts
+++ b/src/components/QuranReader/hooks/useFetchPageVerses.ts
@@ -18,7 +18,7 @@ import { makePageVersesUrl } from '@/utils/apiPaths';
  * @returns {{ pageVersesResponse: VersesResponse; isLoading: boolean; error: any }}
  */
 
-const useGetPageVersesResponse = (pageId: string, initialData: VersesResponse) => {
+const useFetchPageVerses = (pageId: string, initialData: VersesResponse) => {
   const { lang: locale } = useTranslation();
   const quranFont = useSelector(selectQuranFont, shallowEqual);
   const isUsingDefaultFont = useSelector(selectIsUsingDefaultFont);
@@ -43,4 +43,4 @@ const useGetPageVersesResponse = (pageId: string, initialData: VersesResponse) =
   return { isLoading: isValidating, data, error };
 };
 
-export default useGetPageVersesResponse;
+export default useFetchPageVerses;

--- a/src/components/QuranReader/hooks/useFetchPagesLookup.ts
+++ b/src/components/QuranReader/hooks/useFetchPagesLookup.ts
@@ -55,7 +55,7 @@ const useFetchPagesLookup = (
     pagesVersesRange: data.pages,
     lookupRange: data.lookupRange,
     hasError: !!error,
-    isLoading: isValidating,
+    isLoading: isValidating && !data,
   };
 };
 

--- a/src/components/QuranReader/hooks/useFetchPagesLookup.ts
+++ b/src/components/QuranReader/hooks/useFetchPagesLookup.ts
@@ -28,6 +28,7 @@ const useFetchPagesLookup = (
   quranReaderStyles: QuranReaderStyles,
   isUsingDefaultFont: boolean,
 ): {
+  data: PagesLookUpResponse;
   pagesCount: number;
   hasError: boolean;
   pagesVersesRange: Record<number, LookupRecord>;
@@ -51,6 +52,7 @@ const useFetchPagesLookup = (
   );
 
   return {
+    data,
     pagesCount: data.totalPage,
     pagesVersesRange: data.pages,
     lookupRange: data.lookupRange,

--- a/src/pages/page/[pageId].tsx
+++ b/src/pages/page/[pageId].tsx
@@ -57,7 +57,7 @@ const QuranicPage: NextPage<Props> = ({ hasError, pageVerses: initialData }) => 
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
 
   const {
-    lookupRange: pagesLookupData,
+    data: pagesLookupData,
     isLoading: isPagesLookupLoading,
     hasError: pagesLookupError,
   } = useFetchPagesLookup(
@@ -145,7 +145,7 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
     return {
       props: {
         chaptersData,
-        pageVerses: getQuranReaderData(pagesLookupResponse.lookupRange, pageVersesResponse),
+        pageVerses: getQuranReaderData(pagesLookupResponse, pageVersesResponse),
       },
       revalidate: ONE_WEEK_REVALIDATION_PERIOD_SECONDS, // verses will be generated at runtime if not found in the cache, then cached for subsequent requests for 7 days.
     };

--- a/src/pages/page/[pageId].tsx
+++ b/src/pages/page/[pageId].tsx
@@ -3,12 +3,11 @@ import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useSelector } from 'react-redux';
 
-import useGetPageVersesResponse from './hooks/useGetPageVersesResponse';
-
 import { getPagesLookup, getPageVerses } from '@/api';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
 import QuranReader from '@/components/QuranReader';
 import useFetchPagesLookup from '@/components/QuranReader/hooks/useFetchPagesLookup';
+import useFetchPageVerses from '@/components/QuranReader/hooks/useFetchPageVerses';
 import Spinner from '@/dls/Spinner/Spinner';
 import useGetMushaf from '@/hooks/useGetMushaf';
 import Error from '@/pages/_error';
@@ -49,7 +48,7 @@ const QuranicPage: NextPage<Props> = ({ hasError, pageVerses: initialData }) => 
     data: pageVersesData,
     isLoading: isPageVersesLoading,
     error: pageVersesError,
-  } = useGetPageVersesResponse(String(pageId), initialData);
+  } = useFetchPageVerses(String(pageId), initialData);
 
   const isUsingDefaultFont = useSelector(selectIsUsingDefaultFont);
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);

--- a/src/pages/page/hooks/useGetPageVersesResponse.ts
+++ b/src/pages/page/hooks/useGetPageVersesResponse.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import useTranslation from 'next-translate/useTranslation';
+
+import { getPageVerses } from '@/api';
+import useGetMushaf from '@/hooks/useGetMushaf';
+import { getQuranReaderStylesInitialState } from '@/redux/defaultSettings/util';
+import { VersesResponse } from '@/types/ApiResponses';
+import { getDefaultWordFields } from '@/utils/api';
+
+/**
+ * This hooks fetches the page's verses data by the pageId
+ *
+ * @param {string} pageId
+ *
+ * @returns {{ pageVersesResponse: VersesResponse; isLoading: boolean; error: any }}
+ */
+
+const useGetPageVersesResponse = (pageId: string) => {
+  const [data, setData] = useState<VersesResponse>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState();
+  const mushafId = useGetMushaf();
+  const { lang: locale } = useTranslation();
+
+  useEffect(() => {
+    const getData = async () => {
+      try {
+        const pageVersesResponse = await getPageVerses(pageId, locale, {
+          perPage: 'all',
+          mushaf: mushafId,
+          filterPageWords: true,
+          ...getDefaultWordFields(getQuranReaderStylesInitialState(locale).quranFont),
+        });
+
+        setData(pageVersesResponse);
+      } catch (e) {
+        setError(e);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    getData();
+  }, [locale, mushafId, pageId]);
+
+  return { isLoading, pageVersesResponse: data, error };
+};
+
+export default useGetPageVersesResponse;

--- a/src/pages/page/utils/getPageVersesParams.ts
+++ b/src/pages/page/utils/getPageVersesParams.ts
@@ -1,0 +1,12 @@
+import { Mushaf } from '@/types/QuranReader';
+
+const getPageVersesParams = (mushafId: Mushaf, wordFields: { wordFields: string }) => {
+  return {
+    perPage: 'all',
+    mushaf: mushafId,
+    filterPageWords: true,
+    ...wordFields,
+  };
+};
+
+export default getPageVersesParams;

--- a/src/pages/page/utils/getQuranReaderData.ts
+++ b/src/pages/page/utils/getQuranReaderData.ts
@@ -1,0 +1,12 @@
+import { VersesResponse } from '@/types/ApiResponses';
+import LookupRange from '@/types/LookupRange';
+
+const getQuranReaderData = (pagesLookupData: LookupRange, pageVersesData: VersesResponse) => {
+  return {
+    ...pageVersesData,
+    pageVerses: { pagesLookup: pagesLookupData },
+    metaData: { numberOfVerses: pageVersesData.verses.length },
+  };
+};
+
+export default getQuranReaderData;

--- a/src/pages/page/utils/getQuranReaderData.ts
+++ b/src/pages/page/utils/getQuranReaderData.ts
@@ -1,7 +1,9 @@
-import { VersesResponse } from '@/types/ApiResponses';
-import LookupRange from '@/types/LookupRange';
+import { PagesLookUpResponse, VersesResponse } from '@/types/ApiResponses';
 
-const getQuranReaderData = (pagesLookupData: LookupRange, pageVersesData: VersesResponse) => {
+const getQuranReaderData = (
+  pagesLookupData: PagesLookUpResponse,
+  pageVersesData: VersesResponse,
+) => {
   return {
     ...pageVersesData,
     pageVerses: { pagesLookup: pagesLookupData },


### PR DESCRIPTION
# Summary

Fixes #QF-469

Fetch page's verses data on the client to specify the select mushaf ID instead of always using the default mushaf ID which is Uthmani.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

This has been tested on chrome with different pages following this route: `/page/[pageId]` using Indopak, 15 lines, translation mode.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| ![Screenshot 2024-06-09 at 12 12 54 PM](https://github.com/quran/quran.com-frontend-next/assets/8735775/1524b4ee-ecc9-4121-b7ab-41a3aff36a1b) | ![Screenshot 2024-06-09 at 12 13 08 PM](https://github.com/quran/quran.com-frontend-next/assets/8735775/50e7f0cd-9f91-4089-9def-9d3ec85f9dc9) |