### PR TITLE
[Issue #2145] Updated popover color in darkmode

### DIFF
--- a/src/components/dls/Popover/Popover.module.scss
+++ b/src/components/dls/Popover/Popover.module.scss
@@ -16,10 +16,10 @@
   padding-block-end: var(--spacing-xsmall);
   padding-inline-start: var(--spacing-xsmall);
   padding-inline-end: var(--spacing-xsmall);
-  background-color: var(--color-background-default);
+  background-color: var(--color-background-alternative-faint);
   box-shadow: var(--shadow-normal);
   & > span {
-    fill: var(--color-background-default);
+    fill: var(--color-background-alternative-faint);
   }
 }
 


### PR DESCRIPTION
# Summary

Fixes #2145

This pull request addresses issue #2145, which highlights a color contrast problem with the popover component in dark mode. The background color of the popover was previously too similar to the main background, making it difficult to distinguish and reducing readability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

This pull request has been tested by manually verifying the new popover background color in dark mode to ensure it provides sufficient contrast against the main background. Additionally, it was confirmed that the changes do not affect the popover's appearance in light mode.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| 
![Screenshot (170)](https://github.com/quran/quran.com-frontend-next/assets/65947373/4339e43d-8287-4064-b0ec-512fd08c81fa)
 | ![Screenshot (171)](https://github.com/quran/quran.com-frontend-next/assets/65947373/90ad6fd4-028e-4bbf-83f8-9652b1c39061) |
