### PR TITLE
QF-1056 disable auto-translate for media generator content

### DIFF
--- a/src/components/MediaMaker/Content/index.tsx
+++ b/src/components/MediaMaker/Content/index.tsx
@@ -89,6 +89,7 @@ const MediaMakerContent: React.FC<Props> = ({
       style={{
         justifyContent: 'center',
       }}
+      translate="no"
     >
       <div className={styles.videoContainer}>
         <Video loop src={videoPath} />


### PR DESCRIPTION
# Summary

Fixes #QF-1056

This PR disables browser's auto-translating content of the media generator.