### PR TITLE
chore: update Node.js engine version to 20.x in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "node": "18.x"
+    "node": "20.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Summary

update node engines to 20.x

- v18 support will end soon, so upgrading to v20 ensures you receive security updates for a longer period.
- Node.js v20 will have long-term support (LTS) until April 2026, making it a safer choice for long-term projects.

[endoflife v18](https://endoflife.date/nodejs)
<img width="735" alt="image" src="https://github.com/user-attachments/assets/ec31fb4a-35db-41d1-837a-4de5baeac49e">



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
