### PR TITLE
about-us list style change

### DIFF
--- a/src/pages/contentPage.module.scss
+++ b/src/pages/contentPage.module.scss
@@ -1,12 +1,11 @@
-@use "src/styles/breakpoints";
-
+@use 'src/styles/breakpoints';
 .contentPage {
   margin: auto;
   @include breakpoints.desktop {
-    width: 65%;
+    inline-size: 65%;
   }
   @include breakpoints.smallerThanDesktop {
-    width: 90%;
+    inline-size: 90%;
   }
   * {
     line-height: calc(1.3 * var(--line-height-xlarge));
@@ -71,6 +70,9 @@
 .list {
   list-style: unset;
   padding-inline-start: var(--spacing-mega);
+  @media (max-width: breakpoints.$breakpoints-mobileL) {
+    padding-inline-start: 0;
+  }
 }
 
 .underline {


### PR DESCRIPTION
# Summary
Updated the styling of the class .list to make it suitable for the mobile viewers

Fixes #JIRA-TICKET

A brief description for the PR.
The pointers on the about us page had padding-inline-start which was similar for all the devices by default and added an extra padding for mobile users so I checked the I added media property to check If the user is on mobile and if yes then remove the extra padding to ensure proper styling 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

This should state how this PR have been tested.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/adba415a-93ff-4f1f-811b-a2889691f871) | ![image](https://github.com/user-attachments/assets/ec18fbb0-32f1-4306-b1f2-c536402bf7a0) |
