### PR TITLE
fix stretched images in apps page

### DIFF
--- a/src/pages/apps.module.scss
+++ b/src/pages/apps.module.scss
@@ -50,6 +50,7 @@
 
 .appImage {
   max-height: calc(13 * var(--spacing-mega));
+  width: auto;
 }
 
 .downloadButtonsContainer {


### PR DESCRIPTION
# Summary

Fixed stretched images in [mobile apps](https://quran.com/apps) page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| ![quran com_apps](https://github.com/user-attachments/assets/80ced42b-fcad-428b-9007-550e637aa305) | ![quran com_apps (1)](https://github.com/user-attachments/assets/6aa6509d-1b2d-4fa1-b42a-c6480788e0e9) |
