### PR TITLE
updated logic which generated the copy text to include too many newli…

### DIFF
--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -72,12 +72,11 @@ const getTextToCopy = ({
 
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
-    const text = showRangeOfVerses
-      ? res.result
-      : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, ''); // remove trailing newlines
+    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n');
 
     // construct the final complete text for the clipboard
-    return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
+    // remove trailing newlines before the url
+    return `${surahInfoString}\n\n${text.replace(/\n+$/, '')}\n\n${verseUrl}`;
   });
 };
 

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -72,14 +72,10 @@ const getTextToCopy = ({
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
     const text = showRangeOfVerses
-    ? res.result
-    : res.result
-        .split('\n')
-        .slice(2)
-        .join('\n')
-        .replace(/\n+$/, ''); // remove trailing newlines
-  
-    // construct the final complete text for the clipboard 
+      ? res.result
+      : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, ''); // remove trailing newlines
+
+    // construct the final complete text for the clipboard copy feature
     return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -21,6 +21,7 @@ import { getAdvancedCopyRawResult } from 'src/api';
  * @param {object} options.chaptersData - The chapters data object
  * @returns {Promise<string>} textToCopy
  */
+// eslint-disable-next-line react-func/max-lines-per-function
 const getTextToCopy = ({
   verseKey,
   showRangeOfVerses,
@@ -75,7 +76,7 @@ const getTextToCopy = ({
       ? res.result
       : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, ''); // remove trailing newlines
 
-    // construct the final complete text for the clipboard copy feature
+    // construct the final complete text for the clipboard
     return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -71,9 +71,8 @@ const getTextToCopy = ({
 
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
-    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n'); // Remove the first 2 lines which contain the verse key
-
-    return `${surahInfoString}\n\n${text}${verseUrl}`;
+    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, '');    ; // Remove the first 2 lines which contain the verse key
+    return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };
 

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -71,7 +71,15 @@ const getTextToCopy = ({
 
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
-    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, '');    ; // Remove the first 2 lines which contain the verse key
+    const text = showRangeOfVerses
+    ? res.result
+    : res.result
+        .split('\n')
+        .slice(2)
+        .join('\n')
+        .replace(/\n+$/, ''); // remove trailing newlines
+  
+    // construct the final complete text for the clipboard 
     return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };


### PR DESCRIPTION
Closes #QF-2187

**before -- note all the newlines before the verse url** 

The Cow (2:19) 

أَوْ كَصَيِّبٍۢ مِّنَ ٱلسَّمَآءِ فِيهِ ظُلُمَـٰتٌۭ وَرَعْدٌۭ وَبَرْقٌۭ يَجْعَلُونَ أَصَـٰبِعَهُمْ فِىٓ ءَاذَانِهِم مِّنَ ٱلصَّوَٰعِقِ حَذَرَ ٱلْمَوْتِ ۚ وَٱللَّهُ مُحِيطٌۢ بِٱلْكَـٰفِرِينَ ١٩

Or ˹those caught in˺ a rainstorm from the sky with darkness, thunder, and lightning. They press their fingers into their ears at the sound of every thunder-clap for fear of death. And Allah encompasses the disbelievers ˹by His might˺.
— Dr. Mustafa Khattab, The Clear Quran

Or like a rainstorm from the sky, wherein is darkness, thunder, and lightning. They thrust their fingers in their ears to keep out the stunning thunder-clap for fear of death. But Allâh ever encompasses the disbelievers (i.e. Allâh will gather them all together).
— Al-Hilali &amp; Khan



https://quran.com/2/19


**after** 

The Cow (2:19) 

أَوْ كَصَيِّبٍۢ مِّنَ ٱلسَّمَآءِ فِيهِ ظُلُمَـٰتٌۭ وَرَعْدٌۭ وَبَرْقٌۭ يَجْعَلُونَ أَصَـٰبِعَهُمْ فِىٓ ءَاذَانِهِم مِّنَ ٱلصَّوَٰعِقِ حَذَرَ ٱلْمَوْتِ ۚ وَٱللَّهُ مُحِيطٌۢ بِٱلْكَـٰفِرِينَ ١٩

Or ˹those caught in˺ a rainstorm from the sky with darkness, thunder, and lightning. They press their fingers into their ears at the sound of every thunder-clap for fear of death. And Allah encompasses the disbelievers ˹by His might˺.
— Dr. Mustafa Khattab, The Clear Quran


Or like a rainstorm from the sky, wherein is darkness, thunder, and lightning. They thrust their fingers in their ears to keep out the stunning thunder-clap for fear of death. But Allâh ever encompasses the disbelievers (i.e. Allâh will gather them all together).
— Al-Hilali &amp; Khan

http://local.quran.com/2/19