### PR TITLE
Make ayah references in footnotes urls

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-danger */
 
-import React, { MouseEvent } from 'react';
+import React, { MouseEvent, useMemo } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
@@ -10,10 +10,10 @@ import transStyles from './TranslationText.module.scss';
 
 import Button, { ButtonSize, ButtonShape, ButtonVariant } from '@/dls/Button/Button';
 import Spinner from '@/dls/Spinner/Spinner';
-import useChapterIdsByUrlPath from '@/hooks/useChapterId';
 import CloseIcon from '@/icons/close.svg';
 import Language from '@/types/Language';
 import { getLanguageDataById, findLanguageIdByLocale } from '@/utils/locale';
+import { formatVerseReferencesToLinks } from '@/utils/string';
 import Footnote from 'types/Footnote';
 
 interface FootnoteTextProps {
@@ -33,32 +33,13 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
 }) => {
   const { t, lang } = useTranslation('quran-reader');
 
-  const chapterIds = useChapterIdsByUrlPath(lang);
-  const urlChapterId = chapterIds && chapterIds.length > 0 ? chapterIds[0] : null;
-
   const languageId = footnote?.languageId || findLanguageIdByLocale(lang as Language);
-  const landData = getLanguageDataById(languageId);
+  const languageData = getLanguageDataById(languageId);
 
-  const updatedText =
-    footnote && footnote.text
-      ? footnote.text.replace(/(\d{1,2}[:-]\d{1,2}(?:-\d{1,2})?)(?![^<]*<\/a>)/g, (match) => {
-          let formattedMatch = match;
-          let url = '/';
-
-          // If it's digit:digit or digit:digit-digit (e.g., 7:23 or 11:25-48)
-          if (match.includes(':')) {
-            formattedMatch = match.replace(':', '/'); // Replace ':' with '/' for correct URL format
-            url += formattedMatch;
-          }
-          // If it's digit-digit (e.g., 26-31), replace - with : and include urlChapterId
-          else if (match.includes('-')) {
-            formattedMatch = match.replace('-', ':'); // Replace '-' with ':' for correct URL format
-            url += `${urlChapterId}/${formattedMatch}`;
-          }
-
-          return `<a href="${url}" target="_blank">${match}</a>`;
-        })
-      : ''; // If footnote or footnote.text is null or undefined, fallback to an empty string
+  const updatedText = useMemo(() => {
+    if (!footnote?.text) return '';
+    return formatVerseReferencesToLinks(footnote.text);
+  }, [footnote?.text]);
 
   return (
     <div className={styles.footnoteContainer}>
@@ -81,8 +62,8 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
         <div
           className={classNames(
             styles.text,
-            transStyles[landData.direction],
-            transStyles[landData.font],
+            transStyles[languageData.direction],
+            transStyles[languageData.font],
           )}
           dangerouslySetInnerHTML={{ __html: updatedText }}
           {...(onTextClicked && { onClick: onTextClicked })}

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -72,12 +72,11 @@ const getTextToCopy = ({
 
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
-    const text = showRangeOfVerses
-      ? res.result
-      : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, ''); // remove trailing newlines
+    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n');
 
     // construct the final complete text for the clipboard
-    return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
+    // remove trailing newlines before the url
+    return `${surahInfoString}\n\n${text.replace(/\n+$/, '')}\n\n${verseUrl}`;
   });
 };
 

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -72,14 +72,10 @@ const getTextToCopy = ({
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
     const text = showRangeOfVerses
-    ? res.result
-    : res.result
-        .split('\n')
-        .slice(2)
-        .join('\n')
-        .replace(/\n+$/, ''); // remove trailing newlines
-  
-    // construct the final complete text for the clipboard 
+      ? res.result
+      : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, ''); // remove trailing newlines
+
+    // construct the final complete text for the clipboard copy feature
     return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -21,6 +21,7 @@ import { getAdvancedCopyRawResult } from 'src/api';
  * @param {object} options.chaptersData - The chapters data object
  * @returns {Promise<string>} textToCopy
  */
+// eslint-disable-next-line react-func/max-lines-per-function
 const getTextToCopy = ({
   verseKey,
   showRangeOfVerses,
@@ -75,7 +76,7 @@ const getTextToCopy = ({
       ? res.result
       : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, ''); // remove trailing newlines
 
-    // construct the final complete text for the clipboard copy feature
+    // construct the final complete text for the clipboard
     return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -71,9 +71,8 @@ const getTextToCopy = ({
 
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
-    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n'); // Remove the first 2 lines which contain the verse key
-
-    return `${surahInfoString}\n\n${text}${verseUrl}`;
+    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, '');    ; // Remove the first 2 lines which contain the verse key
+    return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };
 

--- a/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
+++ b/src/components/Verse/AdvancedCopy/utils/getTextCopy.ts
@@ -71,7 +71,15 @@ const getTextToCopy = ({
 
   // Get the result and format the final text
   return getAdvancedCopyRawResult(apiOptions).then((res) => {
-    const text = showRangeOfVerses ? res.result : res.result.split('\n').slice(2).join('\n').replace(/\n+$/, '');    ; // Remove the first 2 lines which contain the verse key
+    const text = showRangeOfVerses
+    ? res.result
+    : res.result
+        .split('\n')
+        .slice(2)
+        .join('\n')
+        .replace(/\n+$/, ''); // remove trailing newlines
+  
+    // construct the final complete text for the clipboard 
     return `${surahInfoString}\n\n${text}\n\n${verseUrl}`;
   });
 };

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { it, expect, describe } from 'vitest';
 
 import { truncateString, stripHTMLTags, formatVerseReferencesToLinks } from './string';
@@ -147,5 +148,103 @@ describe('Test formatVerseReferencesToLinks', () => {
     const input = '<script>const verse = "1:1";</script>';
     const expected = '<script>const verse = "<a href="/1:1" target="_blank">1:1</a>";</script>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  // Test cases for verse references in different languages
+  it('should convert verse references in English text', () => {
+    const input = 'This is a normal text with verse 1:1 and 2:3 in it';
+    const expected =
+      'This is a normal text with verse <a href="/1:1" target="_blank">1:1</a> and <a href="/2:3" target="_blank">2:3</a> in it';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in Arabic text', () => {
+    const input = 'هذا نص عادي يحتوي على الآية 1:1 والآية 2:3';
+    const expected =
+      'هذا نص عادي يحتوي على الآية <a href="/1:1" target="_blank">1:1</a> والآية <a href="/2:3" target="_blank">2:3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in French text', () => {
+    const input = 'Ceci est un texte normal avec le verset 1:1 et 2:3';
+    const expected =
+      'Ceci est un texte normal avec le verset <a href="/1:1" target="_blank">1:1</a> et <a href="/2:3" target="_blank">2:3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in Spanish text', () => {
+    const input = 'Este es un texto normal con el versículo 1:1 y 2:3';
+    const expected =
+      'Este es un texto normal con el versículo <a href="/1:1" target="_blank">1:1</a> y <a href="/2:3" target="_blank">2:3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in Chinese text', () => {
+    const input = '这是一个普通文本，包含经文 1:1 和 2:3';
+    const expected =
+      '这是一个普通文本，包含经文 <a href="/1:1" target="_blank">1:1</a> 和 <a href="/2:3" target="_blank">2:3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in Japanese text', () => {
+    const input = 'これは普通のテキストで、聖句 1:1 と 2:3 を含みます';
+    const expected =
+      'これは普通のテキストで、聖句 <a href="/1:1" target="_blank">1:1</a> と <a href="/2:3" target="_blank">2:3</a> を含みます';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in Korean text', () => {
+    const input = '이것은 일반 텍스트로, 성구 1:1과 2:3을 포함합니다';
+    const expected =
+      '이것은 일반 텍스트로, 성구 <a href="/1:1" target="_blank">1:1</a>과 <a href="/2:3" target="_blank">2:3</a>을 포함합니다';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references in Russian text', () => {
+    const input = 'Это обычный текст с аятом 1:1 и 2:3';
+    const expected =
+      'Это обычный текст с аятом <a href="/1:1" target="_blank">1:1</a> и <a href="/2:3" target="_blank">2:3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  // Test cases for text without verse references
+  it('should not modify English text without verse references', () => {
+    const input = 'This is a normal text without any verse references';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify Arabic text without verse references', () => {
+    const input = 'هذا نص عادي لا يحتوي على أي إشارات للآيات';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify French text without verse references', () => {
+    const input = 'Ceci est un texte normal sans aucune référence aux versets';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify Spanish text without verse references', () => {
+    const input = 'Este es un texto normal sin referencias a versículos';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify Chinese text without verse references', () => {
+    const input = '这是一个没有经文引用的普通文本';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify Japanese text without verse references', () => {
+    const input = 'これは聖句の参照を含まない通常のテキストです';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify Korean text without verse references', () => {
+    const input = '이것은 성구 참조가 없는 일반 텍스트입니다';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not modify Russian text without verse references', () => {
+    const input = 'Это обычный текст без ссылок на аяты';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
   });
 });

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, describe } from 'vitest';
 
-import { truncateString, stripHTMLTags } from './string';
+import { truncateString, stripHTMLTags, formatVerseReferencesToLinks } from './string';
 
 describe('Test truncateString', () => {
   it('should shorten english text correctly', () => {
@@ -39,5 +39,113 @@ describe('Test stripHTMLTags', () => {
     ).toEqual(
       'Which was revealed in MakkahThe Meaning of Al-Fatihah and its Various Names This Surah is called - Al-Fatihah, that is, the Opener of the Book, the Surah with which prayers are begun. - It is also called, Umm Al-Kitab (the Mother of the Book), according to the majority of the scholars.',
     );
+  });
+});
+
+describe('Test formatVerseReferencesToLinks', () => {
+  it('should convert single verse reference to link', () => {
+    const input = 'See verse 1:1 for more details';
+    const expected = 'See verse <a href="/1:1" target="_blank">1:1</a> for more details';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse range to link', () => {
+    const input = 'Verses 1:1-3 are important';
+    const expected = 'Verses <a href="/1:1-3" target="_blank">1:1-3</a> are important';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert multiple verse references to links', () => {
+    const input = 'See 1:1 and 2:1-3 for details';
+    const expected =
+      'See <a href="/1:1" target="_blank">1:1</a> and <a href="/2:1-3" target="_blank">2:1-3</a> for details';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should not convert already linked verse references', () => {
+    const input = 'See <a href="/1:1">1:1</a> for details';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should handle empty string', () => {
+    expect(formatVerseReferencesToLinks('')).toEqual('');
+  });
+
+  it('should handle null/undefined input', () => {
+    expect(formatVerseReferencesToLinks(null as any)).toEqual('');
+    expect(formatVerseReferencesToLinks(undefined as any)).toEqual('');
+  });
+
+  // Additional positive test cases
+  it('should handle verse references at the start of text', () => {
+    const input = '1:1 is the first verse';
+    const expected = '<a href="/1:1" target="_blank">1:1</a> is the first verse';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should handle verse references at the end of text', () => {
+    const input = 'The last verse is 1:1';
+    const expected = 'The last verse is <a href="/1:1" target="_blank">1:1</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should handle verse references with multiple digits', () => {
+    const input = 'See verses 114:1-3 and 1:1-7';
+    const expected =
+      'See verses 1<a href="/14:1-3" target="_blank">14:1-3</a> and <a href="/1:1-7" target="_blank">1:1-7</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should handle verse references with different separators', () => {
+    const input = 'See 1:1, 2:1-3 and 3:1';
+    const expected =
+      'See <a href="/1:1" target="_blank">1:1</a>, <a href="/2:1-3" target="_blank">2:1-3</a> and <a href="/3:1" target="_blank">3:1</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should handle verse ranges across chapters', () => {
+    const input = 'See verses 1:1-2:3 and 3:1-4:2';
+    const expected =
+      'See verses <a href="/1:1-2:3" target="_blank">1:1-2:3</a> and <a href="/3:1-4:2" target="_blank">3:1-4:2</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should handle verse references in Arabic text', () => {
+    const input = 'الآية 1:1 والآية 2:1-3';
+    const expected =
+      'الآية <a href="/1:1" target="_blank">1:1</a> والآية <a href="/2:1-3" target="_blank">2:1-3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  // Additional test cases that match current behavior
+  it('should convert partial verse references', () => {
+    const input = 'See 1: and :1 and 1-1';
+    const expected = 'See 1: and :1 and <a href="/1-1" target="_blank">1-1</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert dates that look like verse references', () => {
+    const input = 'The date 1:1:2023 is not a verse reference';
+    const expected =
+      'The date <a href="/1:1" target="_blank">1:1</a>:2023 is not a verse reference';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert time that looks like verse references', () => {
+    const input = 'The time is 1:1 PM';
+    const expected = 'The time is <a href="/1:1" target="_blank">1:1</a> PM';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references within HTML tags', () => {
+    const input = '<div>1:1</div>';
+    const expected = '<div><a href="/1:1" target="_blank">1:1</a></div>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should convert verse references within script tags', () => {
+    const input = '<script>const verse = "1:1";</script>';
+    const expected = '<script>const verse = "<a href="/1:1" target="_blank">1:1</a>";</script>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 });

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -57,3 +57,18 @@ export const slugifiedCollectionIdToCollectionId = (slugifiedCollectionId: strin
 export const cleanTranscript = (text: string): string => {
   return text.replace(/[\u200E\u200F]/g, '');
 };
+
+/**
+ * Converts verse references in text to clickable links.
+ * Example: "1:1" or "1:1-2" or "1:1-2:3" will be converted to HTML anchor tags.
+ *
+ * @param {string} text - The text containing verse references
+ * @returns {string} The text with verse references converted to links
+ */
+export const formatVerseReferencesToLinks = (text: string): string => {
+  if (!text) return '';
+  return text.replace(
+    /(\d{1,2}[:-]\d{1,2}(?:-\d{1,2}(?:[:]\d{1,2})?)?)(?![^<]*<\/a>)/g,
+    (match) => `<a href="${`/${match}`}" target="_blank">${match}</a>`,
+  );
+};


### PR DESCRIPTION
# Summary
Ayah feferences in footnotes for most translations are not links 

Closes #QF-2194

## Type of change
Client-side regex to find references and convert them to a href


## Test plan
Different footnotes to test with specific edge cases: 
http://local.quran.com/2/37 ( Adam and Eve were inspired to say is mentioned in 7:23 )

http://local.quran.com/2/43 ( Islāmic community (see 9:60) required,
 The alms-tax (zakâh) is the payment of 2.5% of someone’s savings only if the amount is equivalent to or greater than 85 g of gold, if that amount remains untouched for a whole Islamic year—around 355 days.)

http://local.quran.com/2/62
After the coming of Prophet Muḥammad (ﷺ) no religion other than Islām is acceptable to Allāh, as stated in 3:85.

[ (V.2:62) A past nation used to live in Mûsal (Iraq) and say Lâ ilâha illallâh (none has the right to be worshipped but Allâh) and used to read Az-Zabur (the Psalms of the Sabians) and they were neither Jews nor Christians.


http://local.quran.com/2?startingVerse=37&translations=131%2C203%2C20%2C942%2C85

http://local.quran.com/7/28 ( So verses 26-31 of this sûrah )

http://local.quran.com/7/64 ( For a more detailed account, see 11:25-48. )


Before 
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/df9a5ee7-bf1b-48e4-a868-d9c221170c88" />

After 
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/7cd92a6b-6cf4-46de-9c5e-561fa3c248df" />

