### PR TITLE
Fix preferences APIs error handling

### DIFF
--- a/src/components/Navbar/SettingsDrawer/ResetButton.tsx
+++ b/src/components/Navbar/SettingsDrawer/ResetButton.tsx
@@ -28,27 +28,7 @@ const ResetButton = () => {
   const toast = useToast();
   const audioService = useContext(AudioPlayerMachineContext);
 
-  const onResetSettingsClicked = async () => {
-    logButtonClick('reset_settings');
-    const resetAndSetInitialState = () => {
-      dispatch(resetSettings(lang));
-      audioService.send({
-        type: 'SET_INITIAL_CONTEXT',
-        ...DEFAULT_XSTATE_INITIAL_STATE,
-      });
-    };
-
-    if (isLoggedIn()) {
-      try {
-        await dispatch(persistDefaultSettings(lang)).then(unwrapResult);
-        resetAndSetInitialState();
-      } catch {
-        // TODO: show an error
-      }
-    } else {
-      resetAndSetInitialState();
-    }
-
+  const cleanupUrlAndShowSuccess = () => {
     const queryParams = [
       QueryParam.TRANSLATIONS,
       QueryParam.RECITER,
@@ -61,6 +41,30 @@ const ResetButton = () => {
       router.push(router, undefined, { shallow: true });
     }
     toast(t('settings.reset-notif'), { status: ToastStatus.Success });
+  };
+
+  const resetAndSetInitialState = () => {
+    dispatch(resetSettings(lang));
+    audioService.send({
+      type: 'SET_INITIAL_CONTEXT',
+      ...DEFAULT_XSTATE_INITIAL_STATE,
+    });
+  };
+
+  const onResetSettingsClicked = async () => {
+    logButtonClick('reset_settings');
+    if (isLoggedIn()) {
+      try {
+        await dispatch(persistDefaultSettings(lang)).then(unwrapResult);
+        resetAndSetInitialState();
+        cleanupUrlAndShowSuccess();
+      } catch {
+        toast(t('error.general'), { status: ToastStatus.Error });
+      }
+    } else {
+      resetAndSetInitialState();
+      cleanupUrlAndShowSuccess();
+    }
   };
 
   return (

--- a/src/components/Navbar/SettingsDrawer/WordByWordSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/WordByWordSection.tsx
@@ -73,6 +73,7 @@ const WordByWordSection = () => {
     action: Action,
     undoAction: Action,
     isReaderStyles = false,
+    successCallback: () => void = undefined,
   ) => {
     onSettingsChange(
       key,
@@ -80,6 +81,7 @@ const WordByWordSection = () => {
       action,
       undoAction,
       isReaderStyles ? PreferenceGroup.QURAN_READER_STYLES : PreferenceGroup.READING,
+      successCallback,
     );
   };
 
@@ -109,13 +111,16 @@ const WordByWordSection = () => {
 
   const onWordByWordLocaleChange = (value: string) => {
     logValueChange('wbw_locale', wordByWordLocale, value);
-    router.query[QueryParam.WBW_LOCALE] = value;
-    router.push(router, undefined, { shallow: true });
     onWordByWordSettingsChange(
       'selectedWordByWordLocale',
       value,
       setSelectedWordByWordLocale({ value, locale: lang }),
       setSelectedWordByWordLocale({ value: wordByWordLocale, locale: lang }),
+      false,
+      () => {
+        router.query[QueryParam.WBW_LOCALE] = value;
+        router.push(router, undefined, { shallow: true });
+      },
     );
   };
 

--- a/src/hooks/auth/usePersistPreferenceGroup.ts
+++ b/src/hooks/auth/usePersistPreferenceGroup.ts
@@ -9,7 +9,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
 import { selectQuranFont, selectQuranMushafLines } from '@/redux/slices/QuranReader/styles';
 import { getMushafId } from '@/utils/api';
-import { addOrUpdateUserPreference } from '@/utils/auth/api';
+import { addOrUpdateUserPreference, throwIfResponseContainsError } from '@/utils/auth/api';
 import { isLoggedIn } from '@/utils/auth/login';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
 
@@ -96,8 +96,14 @@ const usePersistPreferenceGroup = (): PersistPreferences => {
             preferenceGroup,
             getUpdatedMushafId(preferenceGroup, key, value),
           )
-            .then(() => {
+            .then((response) => {
+              throwIfResponseContainsError(response);
               callback();
+            })
+            .catch(() => {
+              toast(t('error.pref-persist-fail'), {
+                status: ToastStatus.Warning,
+              });
             })
             .finally(() => {
               setIsLoading(false);
@@ -123,7 +129,8 @@ const usePersistPreferenceGroup = (): PersistPreferences => {
             preferenceGroup,
             getUpdatedMushafId(preferenceGroup, key, value),
           )
-            .then(() => {
+            .then((response) => {
+              throwIfResponseContainsError(response);
               if (successCallback) {
                 successCallback();
               }
@@ -176,7 +183,8 @@ const usePersistPreferenceGroup = (): PersistPreferences => {
             preferenceGroup,
             getUpdatedMushafId(preferenceGroup, key, value),
           )
-            .then(() => {
+            .then((response) => {
+              throwIfResponseContainsError(response);
               if (successCallback) {
                 successCallback();
               }

--- a/src/utils/auth/api.ts
+++ b/src/utils/auth/api.ts
@@ -125,6 +125,33 @@ const IGNORE_ERRORS = [
   AuthErrorCodes.ValidationError,
 ];
 
+/**
+ * Checks if an API response contains error information and throws an error if it does.
+ * This is useful for handling responses from APIs that return error information in the response body
+ * instead of rejecting the promise (like when ValidationError is in IGNORE_ERRORS).
+ *
+ * @param {unknown} response - The API response to check
+ * @param {string} [errorMessage] - Optional custom error message to throw
+ * @throws {Error} If the response contains error information
+ * @returns {void}
+ */
+export const throwIfResponseContainsError = (response: unknown, errorMessage?: string): void => {
+  if (
+    response &&
+    typeof response === 'object' &&
+    ((response as any).error ||
+      (response as any).details?.error ||
+      (response as any).success === false)
+  ) {
+    const message =
+      errorMessage ||
+      (response as any).error?.message ||
+      (response as any).details?.error?.message ||
+      'API request failed';
+    throw new Error(message);
+  }
+};
+
 const handleErrors = async (res) => {
   const body = await res.json();
   const error = body?.error || body?.details?.error;


### PR DESCRIPTION
Closes [#QF-2580](https://quranfoundation.atlassian.net/browse/QF-2580) 

This PR fixes multiple issues related to calling preferences APIs: 

* If there is an error with API call to update wordByWord preferences, Frontend does not show the error toast.
* If there is an error with reset settings API call, Frontend shows success toast instead.
* If there is an issue with API call to update wbw locale (e.g. selecting French), toast disappears instantly due to changing url params.