### PR TITLE
fix: initialize bookmarkedPages as empty object in state migration

### DIFF
--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -273,4 +273,11 @@ export default {
       isDonationPopupVisible: true,
     },
   }),
+  36: (state) => ({
+    ...state,
+    bookmarks: {
+      ...state.bookmarks,
+      bookmarkedPages: state.bookmarks?.bookmarkedPages || {},
+    },
+  }),
 };


### PR DESCRIPTION
# Summary

Closes: [QF-2899](https://quranfoundation.atlassian.net/browse/QF-2899)

[QF-2899]: https://quranfoundation.atlassian.net/browse/QF-2899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ