### PR TITLE
chore: modernize Playwright config and add surah test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,77 +1,46 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
-const config: PlaywrightTestConfig = {
+export default defineConfig({
   testDir: './tests/integration',
-  /* Maximum time one test can run for. */
+  fullyParallel: true,
   timeout: 30 * 1000,
   expect: {
-    /**
-     * Maximum time expect() should wait for the condition to be met.
-     * For example in `await expect(locator).toHaveText();`
-     */
     timeout: 5000,
   },
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
-    /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000',
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
-
-  /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
+      use: { ...devices['Desktop Chrome'] },
     },
-
     {
       name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-      },
+      use: { ...devices['Desktop Firefox'] },
     },
-
     {
       name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-      },
+      use: { ...devices['Desktop Safari'] },
     },
-
-    /* Test against mobile viewports. */
     {
       name: 'Mobile Chrome',
-      use: {
-        ...devices['Pixel 5'],
-      },
+      use: { ...devices['Pixel 5'] },
     },
-
     {
       name: 'Mobile Safari',
-      use: {
-        ...devices['iPhone 12'],
-      },
+      use: { ...devices['iPhone 12'] },
     },
   ],
-};
-
-export default config;
+  webServer: {
+    command: process.env.CI ? 'yarn start' : 'yarn dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/POM/home-page.ts
+++ b/tests/POM/home-page.ts
@@ -56,7 +56,7 @@ class Homepage {
   }
 
   async openSettingsDrawer() {
-    await this.page.locator('[aria-label="Change Settings"]').click();
+    await this.page.getByLabel('Change Settings').click();
   }
 }
 

--- a/tests/integration/navbar/language-selector.spec.ts
+++ b/tests/integration/navbar/language-selector.spec.ts
@@ -8,25 +8,25 @@ test('Clicking on Nav bar language selector icon should open the language select
   page,
 }) => {
   // 1. make sure the language selector items are not visible
-  await expect(page.locator('div[role="menuitem"]:has-text("English")')).not.toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'English' })).not.toBeVisible();
   // 2. Click on the language selector nav bar trigger
-  await page.locator('[aria-label="Select Language"]').click();
+  await page.getByLabel('Select Language').click();
   // 3. Make sure the language selector items are visible
-  await expect(page.locator('div[role="menuitem"]:has-text("English")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("العربية")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("বাংলা")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("فارسی")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Français")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Italiano")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Dutch")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Português")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("русский")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Shqip")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("ภาษาไทย")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Türkçe")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("اردو")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("简体中文")')).toBeVisible();
-  await expect(page.locator('div[role="menuitem"]:has-text("Melayu")')).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'English' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'العربية' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'বাংলা' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'فارسی' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Français' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Italiano' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Dutch' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Português' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'русский' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Shqip' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'ภาษาไทย' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Türkçe' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'اردو' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: '简体中文' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Melayu' })).toBeVisible();
 });
 
 test('Choosing a language should navigate the user to the localized page of that language', async ({
@@ -35,16 +35,16 @@ test('Choosing a language should navigate the user to the localized page of that
   // 1. Make sure we are on the English version
   await expect(page).toHaveURL('/');
   // 2. Open the language selector menu
-  await page.locator('[aria-label="Select Language"]').click();
+  await page.getByLabel('Select Language').click();
   // 3. select the Bengali language and make sure we are navigated to /bn
-  await Promise.all([page.waitForNavigation({ url: '/bn' }), page.locator('text=বাংলা').click()]);
+  await Promise.all([page.waitForURL('/bn'), page.getByRole('menuitem', { name: 'বাংলা' }).click()]);
 });
 
 test('Choosing a language should persist', async ({ page, baseURL }) => {
   // 1. Open the language selector menu
-  await page.locator('[aria-label="Select Language"]').click();
+  await page.getByLabel('Select Language').click();
   // 2. select the Arabic language and make sure we are navigated to /ar
-  await Promise.all([page.waitForNavigation({ url: '/ar' }), page.locator('text=العربية').click()]);
+  await Promise.all([page.waitForURL('/ar'), page.getByRole('menuitem', { name: 'العربية' }).click()]);
   // 3. Navigate again to /
   await page.goto('/');
   const currentUrl = page.url();

--- a/tests/integration/surah/reader.spec.ts
+++ b/tests/integration/surah/reader.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('opening a surah displays its first verse', async ({ page }) => {
+  await page.goto('/1');
+  const heading = page.getByRole('heading', { level: 1 });
+  await expect(heading).toContainText('Al-Fatihah');
+  await expect(page.locator('[data-verse-key="1:1"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- modernize Playwright config and enable built-in webServer
- update language selector tests to use accessible selectors
- cover surah reader with a basic verse visibility test

## Testing
- `yarn lint` *(fails: package doesn't seem present in lockfile)*
- `yarn build` *(fails: package doesn't seem present in lockfile)*
- `yarn test` *(fails: package doesn't seem present in lockfile)*
- `yarn test:integration` *(fails: package doesn't seem present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f3381f3c832ab5986788b80afd25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test runner configuration to enable parallel execution and auto-start the dev server, improving CI performance and reliability.

* **Tests**
  * Migrated to accessibility-first selectors for menus and controls, improving test stability and aligning with a11y best practices.
  * Enhanced navigation handling in tests for more reliable URL assertions.
  * Added coverage to verify a surah page loads correctly and displays its first verse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->