### PR TITLE
QF-3435: Fix ayah reference formatting for RTL locales

### DIFF
--- a/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText.ts
+++ b/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText.ts
@@ -1,0 +1,82 @@
+import Reference from '@/types/QuranReflect/Reference';
+import { isRTLLocale, toLocalizedNumber } from '@/utils/locale';
+import { makeVerseKey } from '@/utils/verse';
+
+const isChapterOnly = (r: Reference) => r.from === 0 && r.to === 0;
+const hasRange = (r: Reference): r is Reference & { to: number } =>
+  typeof r.to === 'number' && r.to > 0 && r.to !== r.from;
+
+function buildRTLText(
+  verseReferences: Reference[],
+  nonChapterVerseReferences: Reference[],
+  lang: string,
+  t: (key: string) => string,
+): string {
+  const AR_COMMA = '، ';
+
+  const chapterNumbers = verseReferences
+    .filter(isChapterOnly)
+    .map((r) => toLocalizedNumber(r.chapterId, lang));
+
+  const chaptersText = chapterNumbers.join(AR_COMMA);
+
+  const verseItems = nonChapterVerseReferences.map((r) => {
+    const chapterNum = toLocalizedNumber(r.chapterId, lang);
+    const startAyah = toLocalizedNumber(r.from, lang);
+    const endAyah = hasRange(r) ? toLocalizedNumber(r.to, lang) : '';
+    return hasRange(r) ? `${startAyah}:${chapterNum}-${endAyah}` : `${startAyah}:${chapterNum}`;
+  });
+
+  const versesText = verseItems.join(AR_COMMA);
+
+  if (chaptersText && versesText) {
+    return `${t('common:surah')} ${chaptersText} ${t('common:and')} ${t(
+      'common:ayah',
+    )} ${versesText}`;
+  }
+  if (chaptersText) return `${t('common:surah')} ${chaptersText}`;
+  if (versesText) return `${t('common:ayah')} ${versesText}`;
+  return '';
+}
+
+function buildLTRText(
+  verseReferences: Reference[],
+  nonChapterVerseReferences: Reference[],
+  lang: string,
+  t: (key: string) => string,
+): string {
+  const chapters = verseReferences
+    .filter(isChapterOnly)
+    .map((r) => toLocalizedNumber(r.chapterId, lang));
+
+  let text = '';
+  if (chapters.length > 0) {
+    text += `${t('common:surah')} ${chapters.join(', ')}`;
+  }
+
+  const verses = nonChapterVerseReferences.map((r) =>
+    makeVerseKey(
+      toLocalizedNumber(r.chapterId, lang),
+      toLocalizedNumber(r.from, lang),
+      toLocalizedNumber(r.to, lang),
+    ),
+  );
+
+  if (verses.length > 0) {
+    if (chapters.length > 0) text += ` ${t('common:and')} `;
+    text += `${t('common:ayah')} ${verses.join(', ')}`;
+  }
+
+  return text;
+}
+
+export default function buildReferredVerseText(
+  verseReferences: Reference[],
+  nonChapterVerseReferences: Reference[],
+  lang: string,
+  t: (key: string) => string,
+): string {
+  return isRTLLocale(lang)
+    ? buildRTLText(verseReferences, nonChapterVerseReferences, lang, t)
+    : buildLTRText(verseReferences, nonChapterVerseReferences, lang, t);
+}

--- a/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText.ts
+++ b/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText.ts
@@ -54,13 +54,12 @@ function buildLTRText(
     text += `${t('common:surah')} ${chapters.join(', ')}`;
   }
 
-  const verses = nonChapterVerseReferences.map((r) =>
-    makeVerseKey(
-      toLocalizedNumber(r.chapterId, lang),
-      toLocalizedNumber(r.from, lang),
-      toLocalizedNumber(r.to, lang),
-    ),
-  );
+  const verses = nonChapterVerseReferences.map((r) => {
+    const chapter = toLocalizedNumber(r.chapterId, lang);
+    const from = toLocalizedNumber(r.from, lang);
+    const rangeTo = hasRange(r) ? toLocalizedNumber(r.to, lang) : undefined;
+    return makeVerseKey(chapter, from, rangeTo);
+  });
 
   if (verses.length > 0) {
     if (chapters.length > 0) text += ` ${t('common:and')} `;

--- a/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText.ts
+++ b/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText.ts
@@ -2,6 +2,7 @@ import Reference from '@/types/QuranReflect/Reference';
 import { isRTLLocale, toLocalizedNumber } from '@/utils/locale';
 import { makeVerseKey } from '@/utils/verse';
 
+const AR_COMMA = '، ';
 const isChapterOnly = (r: Reference) => r.from === 0 && r.to === 0;
 const hasRange = (r: Reference): r is Reference & { to: number } =>
   typeof r.to === 'number' && r.to > 0 && r.to !== r.from;
@@ -12,8 +13,6 @@ function buildRTLText(
   lang: string,
   t: (key: string) => string,
 ): string {
-  const AR_COMMA = '، ';
-
   const chapterNumbers = verseReferences
     .filter(isChapterOnly)
     .map((r) => toLocalizedNumber(r.chapterId, lang));
@@ -23,8 +22,9 @@ function buildRTLText(
   const verseItems = nonChapterVerseReferences.map((r) => {
     const chapterNum = toLocalizedNumber(r.chapterId, lang);
     const startAyah = toLocalizedNumber(r.from, lang);
-    const endAyah = hasRange(r) ? toLocalizedNumber(r.to, lang) : '';
-    return hasRange(r) ? `${startAyah}:${chapterNum}-${endAyah}` : `${startAyah}:${chapterNum}`;
+    const isRange = hasRange(r);
+    const endAyah = isRange ? toLocalizedNumber(r.to, lang) : '';
+    return isRange ? `${startAyah}:${chapterNum}-${endAyah}` : `${startAyah}:${chapterNum}`;
   });
 
   const versesText = verseItems.join(AR_COMMA);

--- a/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/index.tsx
+++ b/src/components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/index.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
 import styles from './AuthorInfo.module.scss';
+import buildReferredVerseText from './buildReferredVerseText';
 
 import Link, { LinkVariant } from '@/dls/Link/Link';
 import ChevronDownIcon from '@/icons/chevron-down.svg';
@@ -11,9 +12,7 @@ import VerifiedIcon from '@/icons/verified.svg';
 import Reference from '@/types/QuranReflect/Reference';
 import { formatDateRelatively } from '@/utils/datetime';
 import { logButtonClick } from '@/utils/eventLogger';
-import { toLocalizedNumber } from '@/utils/locale';
 import { getQuranReflectAuthorUrl } from '@/utils/quranReflect/navigation';
-import { makeVerseKey } from '@/utils/verse';
 
 type Props = {
   authorUsername: string;
@@ -52,31 +51,10 @@ const AuthorInfo: React.FC<Props> = ({
     logButtonClick('reflection_item_author');
   };
 
-  const referredVerseText = useMemo(() => {
-    let text = '';
-    const chapters = verseReferences
-      .filter((verse) => !verse.from || !verse.to)
-      .map((verse) => toLocalizedNumber(verse.chapterId, lang));
-
-    if (chapters.length > 0) {
-      text += `${t('common:surah')} ${chapters.join(',')}`;
-    }
-
-    const verses = nonChapterVerseReferences.map((verse) =>
-      makeVerseKey(
-        toLocalizedNumber(verse.chapterId, lang),
-        toLocalizedNumber(verse.from, lang),
-        toLocalizedNumber(verse.to, lang),
-      ),
-    );
-
-    if (verses.length > 0) {
-      if (chapters.length > 0) text += ` ${t('common:and')} `;
-      text += `${t('common:ayah')} ${verses.join(',')}`;
-    }
-
-    return text;
-  }, [verseReferences, nonChapterVerseReferences, lang, t]);
+  const referredVerseText = useMemo(
+    () => buildReferredVerseText(verseReferences, nonChapterVerseReferences, lang, t),
+    [verseReferences, nonChapterVerseReferences, lang, t],
+  );
 
   return (
     <div className={styles.authorInfo}>

--- a/src/utils/quranReflect/quran-reflect-reference-ayat.test.ts
+++ b/src/utils/quranReflect/quran-reflect-reference-ayat.test.ts
@@ -16,10 +16,11 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 
 /* eslint-disable max-lines, react-func/max-lines-per-function */
-import type Reference from '../../../types/QuranReflect/Reference';
 import buildReferredVerseText from '../../components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText';
-import { isRTLLocale, toLocalizedNumber } from '../locale';
-import { makeVerseKey } from '../verse';
+
+import type Reference from '@/types/QuranReflect/Reference';
+import { isRTLLocale, toLocalizedNumber } from '@/utils/locale';
+import { makeVerseKey } from '@/utils/verse';
 
 type CommonDict = Record<'ayah' | 'surah' | 'and', string>;
 
@@ -179,6 +180,16 @@ describe('buildReferredVerseText — edge cases', () => {
     const out = buildReferredVerseText(all, all, 'en', t);
     expect(out).not.toMatch(/\s{2,}/);
     expect(out.endsWith(',')).toBe(false);
+    expect(out.endsWith(' ')).toBe(false);
+  });
+
+  it('no extra spaces or trailing commas (RTL)', async () => {
+    const { default: getT } = await import('next-translate/getT');
+    const t = await getT('ar', 'common');
+    const all = [makeRef(2, 1, 1), makeRef(1, 1, 1)];
+    const out = buildReferredVerseText(all, all, 'ar', t);
+    expect(out).not.toMatch(/\s{2,}/);
+    expect(out.endsWith('،')).toBe(false);
     expect(out.endsWith(' ')).toBe(false);
   });
 });

--- a/src/utils/quranReflect/quran-reflect-reference-ayat.test.ts
+++ b/src/utils/quranReflect/quran-reflect-reference-ayat.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Test Suite: buildReferredVerseText — minimal docs
+ *
+ * Validates rendering of Quran references across LTR (en) and RTL (ar/ur/fa).
+ *
+ * Covers:
+ * - Single ayah, multiple ayat, ranges, surah-only, and mixed (surah + ayat).
+ * - Localized digits via `toLocalizedNumber`.
+ * - Punctuation: LTR uses ", ", RTL uses "، ".
+ * - Order: LTR <chapter>:<verse>, RTL <verse>:<chapter>.
+ * - When both surah-only and ayat exist, inserts a single localized "and".
+ * - Empty input returns "".
+ *
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+/* eslint-disable max-lines, react-func/max-lines-per-function */
+import type Reference from '../../../types/QuranReflect/Reference';
+import buildReferredVerseText from '../../components/QuranReader/ReflectionView/ReflectionItem/AuthorInfo/buildReferredVerseText';
+import { isRTLLocale, toLocalizedNumber } from '../locale';
+import { makeVerseKey } from '../verse';
+
+type CommonDict = Record<'ayah' | 'surah' | 'and', string>;
+
+const en: CommonDict = { ayah: 'Ayah', surah: 'Surah', and: 'and' };
+const ar: CommonDict = { ayah: 'آية', surah: 'سورة', and: 'و' };
+const ur: CommonDict = { ayah: 'آیت', surah: 'سورہ', and: 'اور' };
+const fa: CommonDict = { ayah: 'آیه', surah: 'سوره', and: 'و' };
+
+const maps: Record<string, CommonDict> = { en, ar, ur, fa };
+
+vi.mock('next-translate/getT', () => ({
+  default: async (lang: string) => {
+    const dict = maps[lang] ?? maps.en;
+    return (key: string) => {
+      const plainKey = key.includes(':') ? key.split(':')[1] : key;
+      return dict[plainKey] ?? key;
+    };
+  },
+}));
+
+const makeRef = (chapterId: number, from: number, to?: number): Reference => ({
+  chapterId,
+  from,
+  to: typeof to === 'number' ? to : 0,
+  id:
+    to === undefined
+      ? `surah-${chapterId}${from ? `-${from}` : ''}`
+      : `surah-${chapterId}-${from}:${to}`,
+});
+
+const COMMA = { ltr: ', ', rtl: '، ' } as const;
+
+/* eslint-disable max-lines, react-func/max-lines-per-function */
+// ---- LTR (en) ----
+describe('buildReferredVerseText — LTR (en)', () => {
+  let t: (k: string) => string;
+  beforeAll(async () => {
+    const { default: getT } = await import('next-translate/getT');
+    t = await getT('en', 'common');
+  });
+
+  it('single ayah', () => {
+    const verses = [makeRef(2, 1, 1)];
+    const out = buildReferredVerseText(verses, verses, 'en', t);
+    expect(out).toBe(`${t('common:ayah')} ${makeVerseKey('2', '1')}`);
+  });
+
+  it('multiple ayat, stable order, LTR comma', () => {
+    const all = [makeRef(2, 1, 1), makeRef(1, 1, 1)];
+    const out = buildReferredVerseText(all, all, 'en', t);
+    const expected = `${t('common:ayah')} ${makeVerseKey('2', '1')}${COMMA.ltr}${makeVerseKey(
+      '1',
+      '1',
+    )}`;
+    expect(out).toBe(expected);
+  });
+
+  it('mixed: surah-only + ayat (includes a range)', () => {
+    const verseRefs = [makeRef(18, 4, 5), makeRef(2, 0, 0), makeRef(8, 12, 12)];
+    const nonChapters = [makeRef(18, 4, 5), makeRef(8, 12, 12)];
+    const out = buildReferredVerseText(verseRefs, nonChapters, 'en', t);
+    const surahs = `${t('common:surah')} ${toLocalizedNumber(2, 'en')}`;
+    const verses = `${makeVerseKey('18', '4', '5')}${COMMA.ltr}${makeVerseKey('8', '12')}`;
+    expect(out).toBe(`${surahs} ${t('common:and')} ${t('common:ayah')} ${verses}`);
+  });
+
+  it('surah-only', () => {
+    const out = buildReferredVerseText([makeRef(36, 0, 0)], [], 'en', t);
+    expect(out).toBe(`${t('common:surah')} ${toLocalizedNumber(36, 'en')}`);
+  });
+});
+
+// ---- RTL (ar / ur / fa) ----
+describe.each([
+  { lang: 'ar', comma: COMMA.rtl },
+  { lang: 'ur', comma: COMMA.rtl },
+  { lang: 'fa', comma: COMMA.rtl },
+] as const)('buildReferredVerseText — RTL (%s)', ({ lang, comma }) => {
+  let t: (k: string) => string;
+  beforeAll(async () => {
+    const { default: getT } = await import('next-translate/getT');
+    t = await getT(lang, 'common');
+  });
+
+  it('flags RTL locale', () => {
+    expect(isRTLLocale(lang)).toBe(true);
+  });
+
+  it('single ayah uses localized numerals and ":" order (verse:chapter)', () => {
+    const r = [makeRef(2, 1, 1)];
+    const out = buildReferredVerseText(r, r, lang, t);
+    const expected = `${t('common:ayah')} ${toLocalizedNumber(1, lang)}:${toLocalizedNumber(
+      2,
+      lang,
+    )}`;
+    expect(out).toBe(expected);
+  });
+
+  it('multiple ayat join with Arabic comma and single space', () => {
+    const all = [makeRef(2, 1, 1), makeRef(1, 1, 1)];
+    const out = buildReferredVerseText(all, all, lang, t);
+    const first = `${toLocalizedNumber(1, lang)}:${toLocalizedNumber(2, lang)}`;
+    const second = `${toLocalizedNumber(1, lang)}:${toLocalizedNumber(1, lang)}`;
+
+    // enforce exact comma character and spacing
+    expect(comma).toBe('، ');
+    expect(out).toBe(`${t('common:ayah')} ${first}${comma}${second}`);
+  });
+
+  it('mixed: surah-only + ayat (+range) with localized digits', () => {
+    const verseRefs = [makeRef(18, 4, 5), makeRef(2, 0, 0), makeRef(8, 12, 12)];
+    const nonChapters = [makeRef(18, 4, 5), makeRef(8, 12, 12)];
+    const out = buildReferredVerseText(verseRefs, nonChapters, lang, t);
+
+    const surahs = `${t('common:surah')} ${toLocalizedNumber(2, lang)}`;
+    const v1 = `${toLocalizedNumber(4, lang)}:${toLocalizedNumber(18, lang)}-${toLocalizedNumber(
+      5,
+      lang,
+    )}`;
+    const v2 = `${toLocalizedNumber(12, lang)}:${toLocalizedNumber(8, lang)}`;
+    expect(out).toBe(`${surahs} ${t('common:and')} ${t('common:ayah')} ${v1}${comma}${v2}`);
+  });
+});
+
+// ---- edge cases ----
+describe('buildReferredVerseText — edge cases', () => {
+  it('empty input → empty string (all locales)', async () => {
+    const { default: getT } = await import('next-translate/getT');
+    await Promise.all(
+      (['en', 'ar', 'ur', 'fa'] as const).map(async (lang) => {
+        const t = await getT(lang, 'common');
+        expect(buildReferredVerseText([], [], lang, t)).toBe('');
+      }),
+    );
+  });
+
+  it('range where from === to is rendered as single ayah', async () => {
+    const { default: getT } = await import('next-translate/getT');
+    const t = await getT('en', 'common');
+    const verses = [makeRef(2, 5, 5)];
+    const out = buildReferredVerseText(verses, verses, 'en', t);
+    expect(out).toBe(`${t('common:ayah')} ${makeVerseKey('2', '5')}`);
+  });
+
+  it('invalid range (from > to) — documents current behavior (no crash)', async () => {
+    const { default: getT } = await import('next-translate/getT');
+    const t = await getT('en', 'common');
+    const verses = [makeRef(2, 10, 5)];
+    const out = buildReferredVerseText(verses, verses, 'en', t);
+    expect(typeof out).toBe('string');
+  });
+
+  it('no extra spaces or trailing commas (LTR)', async () => {
+    const { default: getT } = await import('next-translate/getT');
+    const t = await getT('en', 'common');
+    const all = [makeRef(2, 1, 1), makeRef(1, 1, 1)];
+    const out = buildReferredVerseText(all, all, 'en', t);
+    expect(out).not.toMatch(/\s{2,}/);
+    expect(out.endsWith(',')).toBe(false);
+    expect(out.endsWith(' ')).toBe(false);
+  });
+});


### PR DESCRIPTION
### PR Title
Fix incorrect Ayah reference formatting in reflections list for Arabic, Urdu, and فارسی (RTL)

### Summary
Fixes [QF-3435](https://quranfoundation.atlassian.net/browse/QF-3435).

The reflections list showed incorrect Ayah references in RTL locales (Arabic, Urdu, فارسی).
This updates the RTL formatting to the correct shape and chapter-only detection. LTR behavior remains unchanged.

_Implementation note:_ While fixing, the formatting logic was moved into a small helper to satisfy lint line-length rules. No functional change beyond the RTL fix.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Test plan
- Run `yarn lint` — expect no errors.
- Switch locale to **Arabic**, **Urdu**, **فارسی**:
  - Open the reflections list and verify Ayah references display with the correct RTL format (including ranges) and proper chapter-only handling.
- Switch to an LTR locale (e.g., English):
  - Confirm formatting is unchanged.
- Spot-check items with:
  - chapter-only references
  - single-ayah references
  - ayah ranges (from–to)

### Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings
- [ ] Dependent changes merged (if any)
- [x] Added/updated comments where helpful
- [ ] Documentation updated (if needed)
- [ ] Added tests (if applicable)
- [] All existing tests pass locally

### Screenshots or videos

Before (RTL) 

<img width="1132" height="330" alt="image" src="https://github.com/user-attachments/assets/ef45d8f5-a7a7-4e1c-a50e-56538a0b3c54" />

After (RTL) 

<img width="1117" height="339" alt="image" src="https://github.com/user-attachments/assets/9a6210da-0d52-425e-b82d-b6506d649faa" />



[QF-3435]: https://quranfoundation.atlassian.net/browse/QF-3435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved verse reference display with full LTR/RTL localization, including localized numerals and localized terms/punctuation.
  * Supports chapter-only references, single verses, and verse ranges; omits output when no references exist.

* **Refactor**
  * Centralized verse text construction into a reusable helper for consistent formatting across views.

* **Tests**
  * Added comprehensive locale-aware tests covering LTR/RTL, ranges, mixed inputs, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->