### PR TITLE
Qf 3439

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -480,5 +480,13 @@
   "share-quran-description-line-1": "The Prophet ﷺ said:",
   "share-quran-description-line-2": "‘Convey from me, even if it is one verse.’",
   "share-quran-description-line-3": "(Bukhari 3461)",
-  "no-verses-available": "No verses available"
+  "no-verses-available": "No verses available",
+  "mulk-lp": {
+    "caption-bold": "Discover powerful lessons in Surah Mulk today",
+    "caption-suffix": "(A free Learning Plan)",
+    "cta-text": "Begin Now",
+    "aria-image-link": "View The Rescuer learning plan for Surah Al-Mulk",
+    "aria-cta": "Learn more about The Rescuer learning plan",
+    "image-alt": "The Rescuer: Powerful Lessons in Surah Mulk learning plan banner"
+  }
 }

--- a/src/components/QuranReader/MulkLearningPlanBanner/MulkLearningPlanBanner.module.scss
+++ b/src/components/QuranReader/MulkLearningPlanBanner/MulkLearningPlanBanner.module.scss
@@ -1,0 +1,255 @@
+@use 'src/styles/breakpoints';
+
+.sentinel {
+  block-size: 1px;
+  inline-size: 100%;
+}
+
+.bannerWrapper {
+  inline-size: 100%;
+  display: flex;
+  justify-content: center;
+  padding-block: var(--spacing-mega);
+  padding-inline: var(--spacing-medium);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+
+  @include breakpoints.smallerThanTablet {
+    padding-block: var(--spacing-large);
+    padding-inline: 0;
+  }
+}
+
+.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.bannerContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  inline-size: 1230px;
+  max-inline-size: 100%;
+
+  @include breakpoints.smallerThanTablet {
+    min-inline-size: 390px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+  }
+}
+
+.mobileCaption {
+  display: none;
+
+  @include breakpoints.smallerThanTablet {
+    display: block;
+    inline-size: 370px;
+    max-inline-size: 100%;
+    padding-block: 0;
+    padding-inline: 10px;
+    margin: 0;
+    color: var(--color-text-default-new, #272727);
+    text-align: center;
+    font-family: Figtree, sans-serif;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 19px;
+
+    [data-theme='dark'] & {
+      color: var(--color-text-inverse);
+    }
+    [data-theme='sepia'] & {
+      color: var(--color-text-default-new, #272727);
+    }
+  }
+}
+
+.imageLink {
+  display: block;
+  inline-size: 100%;
+  text-decoration: none;
+  transition: opacity var(--transition-regular);
+  align-self: stretch;
+
+  &:hover {
+    opacity: 0.95;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary-medium);
+    outline-offset: 4px;
+    border-radius: var(--border-radius-default);
+  }
+
+  @include breakpoints.smallerThanTablet {
+    inline-size: 100%;
+    max-inline-size: 100%;
+  }
+}
+
+.imageWrap {
+  block-size: 307.5px;
+  flex-shrink: 0;
+  inline-size: 100%;
+  aspect-ratio: 1230 / 307.5;
+
+  img {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  @include breakpoints.smallerThanTablet {
+    block-size: 117px;
+    align-self: stretch;
+    aspect-ratio: 10 / 3;
+
+    img {
+      block-size: 100%;
+      inline-size: 100%;
+      object-fit: cover;
+    }
+  }
+}
+
+.mobileButton {
+  display: none;
+
+  @include breakpoints.smallerThanTablet {
+    display: flex;
+    padding: 5px 15px;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    border-radius: 10px;
+    background: var(--color-success-medium);
+    white-space: nowrap;
+    border: none;
+    color: var(--color-text-inverse);
+    text-align: center;
+    font-family: Figtree, sans-serif;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+
+    &:hover {
+      opacity: 0.9;
+      background-color: var(--color-success-deep);
+    }
+
+    [data-theme='dark'] &,
+    [data-theme='auto'] & {
+      &:hover {
+        color: var(--color-text-inverse);
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-text-inverse);
+      outline-offset: 2px;
+    }
+
+    [data-theme='dark'] & {
+      color: var(--color-text-default-new);
+    }
+    [data-theme='sepia'] & {
+      color: var(--color-text-inverse);
+    }
+    [data-theme='auto'] & {
+      color: var(--color-text-default-new);
+    }
+  }
+}
+
+.desktopCaptionRow {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: var(--spacing-xlarge-px);
+  align-self: stretch;
+  padding-inline-start: 167px;
+
+  @include breakpoints.smallerThanTablet {
+    display: none;
+  }
+}
+
+.desktopCaption {
+  margin: 0;
+  color: var(--color-text-default-new);
+  font-size: var(--font-size-large-px);
+  line-height: 29px;
+
+  [data-theme='dark'] & {
+    color: var(--color-text-default-new);
+  }
+  [data-theme='sepia'] & {
+    color: var(--color-text-default-new, #272727);
+  }
+}
+
+.captionBold {
+  font-weight: var(--font-weight-bold);
+
+  @include breakpoints.smallerThanTablet {
+    font-weight: 700;
+  }
+}
+
+.desktopButton {
+  display: flex;
+  padding: var(--spacing-small-px) var(--spacing-medium2-px);
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-small-px);
+  border-radius: 15px;
+  background: var(--color-success-medium);
+  white-space: nowrap;
+  border: none;
+  color: var(--color-text-inverse);
+  font-size: var(--font-size-normal-px);
+  font-weight: var(--font-weight-semibold);
+
+  &:hover {
+    opacity: 0.9;
+    background-color: var(--color-success-deep);
+  }
+
+  [data-theme='dark'] &,
+  [data-theme='auto'] & {
+    &:hover {
+      color: var(--color-text-inverse);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-text-inverse);
+    outline-offset: 2px;
+  }
+
+  [data-theme='dark'] & {
+    color: var(--color-text-default-new);
+  }
+  [data-theme='sepia'] & {
+    color: var(--color-text-inverse);
+  }
+  [data-theme='auto'] & {
+    color: var(--color-text-default-new);
+  }
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .bannerWrapper {
+    transition: none;
+    transform: none;
+  }
+}

--- a/src/components/QuranReader/MulkLearningPlanBanner/index.tsx
+++ b/src/components/QuranReader/MulkLearningPlanBanner/index.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import classNames from 'classnames';
+import Image from 'next/image';
+import useTranslation from 'next-translate/useTranslation';
+
+import styles from './MulkLearningPlanBanner.module.scss';
+
+import Button, { ButtonSize } from '@/dls/Button/Button';
+import Link from '@/dls/Link/Link';
+
+const LEARNING_PLAN_URL = '/learning-plans/the-rescuer-powerful-lessons-in-surah-al-mulk';
+const BANNER_IMAGE_PATH =
+  'https://images.quran.com/the-rescuer-powerful-lessons-in-surah-al-mulk/Banner.png';
+const BANNER_WIDTH = 1230;
+const BANNER_HEIGHT = 307;
+
+const MulkLearningPlanBanner: React.FC = () => {
+  const { t } = useTranslation('common');
+  const [isVisible, setIsVisible] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel) return () => {};
+
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+
+    const handleIntersect: IntersectionObserverCallback = (entries) => {
+      if (entries[0]?.isIntersecting) {
+        setIsVisible(true);
+        observerRef.current?.disconnect();
+        observerRef.current = null;
+      }
+    };
+
+    const obs = new IntersectionObserver(handleIntersect, {
+      root: null,
+      rootMargin: '0px 0px -40% 0px',
+      threshold: 0,
+    });
+
+    obs.observe(sentinel);
+    observerRef.current = obs;
+
+    return () => {
+      obs.disconnect();
+      observerRef.current = null;
+    };
+  }, []);
+
+  const shouldShowBanner = isVisible;
+
+  return (
+    <>
+      <div ref={sentinelRef} aria-hidden="true" className={styles.sentinel} />
+
+      <aside
+        className={classNames(styles.bannerWrapper, {
+          [styles.visible]: shouldShowBanner,
+        })}
+        role="region"
+        aria-label="Learning plan promotion"
+        aria-live="polite"
+      >
+        <div className={styles.bannerContainer}>
+          <p className={styles.mobileCaption} id="mulk-banner-caption">
+            <strong className={styles.captionBold}>{t('mulk-lp.caption-bold')} </strong>
+            {t('mulk-lp.caption-suffix')}
+          </p>
+
+          <Link
+            href={LEARNING_PLAN_URL}
+            className={styles.imageLink}
+            ariaLabel={t('mulk-lp.aria-image-link')}
+          >
+            <div className={styles.imageWrap}>
+              <Image
+                src={BANNER_IMAGE_PATH}
+                alt={t('mulk-lp.image-alt')}
+                width={BANNER_WIDTH}
+                height={BANNER_HEIGHT}
+                sizes="(max-width: 768px) 100vw, 1230px"
+              />
+            </div>
+          </Link>
+
+          <Button
+            size={ButtonSize.Medium}
+            href={LEARNING_PLAN_URL}
+            className={styles.mobileButton}
+            ariaLabel={t('mulk-lp.aria-cta')}
+          >
+            {t('mulk-lp.cta-text')}
+          </Button>
+
+          <div className={styles.desktopCaptionRow} aria-labelledby="mulk-banner-caption">
+            <p className={styles.desktopCaption}>
+              <strong className={styles.captionBold}>{t('mulk-lp.caption-bold')} </strong>
+              {t('mulk-lp.caption-suffix')}
+            </p>
+            <Button
+              size={ButtonSize.Medium}
+              href={LEARNING_PLAN_URL}
+              className={styles.desktopButton}
+              ariaLabel={t('mulk-lp.aria-cta')}
+            >
+              {t('mulk-lp.cta-text')}
+            </Button>
+          </div>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+export default MulkLearningPlanBanner;

--- a/src/components/QuranReader/index.tsx
+++ b/src/components/QuranReader/index.tsx
@@ -6,6 +6,7 @@ import ContextMenu from './ContextMenu';
 import { VerseTrackerContextProvider } from './contexts/VerseTrackerContext';
 import DebuggingObserverWindow from './DebuggingObserverWindow';
 import useSyncChapterPage from './hooks/useSyncChapterPage';
+import MulkLearningPlanBanner from './MulkLearningPlanBanner';
 import Notes from './Notes/Notes';
 import styles from './QuranReader.module.scss';
 import QuranReaderView from './QuranReaderView';
@@ -66,6 +67,13 @@ const QuranReader = ({
         </div>
       </div>
       <Notes />
+      {lang === 'en' &&
+        quranReaderDataType === QuranReaderDataType.Chapter &&
+        Number(id) === 67 && (
+          <MulkLearningPlanBanner
+            key={`mulk-banner-${isReadingPreference ? 'reading' : 'translation'}`}
+          />
+        )}
     </>
   );
 };

--- a/tests/integration/learning-plan-banner/mulk-learning-plan-banner.spec.ts
+++ b/tests/integration/learning-plan-banner/mulk-learning-plan-banner.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+
+const LP_URL = '/learning-plans/the-rescuer-powerful-lessons-in-surah-al-mulk';
+const BANNER_ROLE = { name: 'Learning plan promotion' };
+
+const banner = (page: Page) => page.getByRole('region', BANNER_ROLE);
+const bannerImage = (page: Page) =>
+  banner(page).locator(
+    'img[alt="The Rescuer: Powerful Lessons in Surah Mulk learning plan banner"]',
+  );
+const imageLink = (page: Page) =>
+  page.locator('a[aria-label="View The Rescuer learning plan for Surah Al-Mulk"]');
+const anyCTAInBanner = (page: Page) => banner(page).locator(`a[href="${LP_URL}"]`).first();
+
+const getOpacity = async (locator: Locator) =>
+  locator.evaluate((el) => parseFloat(window.getComputedStyle(el as HTMLElement).opacity));
+
+async function scrollToBottom(page: Page) {
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+}
+
+async function expectBannerNotYetVisible(page: Page) {
+  const $banner = banner(page);
+  await expect($banner).toHaveCount(1);
+  await expect.poll(async () => getOpacity($banner)).toBeLessThan(0.01);
+}
+
+async function waitForBannerVisible(page: Page) {
+  const $banner = banner(page);
+  await expect($banner).toHaveCount(1);
+  await page.waitForFunction((lpUrl) => {
+    const el = document.querySelector('[role="region"][aria-label="Learning plan promotion"]');
+    if (!el) return false;
+    const opacity = parseFloat(window.getComputedStyle(el as HTMLElement).opacity);
+    return opacity > 0.95 || !!(el as HTMLElement).querySelector(`a[href="${lpUrl}"]`);
+  }, LP_URL);
+  return $banner;
+}
+
+test.describe('English language - rendering', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/67');
+  });
+
+  test('shows near the end, image + caption + CTA present', async ({ page }) => {
+    await expectBannerNotYetVisible(page);
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+    await expect(bannerImage(page)).toBeVisible();
+    await expect(imageLink(page)).toHaveAttribute('href', LP_URL);
+    await expect(anyCTAInBanner(page)).toHaveAttribute('href', LP_URL);
+  });
+
+  test('not shown before scrolling near the end', async ({ page }) => {
+    await expectBannerNotYetVisible(page);
+  });
+});
+
+test.describe('English language - navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/67');
+  });
+
+  test('clicking banner image navigates to LP', async ({ page }) => {
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+    await imageLink(page).click();
+    await expect(page).toHaveURL(LP_URL);
+  });
+
+  test('clicking CTA anchor navigates to LP', async ({ page }) => {
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+    await anyCTAInBanner(page).click();
+    await expect(page).toHaveURL(LP_URL);
+  });
+});
+
+test.describe('English language - visibility behavior', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/67');
+  });
+
+  test('once visible, it stays visible even if user scrolls away', async ({ page }) => {
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+    await page.evaluate(() => window.scrollTo(0, Math.max(0, window.scrollY - 1200)));
+    await expect(banner(page)).toHaveClass(/visible/);
+    await expect(anyCTAInBanner(page)).toHaveAttribute('href', LP_URL);
+    await scrollToBottom(page);
+    await expect(banner(page)).toHaveClass(/visible/);
+  });
+});
+
+test.describe('English language - viewport', () => {
+  test('works across viewport sizes', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto('/67');
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/67');
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+  });
+});
+
+test.describe('Non-English language', () => {
+  test('Arabic version does not render the banner', async ({ page }) => {
+    await page.goto('/ar/67');
+    await scrollToBottom(page);
+    await expect(banner(page)).toHaveCount(0);
+  });
+
+  test('French version does not render the banner', async ({ page }) => {
+    await page.goto('/fr/67');
+    await scrollToBottom(page);
+    await expect(banner(page)).toHaveCount(0);
+  });
+});
+
+test.describe('Other chapters', () => {
+  test('Al-Fatiha (1) does not render the banner', async ({ page }) => {
+    await page.goto('/1');
+    await scrollToBottom(page);
+    await expect(banner(page)).toHaveCount(0);
+  });
+
+  test('Al-Baqarah (2) does not render the banner', async ({ page }) => {
+    await page.goto('/2');
+    await scrollToBottom(page);
+    await expect(banner(page)).toHaveCount(0);
+  });
+});
+
+test.describe('Responsive', () => {
+  test('mobile viewport renders mobile caption + CTA anchor', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/67');
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+    await expect(bannerImage(page)).toBeVisible();
+    await expect(anyCTAInBanner(page)).toHaveAttribute('href', LP_URL);
+  });
+});
+
+test.describe('Accessibility', () => {
+  test('has ARIA role/label and allows keyboard focus on the image link', async ({ page }) => {
+    await page.goto('/67');
+    await scrollToBottom(page);
+    await waitForBannerVisible(page);
+    await expect(banner(page)).toHaveAttribute('role', 'region');
+    await expect(banner(page)).toHaveAttribute('aria-label', 'Learning plan promotion');
+    const link = imageLink(page);
+    await expect(link).toBeVisible();
+    await link.focus();
+    await expect(link).toBeFocused();
+  });
+});


### PR DESCRIPTION
# Summary

# [QF-3439](https://quranfoundation.atlassian.net/browse/QF-3439?atlOrigin=eyJpIjoiM2JhZjNiOGRlNzhkNDYzNGEzZmJhNTk2ZjQ2MjFhN2UiLCJwIjoiaiJ9)

Add an English-only banner the end of **Surah Al-Mulk (/67)** promoting the learning plan **“The Rescuer: Powerful Lessons in Surah Al-Mulk.”** The banner includes a short description and a CTA; clicking either navigates to `/learning-plans/the-rescuer-powerful-lessons-in-surah-al-mulk`. Renders in both **Reading** and **Translation** modes, and only when the site language is **English**.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update  

## Test plan

**Automated (Playwright)**
- Run: `yarn test:integration`
  - Renders banner near the end on `/67` (EN).
  - Clicking image and CTA navigates to `/learning-plans/the-rescuer-powerful-lessons-in-surah-al-mulk`.
  - Banner does **not** render on `/1` or `/2`.
  - Banner does **not** render on `/ar/67` or `/fr/67`.
  - Works across viewport sizes; a11y roles/labels and keyboard focus verified.


**Manual QA**
1. Open `/67` (English), scroll to end → banner fades in with exact description.
2. Click image or “Begin Now” → navigates to the learning-plan page.
3. Switch to **Arabic** or **French** → banner is hidden.
4. Toggle between **Reading** and **Translation** → banner shows in both.

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] My changes generate no new warnings  
- [ ] Any dependent changes have been merged and published in downstream modules  
- [x] I have commented on my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] I have added tests that prove my feature works  
- [x] New and existing unit tests pass locally with my changes  

## Screenshots or videos

| Before | After |
| ------ | ----- |
| IMAGE HERE | IMAGE HERE |

**Files**
- `public/images/learning-plans/mulk-rescuer-banner.png`  
- `src/components/QuranReader/MulkLearningPlanBanner/index.tsx`  
- `src/components/QuranReader/MulkLearningPlanBanner/MulkLearningPlanBanner.module.scss`  
- `src/components/QuranReader/index.tsx` (conditional integration for `/67` EN)  
- `locales/en/common.json` (added `mulk-lp.*` copy/alt/aria keys)  
- `tests/integration/learning-plan-banner/mulk-learning-plan-banner.spec.ts`
