### PR TITLE
Fix: QF-3500 Sharing search query did not include the query parameters

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -88,7 +88,21 @@ const SearchPage: NextPage<SearchPageProps> = (): JSX.Element => {
     }),
     [currentPage, searchQuery],
   );
+
   useAddQueryParamsToUrl(navigationUrl, queryParams);
+
+  // Generate canonical path so that it can be used by the built-in mobile share button
+  const canonicalPath = useMemo(() => {
+    const params = new URLSearchParams();
+    if (searchQuery) {
+      params.set(QueryParam.QUERY, searchQuery);
+    }
+    if (currentPage > 1) {
+      params.set(QueryParam.PAGE, String(currentPage));
+    }
+    const queryString = params.toString();
+    return `${navigationUrl}${queryString ? `?${queryString}` : ''}`;
+  }, [currentPage, searchQuery]);
 
   const REQUEST_PARAMS = getAdvancedSearchQuery(
     searchQuery,
@@ -137,8 +151,8 @@ const SearchPage: NextPage<SearchPageProps> = (): JSX.Element => {
             : t('search:search')
         }
         description={t('search:search-desc')}
-        canonical={getCanonicalUrl(lang, navigationUrl)}
-        languageAlternates={getLanguageAlternates(navigationUrl)}
+        canonical={getCanonicalUrl(lang, canonicalPath)}
+        languageAlternates={getLanguageAlternates(canonicalPath)}
       />
       <div className={styles.pageContainer}>
         <div className={styles.searchInputContainer}>


### PR DESCRIPTION
# Summary

Fixes #QF-3500

Fixed the canonical path of the NextSeoWrapper component to include the query parameters.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

I've launched all Playwright tests, and they all passed. I tried sharing the link on a mobile phone, and the issue was resolved. Since Playwright does not support the built-in share button for mobile emulation, writing tests for this is not possible.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas

## Screenshots or videos

| Before | After |
| ----- | ------ |
| ![5994441269427947422](https://github.com/user-attachments/assets/0df0c1d0-e90c-405a-968f-2e7efe6ec96a) |![5994441269427947421](https://github.com/user-attachments/assets/2aa30191-af2a-4c2f-a027-65f8e941c338) |
