### PR TITLE
QF-3501 - Fix "Tafsirs" button triggering Surah selection

### DIFF
--- a/src/components/dls/ContentModal/ContentModal.tsx
+++ b/src/components/dls/ContentModal/ContentModal.tsx
@@ -60,6 +60,7 @@ const ContentModal = ({
   isBottomSheetOnMobile = true,
 }: ContentModalProps) => {
   const overlayRef = useRef<HTMLDivElement>();
+  const contentRef = useRef<HTMLDivElement>(null);
   const { locale } = useRouter();
   useImperativeHandle(innerRef, () => ({
     scrollToTop: () => {
@@ -96,11 +97,13 @@ const ContentModal = ({
   };
 
   /**
-   * Prevents Safari from clicking on the first input element inside the modal
+   * Prevents Safari from focusing the first focusable element in the modal.
    * @param {Event} event
    */
-  const handleOpen = useCallback((event: Event) => {
+  const handleOpenAutoFocus = useCallback((event: Event) => {
+    if (event.defaultPrevented) return;
     event.preventDefault();
+    contentRef.current?.focus({ preventScroll: true });
   }, []);
 
   return (
@@ -117,6 +120,7 @@ const ContentModal = ({
         >
           <Dialog.Content
             {...(onClick && { onClick })}
+            ref={contentRef}
             className={classNames(styles.contentWrapper, {
               [contentClassName]: contentClassName,
               [styles.small]: size === ContentModalSize.SMALL,
@@ -126,7 +130,7 @@ const ContentModal = ({
             })}
             onEscapeKeyDown={onEscapeKeyDown}
             onPointerDownOutside={onPointerDownOutside}
-            onOpenAutoFocus={handleOpen}
+            onOpenAutoFocus={handleOpenAutoFocus}
           >
             {hasHeader && (
               <div className={classNames(styles.header, headerClassName)}>


### PR DESCRIPTION
# Summary

Fixes #QF-3501

On iOS Safari, opening the Tafsir modal automatically focused the first focusable element, causing the Surah `<select>` to open by itself. I now intercept `onOpenAutoFocus` inside `ContentModal` and redirect focus to the modal container using `event.preventDefault();`. This ensures that no dropdown receives focus and no input is opened automatically.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

I tested using BrowserStack and confirmed that the issue is resolved on Safari. I also tested on other browsers to ensure everything continues to work correctly.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved modal open handling to ensure consistent focus behavior across browsers.

* **Bug Fixes**
  * Prevents Safari from auto-focusing the first interactive element when a modal opens, avoiding unexpected scroll jumps.

* **Accessibility**
  * Focus now reliably lands on modal content on open, improving keyboard navigation and screen reader context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->