### PR TITLE
Fix: Quran in a Year auto scrolling

### DIFF
--- a/src/components/QuranicCalendar/MyProgress/MonthCard.tsx
+++ b/src/components/QuranicCalendar/MyProgress/MonthCard.tsx
@@ -45,6 +45,8 @@ const MonthCard: React.FC<MonthCardProps> = ({
     try {
       // Call the parent's onWeekSelect to update the selected week
       onWeekSelect(weekNumber);
+      // Scroll to top to see the updated verses
+      window.scrollTo({ top: 0 });
     } catch (error) {
       toast(t('common:error.general'), { status: ToastStatus.Error });
     } finally {

--- a/tests/POM/home-page.ts
+++ b/tests/POM/home-page.ts
@@ -1,4 +1,4 @@
-import { BrowserContext, expect, Page } from '@playwright/test';
+import { BrowserContext, Locator, Page } from '@playwright/test';
 
 class Homepage {
   readonly page: Page;
@@ -16,8 +16,35 @@ class Homepage {
     this.context = context;
   }
 
-  async goTo() {
-    await this.page.goto('/');
+  /**
+   * Navigate to a specific path.
+   * @param {string} path The path to navigate to, defaults to the homepage ('/')
+   */
+  async goTo(path: string = '/') {
+    await this.page.goto(path, { waitUntil: 'networkidle' });
+    await this.hideNextJSOverlay();
+  }
+
+  /**
+   * Reload the current page.
+   */
+  async reload() {
+    await this.page.reload({ waitUntil: 'networkidle' });
+    await this.hideNextJSOverlay();
+  }
+
+  /**
+   * Hide the Next.js error overlay that may appear on the page.
+   * Needed to click on elements behind it.
+   */
+  async hideNextJSOverlay() {
+    await this.page.addStyleTag({
+      content: `
+      nextjs-portal {
+        display: none;
+      }
+    `,
+    });
   }
 
   /**
@@ -38,14 +65,29 @@ class Homepage {
    * @returns {any|null}
    */
   async getPersistedValue(name: string, storageKey = 'persist:root'): Promise<any | null> {
-    await this.page.waitForTimeout(1000);
+    // Wait for the page to be fully loaded and React to initialize localStorage
+    await this.page.waitForLoadState('networkidle');
+
+    // Wait for React hydration and localStorage to be populated
+    await this.page.waitForFunction(
+      () => {
+        return window.localStorage.getItem('persist:root') !== null;
+      },
+      { timeout: 10000 },
+    );
+
     const storage = await this.context.storageState();
-    expect(storage?.origins?.[0]?.localStorage).not.toBe(undefined);
-    const localStorageArray = storage?.origins?.[0]?.localStorage;
+
+    if (!storage.origins || storage.origins.length === 0) {
+      return null;
+    }
+    const localStorageArray = storage.origins[0].localStorage;
+
     const persistedRoot = localStorageArray.filter(
       (localStorageObject) => localStorageObject.name === storageKey,
     );
-    if (!persistedRoot) {
+
+    if (!persistedRoot || persistedRoot.length === 0) {
       return null;
     }
     const parentObject = JSON.parse(persistedRoot[0].value);
@@ -56,7 +98,31 @@ class Homepage {
   }
 
   async openSettingsDrawer() {
-    await this.page.locator('[aria-label="Change Settings"]').click();
+    await this.page.getByTestId('settings-button').click();
+  }
+
+  async enableMushafMode(isMobile: boolean) {
+    if (isMobile) {
+      // scroll down a little to make the tab visible (bypassing a render issue)
+      // FIXME: Remove this workaround when the underlying issue is fixed
+      await this.page.mouse.wheel(0, 200);
+      await this.page.mouse.wheel(0, -100);
+
+      await this.page.getByTestId('reading-tab').click();
+    } else {
+      await this.page.getByTestId('reading-button').click();
+    }
+  }
+
+  /**
+   * Search for a query using the search bar and return the search results locator.
+   * @param {string} query The search query to fill in the search bar
+   * @returns {Promise<Locator>} The search results locator
+   */
+  async searchFor(query: string): Promise<Locator> {
+    const searchBar = this.page.locator('#searchQuery');
+    await searchBar.fill(query);
+    return this.page.getByTestId('search-results');
   }
 }
 

--- a/tests/integration/quran-in-a-year/quran-in-a-year.spec.ts
+++ b/tests/integration/quran-in-a-year/quran-in-a-year.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+import Homepage from '@/tests/POM/home-page';
+
+let homepage: Homepage;
+
+test.beforeEach(async ({ page, context }) => {
+  homepage = new Homepage(page, context);
+  await homepage.goTo('/calendar');
+});
+
+test(
+  'Selecting a week should scroll to the top of the page',
+  { tag: ['@quran-in-a-year'] },
+  async ({ page }) => {
+    // Scroll to the bottom of the page
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    // Click on a week button
+    const weekButton = page.getByLabel('Week 1 of Shawwal');
+    await weekButton.click();
+
+    // Wait for the scroll to complete
+    await page.waitForTimeout(500);
+
+    // Check if the page has scrolled to the top
+    const scrollPosition = await page.evaluate(() => window.scrollY);
+    expect(scrollPosition).toBeLessThan(100);
+  },
+);


### PR DESCRIPTION
# Summary

Fixes #QF-2854

Selecting a week in the calendar on the "Quran In a Year" page now triggers a scroll to the top of the page.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

Added a Playwright test to verify that the scroll occurs correctly when a week is clicked.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Quranic Calendar now auto-scrolls to the top after selecting a week, improving navigation and readability.

- Tests
  - Added an end-to-end test to verify the calendar scroll-to-top behavior.
  - Enhanced test utilities with improved navigation, page reload, search, mode switching, and overlay handling to increase test reliability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->