### PR TITLE
QF-2651 : Text does not wrap on saved notes

### DIFF
--- a/src/components/Notes/NoteModal/EditNoteMode/EditNoteListItem/NoteListItem.module.scss
+++ b/src/components/Notes/NoteModal/EditNoteMode/EditNoteListItem/NoteListItem.module.scss
@@ -1,33 +1,33 @@
 .container {
-  margin-block: var(--spacing-xsmall);
-  border: 1px var(--color-borders-hairline) solid;
-  padding: var(--spacing-small);
-  border-radius: var(--border-radius-rounded);
-  box-shadow: var(--shadow-small);
+    margin-block: var(--spacing-xsmall);
+    border: 1px var(--color-borders-hairline) solid;
+    padding: var(--spacing-small);
+    border-radius: var(--border-radius-rounded);
+    box-shadow: var(--shadow-small);
 }
 
 .headerContainer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .noteBody {
-  margin-block-end: var(--spacing-small);
-  text-wrap: wrap;
-  overflow-wrap: break-word;
-  text-align: justify;
-  white-space: pre-wrap;
+    margin-block-end: var(--spacing-small);
+    text-wrap: wrap;
+    overflow-wrap: break-word;
+    text-align: justify;
+    white-space: pre-wrap;
 }
 
 .shareButtonContainer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
 }
 
 .buttonsContainer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
 }


### PR DESCRIPTION
# Summary

Fixes #QF-2651

Changed `line-break: anywhere` to:

```css
text-wrap: wrap;
overflow-wrap: break-word;
text-align: justify;
```

in the notes text CSS.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

I didn’t find it necessary to write a specific test for something this trivial, so I just verified that the CSS displays correctly on the page.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules


## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="1192" height="607" alt="image" src="https://github.com/user-attachments/assets/c202d5ac-50fb-48c0-9823-9f2843af1a6e" /> | <img width="1170" height="582" alt="image" src="https://github.com/user-attachments/assets/94436df7-17cb-4207-9ace-de69211d194a" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved note body readability with refined text wrapping and alignment.
  * Long words now break gracefully to prevent overflow and layout shifts.
  * Paragraphs are justified for a cleaner, more polished appearance.
  * Manual line breaks are preserved to maintain author formatting.
  * Enhances consistency across different screen sizes and note lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->