### PR TITLE
QF-1295 - Hides the navbar during automatic scrolling to a verse

### DIFF
--- a/src/components/QuranReader/ReadingView/Line.tsx
+++ b/src/components/QuranReader/ReadingView/Line.tsx
@@ -53,8 +53,8 @@ const Line = ({ lineKey, words, isBigTextLayout, pageIndex, lineIndex }: LinePro
   useEffect(() => {
     if (isHighlighted && enableAutoScrolling) {
       // Hide the navbar and lock its state to avoid showing it on scroll
-      dispatch({ type: setIsVisible.type, payload: false });
-      dispatch({ type: setLockVisibilityState.type, payload: true });
+      dispatch(setIsVisible(false));
+      dispatch(setLockVisibilityState(true));
 
       scrollToSelectedItem();
 
@@ -63,9 +63,9 @@ const Line = ({ lineKey, words, isBigTextLayout, pageIndex, lineIndex }: LinePro
         window.clearTimeout(hideNavbarTimeoutRef.current);
       }
       hideNavbarTimeoutRef.current = window.setTimeout(() => {
-        dispatch({ type: setIsVisible.type, payload: false });
-        dispatch({ type: setLockVisibilityState.type, payload: false });
-      }, 1000);
+        dispatch(setIsVisible(false));
+        dispatch(setLockVisibilityState(false));
+      }, 1500);
     }
   }, [dispatch, enableAutoScrolling, isHighlighted, scrollToSelectedItem]);
 
@@ -74,9 +74,8 @@ const Line = ({ lineKey, words, isBigTextLayout, pageIndex, lineIndex }: LinePro
       if (hideNavbarTimeoutRef.current) {
         window.clearTimeout(hideNavbarTimeoutRef.current);
       }
-      dispatch({ type: setLockVisibilityState.type, payload: false });
     },
-    [dispatch],
+    [],
   );
   const firstWordData = getWordDataByLocation(words[0].location);
   const shouldShowChapterHeader = firstWordData[1] === '1' && firstWordData[2] === '1';

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -67,8 +67,8 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
   useEffect(() => {
     if ((isHighlighted && enableAutoScrolling) || Number(startingVerse) === verseIndex + 1) {
       // Hide the navbar and lock its state to avoid showing it on scroll
-      dispatch({ type: setIsVisible.type, payload: false });
-      dispatch({ type: setLockVisibilityState.type, payload: true });
+      dispatch(setIsVisible(false));
+      dispatch(setLockVisibilityState(true));
 
       scrollToSelectedItem();
 
@@ -77,8 +77,8 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
         window.clearTimeout(hideNavbarTimeoutRef.current);
       }
       hideNavbarTimeoutRef.current = window.setTimeout(() => {
-        dispatch({ type: setIsVisible.type, payload: false });
-        dispatch({ type: setLockVisibilityState.type, payload: false });
+        dispatch(setIsVisible(false));
+        dispatch(setLockVisibilityState(false));
       }, 1000);
     }
   }, [
@@ -95,9 +95,8 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
       if (hideNavbarTimeoutRef.current) {
         window.clearTimeout(hideNavbarTimeoutRef.current);
       }
-      dispatch({ type: setLockVisibilityState.type, payload: false });
     },
-    [dispatch],
+    [],
   );
   const translationsLabel = getTranslationsLabelString(verse.translations);
   const translationsCount = verse.translations?.length || 0;


### PR DESCRIPTION
# Summary

Fixes #QF-1295

Prevents the navbar from overlapping and hiding part of the verse during automatic scrolling in reading mode.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

A Playwright test has been added to ensure that the navbar correctly hides itself during automatic scrolling to a verse (see [this commit](https://github.com/quran/quran.com-frontend-next/commit/e9feb0a481ebd930353eed6e27e3614496f69867)).

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="2549" height="785" alt="image" src="https://github.com/user-attachments/assets/8f597616-9361-4697-9c02-270fe5d38c91" /> | <img width="2543" height="787" alt="image" src="https://github.com/user-attachments/assets/97dedae1-ecd2-467e-875a-f01a431ed7f8" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading and Translation views now auto-hide and lock the navbar during auto-scrolling to a highlighted verse/line, then restore it after 1 second for a cleaner, focused jump.
  * Debounce and cleanup improvements prevent flicker and ensure the navbar lock is reliably reset when navigating away.

* **Tests**
  * Added a test identifier to verse containers to improve UI test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->