### PR TITLE
QF-1295 - Hides the navbar during automatic scrolling to a verse #2530

### DIFF
--- a/src/components/QuranReader/ReadingView/Line.tsx
+++ b/src/components/QuranReader/ReadingView/Line.tsx
@@ -56,8 +56,8 @@ const Line = ({
     shallowEqual,
   );
 
-  // Use the custom hook for navbar auto-hide functionality with 1500ms timeout
-  useNavbarAutoHide(isHighlighted && enableAutoScrolling, scrollToSelectedItem, 1500, [
+  // Use the custom hook for navbar auto-hide functionality
+  useNavbarAutoHide(isHighlighted && enableAutoScrolling, scrollToSelectedItem, [
     enableAutoScrolling,
     isHighlighted,
     scrollToSelectedItem,

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -64,7 +64,7 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
 
   const shouldTrigger =
     (isHighlighted && enableAutoScrolling) || Number(startingVerse) === verseIndex + 1;
-  useNavbarAutoHide(shouldTrigger, scrollToSelectedItem, 1000, [
+  useNavbarAutoHide(shouldTrigger, scrollToSelectedItem, [
     enableAutoScrolling,
     isHighlighted,
     scrollToSelectedItem,

--- a/src/hooks/useNavbarAutoHide.ts
+++ b/src/hooks/useNavbarAutoHide.ts
@@ -4,6 +4,8 @@ import { useDispatch } from 'react-redux';
 
 import { setIsVisible, setLockVisibilityState } from '@/redux/slices/navbar';
 
+const DEFAULT_TIMEOUT_MS = 1000;
+
 /**
  * A custom hook that handles navbar auto-hide functionality during automatic scrolling.
  *
@@ -14,15 +16,15 @@ import { setIsVisible, setLockVisibilityState } from '@/redux/slices/navbar';
  *
  * @param {boolean} shouldTrigger - Boolean condition that determines when to trigger the auto-hide behavior
  * @param {() => void} scrollCallback - Function to call for scrolling (e.g., scrollToSelectedItem)
- * @param {number} timeout - Time in milliseconds to wait before unlocking navbar visibility (default: 1000ms)
  * @param {React.DependencyList} dependencies - Additional dependencies for the useEffect hook
+ * @param {number} timeout - Time in milliseconds to wait before unlocking navbar visibility (default: 1000ms)
  * @returns {React.MutableRefObject<number | undefined>} Reference to the timeout ID for cleanup
  */
 const useNavbarAutoHide = (
   shouldTrigger: boolean,
   scrollCallback: () => void,
-  timeout: number = 1000,
   dependencies: React.DependencyList = [],
+  timeout: number = DEFAULT_TIMEOUT_MS,
 ) => {
   const dispatch = useDispatch();
   const hideNavbarTimeoutRef = useRef<number | undefined>(undefined);


### PR DESCRIPTION
# Summary

Fixes #QF-1295

Prevents the navbar from overlapping and hiding part of the verse during automatic scrolling in reading mode.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

A Playwright test has been added to ensure that the navbar correctly hides itself during automatic scrolling to a verse (see [this commit](https://github.com/quran/quran.com-frontend-next/commit/e9feb0a481ebd930353eed6e27e3614496f69867)).

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="2549" height="785" alt="image" src="https://github.com/user-attachments/assets/8f597616-9361-4697-9c02-270fe5d38c91" /> | <img width="2543" height="787" alt="image" src="https://github.com/user-attachments/assets/97dedae1-ecd2-467e-875a-f01a431ed7f8" /> |
| before (video) https://github.com/user-attachments/assets/a5e710ee-45f1-41cd-bd7d-2dfb0cde15b5  | after (video) https://github.com/user-attachments/assets/bbe19f93-67b7-4d47-b68f-909756994f89 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navbar now auto-hides and locks while a line or verse is highlighted, then restores after a short delay for a distraction-free reading experience.
  * Smoother scrolling when navigating to highlighted content in Reading and Translation views.
* **Tests**
  * Added identifiers to verse containers to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->