### PR TITLE
QF-2998 - Fixed line height of Answer text

### DIFF
--- a/src/components/MarkdownEditor/MarkdownEditor.module.scss
+++ b/src/components/MarkdownEditor/MarkdownEditor.module.scss
@@ -1,92 +1,94 @@
 .editor {
-    li, p {
-        font-size: var(--font-size-large);
-    }
-    // min-height: calc(var(--spacing-mega) * 10);
-    em,
-    strong {
-        all: revert;
+  li,
+  p {
+    font-size: var(--font-size-large);
+    line-height: 160%;
+  }
+  // min-height: calc(var(--spacing-mega) * 10);
+  em,
+  strong {
+    all: revert;
+  }
+
+  ul,
+  ol {
+    padding: 0 var(--spacing-medium);
+  }
+  ul {
+    list-style: initial !important;
+  }
+  ol {
+    list-style-type: decimal !important;
+  }
+
+  li {
+    padding-block: var(--spacing-micro);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    all: revert;
+  }
+
+  hr {
+    margin: var(--spacing-medium) 0;
+    border: none;
+    border-block-start: 2px solid var(--color-background-inverse);
+  }
+  blockquote {
+    background-color: var(--color-success-faint);
+    display: block;
+    padding: var(--spacing-mega);
+    margin-block: var(--spacing-large);
+    position: relative;
+    border-radius: var(--border-radius-rounded);
+
+    /*Font*/
+    line-height: var(--line-height-jumbo);
+    color: var(--color-text-default);
+
+    &::before {
+      content: '\201C'; /*Unicode for Left Double Quote*/
+
+      /*Font*/
+      font-family: Georgia, serif;
+      font-size: calc(1.6 * var(--font-size-jumbo));
+      font-weight: bold;
+      color: var(--color-text-default);
+
+      /*Positioning*/
+      position: absolute;
+      inset-inline-start: var(--spacing-medium);
+      inset-block-start: var(--spacing-medium);
     }
 
-    ul,
-    ol {
-        padding: 0 var(--spacing-medium);
-    }
-    ul {
-        list-style: initial !important;
-    }
-    ol {
-        list-style-type: decimal !important;
+    &::after {
+      /*Reset to make sure*/
+      content: '';
     }
 
-    li {
-        padding-block: var(--spacing-micro);
+    p {
+      font-size: var(--font-size-xlarge);
+      font-weight: var(--font-weight-semibold);
+      line-height: var(--line-height-xlarge);
+      text-align: center;
     }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        all: revert;
-    }
-
-    hr {
-        margin: var(--spacing-medium) 0;
-        border: none;
-        border-top: 2px solid var(--color-background-inverse);
-    }
-    blockquote {
-        background-color: var(--color-success-faint);
-        display: block;
-        padding: var(--spacing-mega);
-        margin-block: var(--spacing-large);
-        position: relative;
-        border-radius: var(--border-radius-rounded);
-
-        /*Font*/
-        line-height: var(--line-height-jumbo);
-        color: var(--color-text-default);
-
-        &::before {
-            content: "\201C"; /*Unicode for Left Double Quote*/
-
-            /*Font*/
-            font-family: Georgia, serif;
-            font-size: calc(1.6 * var(--font-size-jumbo));
-            font-weight: bold;
-            color: var(--color-text-default);
-
-            /*Positioning*/
-            position: absolute;
-            inset-inline-start: var(--spacing-medium);
-            inset-block-start: var(--spacing-medium);
-        }
-
-        &::after {
-            /*Reset to make sure*/
-            content: "";
-        }
-
-        p {
-            font-size: var(--font-size-xlarge);
-            font-weight: var(--font-weight-semibold);
-            line-height: var(--line-height-xlarge);
-            text-align: center;
-        }
-    }
-    img {
-        display: block;
-        margin: auto;
-        max-width: 100%;
-    }
-    iframe {
-        display: block; // Makes iframe a block element, ensuring it's on a new line
-        margin: var(--spacing-medium) auto; // Centers the iframe and adds vertical spacing
-        max-width: 100%;
-    }
+  }
+  img {
+    display: block;
+    margin: auto;
+    max-inline-size: 100%;
+  }
+  iframe {
+    display: block; // Makes iframe a block element, ensuring it's on a new line
+    margin: var(--spacing-medium) auto; // Centers the iframe and adds vertical spacing
+    max-inline-size: 100%;
+  }
 }
 .content {
-    flex: 1 1 auto;
+  flex: 1 1 auto;
 }


### PR DESCRIPTION
# Summary

Fixes #QF-2998

Increased the line height of the answer body for questions.

**Note**: As for making the bullet letters bold and placing each on a new line, this should be done directly in the database by adding line breaks `\n` and surrounding the letters with bold formatting, e.g., `**a.**`. If needed, I can implement a programmatic solution for this, but it wouldn’t be clean.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

I visually verified that the line height has been correctly increased.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="1399" height="713" alt="image" src="https://github.com/user-attachments/assets/cc51bf04-bbf2-4529-89d0-f280f4154539" /> | <img width="1439" height="751" alt="image" src="https://github.com/user-attachments/assets/0845f114-5d87-4c1b-89ab-168c419b1030" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined Markdown editor typography, list and paragraph spacing, headings, blockquote visuals, and normalized images/iframes for consistent rendering.

* **New Features**
  * Temporarily hides the top navigation when a verse/line is programmatically highlighted to improve focus during auto-scroll.

* **Chores**
  * Added test identifiers to verse containers for more reliable UI testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->