### PR TITLE
QF-3062 - Show 'Verses about the Sunnah' link only in production environment

### DIFF
--- a/src/components/HomePage/ExploreTopicsSection/index.tsx
+++ b/src/components/HomePage/ExploreTopicsSection/index.tsx
@@ -9,6 +9,8 @@ import Button, { ButtonShape, ButtonSize, ButtonType, ButtonVariant } from '@/dl
 import ArrowIcon from '@/public/icons/arrow.svg';
 import { logButtonClick } from '@/utils/eventLogger';
 
+const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+
 const TOPICS = [
   {
     slug: 'about-the-quran',
@@ -21,11 +23,15 @@ const TOPICS = [
   //   logKey: 'jesus-in-quran',
   //   key: 'jesus-in-quran',
   // },
-  {
-    slug: 'collections/the-authority-and-importance-of-the-sunnah-clem7p7lf15921610rsdk4xzulfj',
-    key: 'sunnah',
-    logKey: 'sunnah_collection',
-  },
+  ...(isProduction
+    ? [
+        {
+          slug: 'collections/the-authority-and-importance-of-the-sunnah-clem7p7lf15921610rsdk4xzulfj',
+          key: 'sunnah',
+          logKey: 'sunnah_collection',
+        },
+      ]
+    : []),
   {
     slug: 'what-is-ramadan',
     logKey: 'what-is-ramadan',


### PR DESCRIPTION
# Summary

Fixes #QF-3062

Show the "Verses about the Sunnah" link only in production.
The backing collection for this link exists in the production database but not in testing.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

* Manually verified that the link **does not** appear when the environment is non-production.
* Manually verified that the link **does** appear when the environment is set to production.

Note: Automating this with Playwright is non-trivial because it requires swapping environment variables at runtime.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="2098" height="682" alt="image" src="https://github.com/user-attachments/assets/5cd95856-0269-4ba8-9d66-26477629435c" /> | <img width="2081" height="700" alt="image" src="https://github.com/user-attachments/assets/06536dc3-e15c-4940-a123-013881484278" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sunnah topic is now available in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->