### PR TITLE
QF-2492 - Sort collections by name and not id

### DIFF
--- a/src/components/Verse/SaveToCollectionAction.tsx
+++ b/src/components/Verse/SaveToCollectionAction.tsx
@@ -220,7 +220,9 @@ const SaveToCollectionAction: React.FC<Props> = ({
           name: collection.name,
           checked: bookmarkCollectionIdsData?.includes(collection.id),
         }))
-        .sort((a, b) => a.name.localeCompare(b.name)) as Collection[]);
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+        ) as Collection[]);
 
   return (
     <>


### PR DESCRIPTION
# Summary

Fixes #QF-2492

Sorts collections by name instead of ID.
Ideally, an `ORDER BY` clause should be added to the SQL query in the backend, but I don’t have access to it.

## Type of change

* [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

I visually confirmed that collections are now ordered by name.

## Checklist

* [x] My code follows the project’s style guidelines
* [x] I have performed a self-review of my code
* [x] My changes introduce no new warnings
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots or videos

| Before                                                                                                                              | After                                                                                                                              |
| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
| <img width="541" height="378" alt="before" src="https://github.com/user-attachments/assets/dd03972c-f2aa-4faa-8640-b4656bfd655b" /> | <img width="548" height="399" alt="after" src="https://github.com/user-attachments/assets/534d7379-716c-4223-abcc-d159e3d5ea10" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collections now display in a consistent alphabetical order when saving items to collections. This makes it easier to find and select the desired collection, reduces confusion from changing order, and improves the overall saving experience and discoverability. Users will see predictable, stable ordering across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->