### PR TITLE
Enhance ExploreTopicsSection styling for better layout and scrolling …

### DIFF
--- a/src/components/HomePage/ExploreTopicsSection/ExploreTopicsSection.module.scss
+++ b/src/components/HomePage/ExploreTopicsSection/ExploreTopicsSection.module.scss
@@ -23,6 +23,7 @@
     flex-direction: row;
     align-items: center;
     color: var(--color-text-default-new);
+    white-space: nowrap;
 
     @include breakpoints.tablet {
         font-size: var(--font-size-large-px);
@@ -34,13 +35,17 @@
     width: 100%;
     gap: var(--spacing-small);
     flex-wrap: nowrap;
+
     @include breakpoints.smallerThanTablet {
         gap: var(--spacing-xxsmall);
     }
-    overflow-x: scroll;
+
+    overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none;
     -ms-overflow-style: none;
+    -webkit-overflow-scrolling: touch;
+    scroll-behavior: smooth;
 
     &::-webkit-scrollbar {
         display: none;


### PR DESCRIPTION
# Summary

[QF-3541](https://quranfoundation.atlassian.net/browse/QF-3541?atlOrigin=eyJpIjoiMWRmZTdhZTgzMjI5NDBiN2IwZTEwNTczZjIzYTE0YmMiLCJwIjoiaiJ9)

Fixes Safari/iOS 17.5 scrolling and display issues in ExploreTopicsSection

This PR addresses UI rendering problems that occurred specifically in Safari browser and iOS 17.5, where the horizontal scrolling container for explore topics was not functioning properly. The fix includes Safari-specific CSS properties to ensure smooth scrolling behavior and proper overflow handling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

- Manual testing on Safari browser (macOS and iOS 17.5)
- Tests can be run with: yarn test:integration --headed tests/integration/homepage/explore-topics-scroll.spec.ts

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
|:------:|:------:|
| <img width="1284" height="2778" alt="Before screenshot" src="https://github.com/user-attachments/assets/f19757e3-3535-422d-8d94-846abcc96c49" /> | <img width="313" height="603" alt="After screenshot" src="https://github.com/user-attachments/assets/91a3b26a-5b8e-423d-8358-c6c9010a3030" /> |




[QF-3519]: https://quranfoundation.atlassian.net/browse/QF-3519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QF-3541]: https://quranfoundation.atlassian.net/browse/QF-3541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ