### PR TITLE
QF-3548 ch: update ayah reflection URL to use verifiedOnly filter instead of feed flag

### DIFF
--- a/src/utils/quranReflect/apiPaths.ts
+++ b/src/utils/quranReflect/apiPaths.ts
@@ -53,7 +53,7 @@ export const makeAyahReflectionsUrl = ({
     page,
     tab: Tab.Popular, // always reviewed content
     languages: localeToQuranReflectLanguageID(locale),
-    feed: true, // TODO: check this
+    'filter[verifiedOnly]': true,
   });
 };
 


### PR DESCRIPTION
Part of [QF-3548]

[QF-3548]: https://quranfoundation.atlassian.net/browse/QF-3548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API filtering to display only verified content instead of feed-based content, ensuring users see verified posts and reflections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->