### PR TITLE
QF-3656 - Update verse link regex and tests for triple-digit references

### DIFF
--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -50,6 +50,12 @@ describe('Test formatVerseReferencesToLinks', () => {
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
+  it('should convert verse reference with three digit verse number to link', () => {
+    const input = 'Verse 2:123 is important';
+    const expected = 'Verse <a href="/2:123" target="_blank">2:123</a> is important';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
   it('should convert verse range to link', () => {
     const input = 'Verses 1:1-3 are important';
     const expected = 'Verses <a href="/1:1-3" target="_blank">1:1-3</a> are important';
@@ -93,7 +99,7 @@ describe('Test formatVerseReferencesToLinks', () => {
   it('should handle verse references with multiple digits', () => {
     const input = 'See verses 114:1-3 and 1:1-7';
     const expected =
-      'See verses 1<a href="/14:1-3" target="_blank">14:1-3</a> and <a href="/1:1-7" target="_blank">1:1-7</a>';
+      'See verses <a href="/114:1-3" target="_blank">114:1-3</a> and <a href="/1:1-7" target="_blank">1:1-7</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -68,7 +68,7 @@ export const cleanTranscript = (text: string): string => {
 export const formatVerseReferencesToLinks = (text: string): string => {
   if (!text) return '';
   return text.replace(
-    /(\d{1,2}[:-]\d{1,2}(?:-\d{1,2}(?:[:]\d{1,2})?)?)(?![^<]*<\/a>)/g,
+    /(\d{1,3}[:-]\d{1,3}(?:-\d{1,3}(?::\d{1,3})?)?)(?![^<]*<\/a>)/g,
     (match) => `<a href="${`/${match}`}" target="_blank">${match}</a>`,
   );
 };


### PR DESCRIPTION
# Summary

Fixes #QF-3656

Update verse link regex for triple-digit references so patterns like S:VVV are recognized.
Add a unit test for the new scenario.
Fix a test that was itself incorrect.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

Add a unit test for the new scenario.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="1445" height="325" alt="before2" src="https://github.com/user-attachments/assets/2c0fce65-9fff-4b71-b4e2-07cdab4d84bc" /> |<img width="1441" height="314" alt="after2" src="https://github.com/user-attachments/assets/1eee595b-96e9-446d-895e-b8efd5645888" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended verse reference hyperlink support to handle three-digit chapter and verse numbers, enabling proper parsing of references like "114:123" and ranges such as "100:50-102:75".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->