### PR TITLE
Perf - Defer Quran In Year verses fetch until idle

### DIFF
--- a/src/components/HomePage/QuranInYearSection/QuranInYearSection.module.scss
+++ b/src/components/HomePage/QuranInYearSection/QuranInYearSection.module.scss
@@ -1,88 +1,99 @@
-@use "src/styles/breakpoints";
-@use "src/styles/theme";
+@use 'src/styles/breakpoints';
+@use 'src/styles/theme';
 
 .header {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding-block-end: var(--spacing-medium);
-    @include breakpoints.tablet {
-        padding-block-end: var(--spacing-large-px);
-    }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-block-end: var(--spacing-medium);
+  @include breakpoints.tablet {
+    padding-block-end: var(--spacing-large-px);
+  }
 
-    h1 {
-        font-size: var(--font-size-xlarge-px);
-        font-weight: var(--font-weight-bold);
-        @include breakpoints.tablet {
-            font-size: var(--font-size-xxlarge-px);
-        }
+  h1 {
+    font-size: var(--font-size-xlarge-px);
+    font-weight: var(--font-weight-bold);
+    @include breakpoints.tablet {
+      font-size: var(--font-size-xxlarge-px);
     }
+  }
 }
 
 .cardWithIcon {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: var(--spacing-micro);
-    @include breakpoints.tablet {
-        font-size: var(--font-size-large-px);
-    }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-micro);
+  @include breakpoints.tablet {
+    font-size: var(--font-size-large-px);
+  }
 }
 
 .calendarContainer {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .calendarText {
-    font-size: var(--font-size-small-px);
-    @include breakpoints.tablet {
-        font-size: var(--font-size-normal-px);
-    }
+  font-size: var(--font-size-small-px);
+  @include breakpoints.tablet {
+    font-size: var(--font-size-normal-px);
+  }
 }
 
 .container {
-    @include theme.light {
-        box-shadow: 0px 4px 25px 0px rgba(0, 0, 0, 0.1);
-    }
-    @include theme.dark {
-        box-shadow: 0px 4px 25px 0px rgba(0, 0, 0, 0.8);
-    }
-    @include theme.sepia {
-        box-shadow: 0px 4px 25px 0px rgba(0, 0, 0, 0.1);
-    }
-    border-radius: var(--border-radius-rounded);
-    padding: var(--spacing-medium);
+  @include theme.light {
+    box-shadow: 0px 4px 25px 0px rgba(0, 0, 0, 0.1);
+  }
+  @include theme.dark {
+    box-shadow: 0px 4px 25px 0px rgba(0, 0, 0, 0.8);
+  }
+  @include theme.sepia {
+    box-shadow: 0px 4px 25px 0px rgba(0, 0, 0, 0.1);
+  }
+  border-radius: var(--border-radius-rounded);
+  padding: var(--spacing-medium);
+}
+
+.verseContainer {
+  margin-block-end: var(--spacing-medium);
+}
+
+.loadingPlaceholder {
+  min-block-size: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .button {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    font-size: var(--font-size-medium-px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: var(--font-size-medium-px);
 }
 
 .arrowIcon {
-    svg {
-        @include breakpoints.smallerThanTablet {
-            width: 12px !important;
-            height: 12px !important;
-        }
+  svg {
+    @include breakpoints.smallerThanTablet {
+      inline-size: 12px !important;
+      block-size: 12px !important;
     }
+  }
 }
 
 // Custom styles for the Arabic verse and translation text
 .customArabicVerse {
-    margin-block-start: 0 !important;
+  margin-block-start: 0 !important;
 
-    > div {
-        @include breakpoints.tablet {
-            font-size: var(--font-size) !important;
-        }
+  > div {
+    @include breakpoints.tablet {
+      font-size: var(--font-size) !important;
     }
+  }
 }
 
 .customTranslation {
-    margin-block-start: 0 !important;
+  margin-block-start: 0 !important;
 }

--- a/src/components/HomePage/QuranInYearSection/index.tsx
+++ b/src/components/HomePage/QuranInYearSection/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
 
@@ -8,6 +8,7 @@ import Button, { ButtonSize, ButtonType, ButtonVariant } from '@/components/dls/
 import Link, { LinkVariant } from '@/components/dls/Link/Link';
 import VerseAndTranslation from '@/components/Verse/VerseAndTranslation';
 import IconContainer, { IconSize } from '@/dls/IconContainer/IconContainer';
+import Spinner from '@/dls/Spinner/Spinner';
 import ArrowIcon from '@/public/icons/arrow.svg';
 import CalendarIcon from '@/public/icons/new-calendar.svg';
 import { QuranFont } from '@/types/QuranReader';
@@ -20,6 +21,7 @@ const FONT_SCALE = 3;
 
 const QuranInYearSection = () => {
   const { t } = useTranslation('home');
+  const [shouldLoadVerse, setShouldLoadVerse] = useState(false);
 
   const onCalendarClicked = () => {
     logButtonClick('quran_in_year_header_calendar');
@@ -27,6 +29,48 @@ const QuranInYearSection = () => {
 
   // Get the Ayah for today's date
   const todayAyah = useMemo(() => getCurrentDayAyah(), []);
+
+  // eslint-disable-next-line react-func/max-lines-per-function
+  useEffect(() => {
+    if (!todayAyah || shouldLoadVerse) {
+      return undefined;
+    }
+
+    const triggerLoad = () => {
+      setShouldLoadVerse(true);
+    };
+
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (
+        callback: () => void,
+        options?: {
+          timeout?: number;
+        },
+      ) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+
+    if (typeof idleWindow.requestIdleCallback === 'function') {
+      const idleId = idleWindow.requestIdleCallback(
+        () => {
+          triggerLoad();
+        },
+        { timeout: 2000 },
+      );
+      return () => {
+        idleWindow.cancelIdleCallback?.(idleId);
+      };
+    }
+
+    const timeoutId = window.setTimeout(triggerLoad, 1000);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [shouldLoadVerse, todayAyah]);
 
   // Don't render anything if we're before April 1st, 2025
   if (!todayAyah) {
@@ -47,16 +91,24 @@ const QuranInYearSection = () => {
         </div>
       </div>
       <div className={styles.container}>
-        <VerseAndTranslation
-          chapter={todayAyah.chapter}
-          from={todayAyah.verse}
-          to={todayAyah.verse}
-          quranFont={QuranFont.QPCHafs}
-          translationsLimit={1}
-          arabicVerseClassName={styles.customArabicVerse}
-          translationClassName={styles.customTranslation}
-          fixedFontScale={FONT_SCALE}
-        />
+        <div className={styles.verseContainer}>
+          {shouldLoadVerse ? (
+            <VerseAndTranslation
+              chapter={todayAyah.chapter}
+              from={todayAyah.verse}
+              to={todayAyah.verse}
+              quranFont={QuranFont.QPCHafs}
+              translationsLimit={1}
+              arabicVerseClassName={styles.customArabicVerse}
+              translationClassName={styles.customTranslation}
+              fixedFontScale={FONT_SCALE}
+            />
+          ) : (
+            <div className={styles.loadingPlaceholder}>
+              <Spinner />
+            </div>
+          )}
+        </div>
         <Button
           type={ButtonType.Primary}
           variant={ButtonVariant.Compact}


### PR DESCRIPTION
# Summary

I changed the Quran In a Year block so it only fetches and renders the daily verse once the browser is idle, showing a tiny spinner meanwhile. 
That keeps the homepage light during first paint and makes the section feel more responsive when users land on it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

I've checked with MCP Playwright that the changes took effect on the site.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented lazy loading for the daily Quran verse with a loading indicator displayed while fetching.

* **Style**
  * Refined CSS styling and layout formatting for the Quran section, including improved icon sizing and spacing adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->