### PR TITLE
Perf - Lazy load homepage learning plans after idle

### DIFF
--- a/src/components/Course/CoursesList/index.tsx
+++ b/src/components/Course/CoursesList/index.tsx
@@ -71,7 +71,7 @@ const CoursesList: React.FC<Props> = ({ courses, isMyCourses }) => {
             ? getLessonNavigationUrl(slug, continueFromLesson)
             : getCourseNavigationUrl(slug);
           return (
-            <Link key={id} href={navigateTo}>
+            <Link key={id} href={navigateTo} shouldPrefetch={false}>
               <Card
                 shouldShowFullTitle
                 imgSrc={thumbnail}

--- a/src/components/HomePage/Card/index.tsx
+++ b/src/components/HomePage/Card/index.tsx
@@ -13,6 +13,7 @@ interface CardProps {
   className?: string;
   linkClassName?: string;
   onClick?: () => void;
+  shouldPrefetch?: boolean;
 }
 
 const Card: React.FC<CardProps> = ({
@@ -22,10 +23,17 @@ const Card: React.FC<CardProps> = ({
   className,
   linkClassName,
   onClick,
+  shouldPrefetch,
 }) => {
   if (link) {
     return (
-      <Link href={link} isNewTab={isNewTab} className={linkClassName} onClick={onClick}>
+      <Link
+        href={link}
+        isNewTab={isNewTab}
+        className={linkClassName}
+        onClick={onClick}
+        {...(typeof shouldPrefetch !== 'undefined' && { shouldPrefetch })}
+      >
         <div className={classNames(className, styles.card, styles.cardWithLink)}>{children}</div>
       </Link>
     );


### PR DESCRIPTION
# Summary

Now wait to load the learning plans until the section is close to the viewport, show the existing skeleton while we wait, and keep every course link from prefetching so the homepage stays light.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

Checked with MCP Playwright that the changes took effect on the site.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Learning plans section now uses lazy-loading—content loads automatically when the section comes into view, improving initial page performance.

* **Performance Improvements**
  * Link prefetching is now configurable and disabled for course links by default, reducing unnecessary background requests and enhancing app performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->