### PR TITLE
Perf - Fixed the React "Hydration failed because the initial UI..." error on homepage

### DIFF
--- a/src/components/HomePage/Card/index.tsx
+++ b/src/components/HomePage/Card/index.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 
 import classNames from 'classnames';
+import { useRouter } from 'next/router';
 
 import styles from './Card.module.scss';
-
-import Link from '@/dls/Link/Link';
 
 interface CardProps {
   children: React.ReactNode;
@@ -23,15 +22,106 @@ const Card: React.FC<CardProps> = ({
   linkClassName,
   onClick,
 }) => {
-  if (link) {
-    return (
-      <Link href={link} isNewTab={isNewTab} className={linkClassName} onClick={onClick}>
-        <div className={classNames(className, styles.card, styles.cardWithLink)}>{children}</div>
-      </Link>
-    );
-  }
+  const router = useRouter();
+  const cardRef = useRef<HTMLDivElement>(null);
 
-  return <div className={classNames(className, styles.card)}>{children}</div>;
+  /**
+   * Determine if an event target is a nested interactive element that should keep control.
+   */
+  const shouldIgnoreEvent = useCallback(
+    (target: EventTarget | null) => {
+      if (!link) return false;
+      if (!(target instanceof HTMLElement)) return false;
+      if (!cardRef.current) return false;
+      const interactiveElement = target.closest(
+        'a, button, input, textarea, select, [role="button"], [role="link"]',
+      );
+      return Boolean(interactiveElement && interactiveElement !== cardRef.current);
+    },
+    [link],
+  );
+
+  /**
+   * Trigger navigation using Next.js for internal routes or the browser for external URLs.
+   */
+  const navigate = useCallback(() => {
+    if (!link) return;
+
+    if (isNewTab) {
+      if (typeof window !== 'undefined') {
+        window.open(link, '_blank', 'noopener,noreferrer');
+      }
+      return;
+    }
+
+    const isInternal = link.startsWith('/') || link.startsWith('#');
+
+    if (isInternal) {
+      router.push(link);
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      window.location.href = link;
+    }
+  }, [isNewTab, link, router]);
+
+  /**
+   * Handle mouse clicks on the card while respecting nested controls.
+   */
+  const handleCardClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!link) {
+        onClick?.();
+        return;
+      }
+
+      onClick?.();
+
+      if (event.defaultPrevented || shouldIgnoreEvent(event.target)) return;
+
+      event.preventDefault();
+
+      navigate();
+    },
+    [link, navigate, onClick, shouldIgnoreEvent],
+  );
+
+  /**
+   * Provide keyboard accessibility for the card when it acts like a link.
+   */
+  const handleCardKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!link) return;
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClick?.();
+        navigate();
+      }
+    },
+    [link, navigate, onClick],
+  );
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      ref={cardRef}
+      role={link ? 'link' : undefined}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={link ? 0 : undefined}
+      className={classNames(
+        styles.card,
+        className,
+        { [styles.cardWithLink]: Boolean(link) },
+        link ? linkClassName : undefined,
+      )}
+      onClick={link ? handleCardClick : onClick}
+      onKeyDown={link ? handleCardKeyDown : undefined}
+    >
+      {children}
+    </div>
+  );
 };
 
 export default Card;


### PR DESCRIPTION
# Summary

The mismatch forced React to discard the server DOM and rebuild it on the client, slightly impacting Performance/Best Practices scores on slower devices.  
The shared Card component now renders a single focusable container instead of a nested div inside the <a> link, which previously caused the hydration error.

Note: only for non-logged-in users

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

Verified that the card still works as expected and that the hydration error no longer appears.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="1347" height="696" alt="image" src="https://github.com/user-attachments/assets/b075e302-8b88-4359-b2e8-11ee4db06b5e" />| cleared |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Card components now feature interactive navigation with keyboard accessibility support.
  * Enhanced link handling for both internal URLs and new tab targeting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->