### PR TITLE
Perf - Drop unused homepage background preload

### DIFF
--- a/src/components/HomePage/HomePageHero.tsx
+++ b/src/components/HomePage/HomePageHero.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import useTranslation from 'next-translate/useTranslation';
 
 import NavigationButton from './HeroButtons/NavigationButton';
@@ -13,9 +12,6 @@ const HomePageHero = () => {
   const { t } = useTranslation('common');
   return (
     <div className={styles.outerContainer}>
-      <Head>
-        <link rel="preload" as="image" href="/images/background.png" />
-      </Head>
       <div className={styles.backgroundImage}>
         <Background />
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import React, { useMemo } from 'react';
 
 import classNames from 'classnames';
 import { NextPage, GetStaticProps } from 'next';
-import Head from 'next/head';
 import useTranslation from 'next-translate/useTranslation';
 
 import styles from './index.module.scss';
@@ -19,12 +18,12 @@ import QuranGrowthJourneySection from '@/components/HomePage/QuranGrowthJourneyS
 import QuranInYearSection from '@/components/HomePage/QuranInYearSection';
 import ReadingSection from '@/components/HomePage/ReadingSection';
 import NextSeoWrapper from '@/components/NextSeoWrapper';
+import useIsMobile from '@/hooks/useIsMobile';
 import { isLoggedIn } from '@/utils/auth/login';
 import { getAllChaptersData } from '@/utils/chapter';
 import { getLanguageAlternates } from '@/utils/locale';
 import { getCanonicalUrl } from '@/utils/navigation';
 import getCurrentDayAyah from '@/utils/quranInYearCalendar';
-import { isMobile } from '@/utils/responsive';
 import { ChaptersResponse } from 'types/ApiResponses';
 import ChaptersData from 'types/ChaptersData';
 
@@ -37,12 +36,10 @@ const Index: NextPage<IndexProps> = ({ chaptersResponse: { chapters } }): JSX.El
   const { t, lang } = useTranslation('home');
   const isUserLoggedIn = isLoggedIn();
   const todayAyah = useMemo(() => getCurrentDayAyah(), []);
+  const isMobileView = useIsMobile();
 
   return (
     <>
-      <Head>
-        <link rel="preload" as="image" href="/images/background.png" crossOrigin="anonymous" />
-      </Head>
       <NextSeoWrapper
         title={t('home:noble-quran')}
         url={getCanonicalUrl(lang, '')}
@@ -55,7 +52,7 @@ const Index: NextPage<IndexProps> = ({ chaptersResponse: { chapters } }): JSX.El
             <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
               <ReadingSection />
             </div>
-            {isMobile() ? (
+            {isMobileView ? (
               <MobileHomepageSections isUserLoggedIn={isUserLoggedIn} todayAyah={todayAyah} />
             ) : (
               <>


### PR DESCRIPTION
# Summary

Removing the unused background-image preload eliminates a "wasted preload" warning.  
Lighthouse considers such preloads as render-blocking overhead.  
Allowing the hero image to load normally avoids unnecessary early bytes, resulting in faster painting and no warning.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test plan

Verified that the warning disappeared and that the image still loads correctly.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="526" height="74" alt="image" src="https://github.com/user-attachments/assets/31856ca1-64a1-4223-b6a8-ae331b06e223" /> | Cleared |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored mobile detection logic for improved performance on mobile devices.
  * Adjusted background image loading behavior for optimized asset preloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->