### PR TITLE
Add systemd service and timer configuration for continuous Playwright…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ node_modules/
 .env
 .env.local
 
+# mise local configuration
+.mise.local.toml
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ node_modules/
 .env
 .env.local
 
-# mise local configuration
-.mise.local.toml
-
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 

--- a/tests/service/README.md
+++ b/tests/service/README.md
@@ -1,0 +1,136 @@
+# Quran.com Playwright Tests - Systemd Service
+
+This directory contains the systemd service and timer configuration for continuous Playwright
+testing of quran.com.
+
+## Files
+
+- `quran-tests.service` - Main service that runs Playwright tests
+- `quran-tests.timer` - Timer that triggers the service every 5 minutes
+
+## How It Works
+
+The service uses `mise` to:
+
+- Load Node.js 18.20.8 from `.mise.local.toml`
+- Load environment variables from `.mise.local.toml` including Discord credentials
+- Run Playwright tests against the live quran.com site
+- Send Discord notifications for test failures
+
+## Setup (One-time)
+
+### Create Symbolic Links
+
+```bash
+# Create symlinks to this directory
+ln -sf /srv/apps/playwright-tests/tests/service/quran-tests.service ~/.config/systemd/user/quran-tests.service
+ln -sf /srv/apps/playwright-tests/tests/service/quran-tests.timer ~/.config/systemd/user/quran-tests.timer
+
+# Reload systemd daemon
+systemctl --user daemon-reload
+```
+
+### Enable and Start
+
+```bash
+# Enable timer (starts automatically on boot)
+systemctl --user enable quran-tests.timer
+
+# Start timer (begins 5-minute schedule)
+systemctl --user start quran-tests.timer
+
+# Start service manually (optional, timer will trigger it)
+systemctl --user start quran-tests.service
+```
+
+## Service Management
+
+### Start/Stop Service
+
+```bash
+# Start service manually
+systemctl --user start quran-tests.service
+
+# Stop service
+systemctl --user stop quran-tests.service
+
+# Restart service
+systemctl --user restart quran-tests.service
+```
+
+### Start/Stop Timer
+
+```bash
+# Start timer (5-minute intervals)
+systemctl --user start quran-tests.timer
+
+# Stop timer
+systemctl --user stop quran-tests.timer
+
+# Disable timer (prevents auto-start on boot)
+systemctl --user disable quran-tests.timer
+
+# Re-enable timer
+systemctl --user enable quran-tests.timer
+```
+
+## Status and Logs
+
+### Check Status
+
+```bash
+# Check service status
+systemctl --user status quran-tests.service
+
+# Check timer status
+systemctl --user status quran-tests.timer
+
+# Check both at once
+systemctl --user status quran-tests.timer quran-tests.service
+```
+
+### View Logs
+
+```bash
+# View recent service logs
+journalctl --user -u quran-tests.service
+
+# Follow live logs
+journalctl --user -u quran-tests.service -f
+
+# View last 50 lines
+journalctl --user -u quran-tests.service -n 50
+
+# View timer logs
+journalctl --user -u quran-tests.timer
+
+# View logs with timestamps
+journalctl --user -u quran-tests.service --since "1 hour ago"
+```
+
+### Check Timer Schedule
+
+```bash
+# List all user timers
+systemctl --user list-timers
+
+# Show next scheduled run
+systemctl --user list-timers --all
+```
+
+## Configuration
+
+### Environment Variables
+
+The service loads configuration from `/srv/apps/playwright-tests/.mise.local.toml`:
+
+```toml
+[env]
+PLAYWRIGHT_TEST_BASE_URL = "https://quran.com"
+PLAYWRIGHT_SKIP_WEB_SERVER = "true"
+DISCORD_BOT_TOKEN = "your_bot_token_here"
+DISCORD_CHANNEL_ID = "your_channel_id_here"
+TEST_USER_EMAIL = "test@example.com"
+TEST_USER_PASSWORD = "password"
+TEST_USER_USERNAME = "testuser"
+```

--- a/tests/service/README.md
+++ b/tests/service/README.md
@@ -19,28 +19,21 @@ The service uses `mise` to:
 
 ## Setup (One-time)
 
-### Create Symbolic Links
+### Enable Services
 
 ```bash
-# Create symlinks to this directory
-ln -sf /srv/apps/playwright-tests/tests/service/quran-tests.service ~/.config/systemd/user/quran-tests.service
-ln -sf /srv/apps/playwright-tests/tests/service/quran-tests.timer ~/.config/systemd/user/quran-tests.timer
+# Navigate to service directory
+cd /srv/apps/playwright-tests/tests/service
+
+# Enable both service and timer
+systemctl --user enable $PWD/quran-tests.service
+systemctl --user enable $PWD/quran-tests.timer
 
 # Reload systemd daemon
 systemctl --user daemon-reload
-```
 
-### Enable and Start
-
-```bash
-# Enable timer (starts automatically on boot)
-systemctl --user enable quran-tests.timer
-
-# Start timer (begins 5-minute schedule)
+# Start the timer
 systemctl --user start quran-tests.timer
-
-# Start service manually (optional, timer will trigger it)
-systemctl --user start quran-tests.service
 ```
 
 ## Service Management

--- a/tests/service/quran-tests.service
+++ b/tests/service/quran-tests.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=oneshot
 WorkingDirectory=/srv/apps/playwright-tests
-ExecStart=mise -C /srv/apps/playwright-tests x -- yarn playwright test tests/integration/url/path.spec.ts --reporter=./tests/reporter/discord-reporter.js,list
+ExecStart=mise x -- yarn playwright test tests/integration/url/path.spec.ts --reporter=./tests/reporter/discord-reporter.js,list
 StandardOutput=journal
 StandardError=journal
 

--- a/tests/service/quran-tests.service
+++ b/tests/service/quran-tests.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Quran.com Continuous Playwright Tests
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/srv/apps/playwright-tests
+ExecStart=mise -C /srv/apps/playwright-tests x -- yarn playwright test tests/integration/url/path.spec.ts --reporter=./tests/reporter/discord-reporter.js,list
+Restart=always
+RestartSec=300
+StandardOutput=journal
+StandardError=journal
+
+TimeoutStopSec=60
+KillMode=control-group
+TimeoutStartSec=180
+KillSignal=SIGTERM

--- a/tests/service/quran-tests.service
+++ b/tests/service/quran-tests.service
@@ -3,15 +3,11 @@ Description=Quran.com Continuous Playwright Tests
 After=network.target
 
 [Service]
-Type=simple
+Type=oneshot
 WorkingDirectory=/srv/apps/playwright-tests
 ExecStart=mise -C /srv/apps/playwright-tests x -- yarn playwright test tests/integration/url/path.spec.ts --reporter=./tests/reporter/discord-reporter.js,list
-Restart=always
-RestartSec=300
 StandardOutput=journal
 StandardError=journal
 
-TimeoutStopSec=60
-KillMode=control-group
 TimeoutStartSec=180
-KillSignal=SIGTERM
+TimeoutStopSec=60

--- a/tests/service/quran-tests.timer
+++ b/tests/service/quran-tests.timer
@@ -1,9 +1,9 @@
 [Unit]
-Description=Run Quran.com Playwright tests continuously
+Description=Run Quran.com Playwright tests every 5 minutes
 Requires=quran-tests.service
 
 [Timer]
-OnCalendar=*:*:0/5
+OnCalendar=*-*-* *:0/5:00
 Persistent=true
 
 [Install]

--- a/tests/service/quran-tests.timer
+++ b/tests/service/quran-tests.timer
@@ -3,7 +3,7 @@ Description=Run Quran.com Playwright tests every 5 minutes
 Requires=quran-tests.service
 
 [Timer]
-OnCalendar=*-*-* *:0/5:00
+OnCalendar=*:0/5
 Persistent=true
 
 [Install]

--- a/tests/service/quran-tests.timer
+++ b/tests/service/quran-tests.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Quran.com Playwright tests continuously
+Requires=quran-tests.service
+
+[Timer]
+OnCalendar=*:*:0/5
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added systemd-based automated testing to run integration tests on a recurring schedule.
* **Documentation**
  * Added setup and management instructions for the new testing service and its scheduler, including enable/start commands, status/log checks, scheduling verification, and environment configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->