### PR TITLE
Fix: Questions button not showing due to incorrect data structure access

### DIFF
--- a/src/components/QuranReader/ReadingView/Buttons/QuestionsButton/index.tsx
+++ b/src/components/QuranReader/ReadingView/Buttons/QuestionsButton/index.tsx
@@ -24,7 +24,7 @@ const QuestionsButton: React.FC<Props> = ({ verseKey, onActionTriggered }) => {
   const { t, lang } = useTranslation('quran-reader');
   const router = useRouter();
   const [isContentModalOpen, setIsContentModalOpen] = useState(false);
-  const hasQuestions = pageQuestionsCount && pageQuestionsCount[verseKey] > 0;
+  const hasQuestions = pageQuestionsCount && pageQuestionsCount[verseKey]?.total > 0;
   const onButtonClicked = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();

--- a/src/components/QuranReader/ReadingView/context/PageQuestionsContext.tsx
+++ b/src/components/QuranReader/ReadingView/context/PageQuestionsContext.tsx
@@ -1,6 +1,10 @@
 import { createContext, useContext } from 'react';
 
-export const PageQuestionsContext = createContext<Record<string, number> | undefined>(undefined);
+import { QuestionData } from '@/utils/auth/api';
+
+export const PageQuestionsContext = createContext<Record<string, QuestionData> | undefined>(
+  undefined,
+);
 
 export const usePageQuestions = () => {
   const context = useContext(PageQuestionsContext);

--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
@@ -104,8 +104,8 @@ const TranslationPageVerse: React.FC<TranslationPageVerse> = ({
     };
   }, [isLastVerseInView, verse, verseKeysQueue]);
 
-  const hasQuestions = questionsCount && questionsCount[verse.verseKey] > 0;
-  const hasNotes = notesCount && notesCount[verse.verseKey] > 0;
+  const hasQuestions = questionsCount?.[verse.verseKey]?.total > 0;
+  const hasNotes = notesCount?.[verse.verseKey] > 0;
 
   return (
     <div

--- a/src/hooks/auth/useCountRangeQuestions.ts
+++ b/src/hooks/auth/useCountRangeQuestions.ts
@@ -2,7 +2,7 @@ import useTranslation from 'next-translate/useTranslation';
 import useSWRImmutable from 'swr/immutable';
 
 import Language from '@/types/Language';
-import { countQuestionsWithinRange } from '@/utils/auth/api';
+import { countQuestionsWithinRange, QuestionData } from '@/utils/auth/api';
 import { makeCountQuestionsWithinRangeUrl } from '@/utils/auth/apiPaths';
 
 type Range = {
@@ -11,18 +11,18 @@ type Range = {
 };
 
 type CountRangeQuestionsResponse = {
-  data: Record<string, number>;
+  data: Record<string, QuestionData>;
   isLoading: boolean;
   error: Error | null;
 };
 
 const useCountRangeQuestions = (questionsRange: Range): CountRangeQuestionsResponse => {
   const { lang } = useTranslation();
-  const { data, isValidating, error } = useSWRImmutable<Record<string, number>>(
+  const { data, isValidating, error } = useSWRImmutable<Record<string, QuestionData>>(
     questionsRange
       ? makeCountQuestionsWithinRangeUrl(questionsRange.from, questionsRange.to, lang as Language)
       : null,
-    async (): Promise<Record<string, number>> => {
+    async (): Promise<Record<string, QuestionData>> => {
       return countQuestionsWithinRange(questionsRange.from, questionsRange.to, lang as Language);
     },
   );

--- a/src/utils/auth/api.ts
+++ b/src/utils/auth/api.ts
@@ -478,11 +478,16 @@ export const addCollection = async (collectionName: string) => {
   return postRequest(makeAddCollectionUrl(), { name: collectionName });
 };
 
+export type QuestionData = {
+  types: Record<string, number>;
+  total: number;
+};
+
 export const countQuestionsWithinRange = async (
   from: string,
   to: string,
   language: Language,
-): Promise<Record<string, number>> => {
+): Promise<Record<string, QuestionData>> => {
   return privateFetcher(makeCountQuestionsWithinRangeUrl(from, to, language));
 };
 


### PR DESCRIPTION
## Problem

Closes: [QF-3857](https://quranfoundation.atlassian.net/browse/QF-3857)

The "Explore Answers" button was not appearing for verses with questions in both Translation View and Reading View.

### Root Cause

The API returns questions data with this structure:
```json
{
  "1:2": {
    "types": {
      "TAFSIR": 3,
      "COMMUNITY": 2
    },
    "total": 5
  }
}
```

However, the code was comparing the entire object to a number:
```tsx
// ❌ Wrong - compares object to number
const hasQuestions = questionsCount[verseKey] > 0;  
```

This comparison always evaluated to `false`, preventing the button from showing.

## Solution

Updated all code to correctly access the `.total` property:
```tsx
// ✅ Correct - accesses total property
const hasQuestions = questionsCount?.[verseKey]?.total > 0;
```

## Changes

### 1. Fixed Data Access (3 files)
- **QuestionsButton/index.tsx**: Added `.total` property access with optional chaining
- **TranslationPageVerse.tsx**: Added `.total` property access with optional chaining
- Both now correctly check if verses have questions

### 2. Updated Type Definitions (3 files)
- **api.ts**: Added `QuestionData` type export matching API response structure
- **useCountRangeQuestions.ts**: Updated types from `Record<string, number>` to `Record<string, QuestionData>`
- **PageQuestionsContext.tsx**: Updated context type to use `QuestionData`

This ensures type safety and prevents similar bugs in the future.

## Testing

Verified with production API data:
- Verse 1:2 with 5 questions → Button shows ✅
- Verse 1:3 with 1 question → Button shows ✅
- Verse 1:1 with 0 questions → No button ✅

## Files Changed

```
src/components/QuranReader/ReadingView/Buttons/QuestionsButton/index.tsx
src/components/QuranReader/ReadingView/context/PageQuestionsContext.tsx
src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
src/hooks/auth/useCountRangeQuestions.ts
src/utils/auth/api.ts
```

## Impact

- ✅ **No breaking changes** - Pure bug fix
- ✅ **No regressions** - Only affects questions button visibility
- ✅ **Type safe** - Prevents future bugs with proper TypeScript types
- ✅ **Backward compatible** - Optional chaining handles all edge cases

## Checklist

- [x] Code reviewed for correctness
- [x] Edge cases verified (null/undefined handling)
- [x] Type safety improved with proper TypeScript types
- [x] All usages of questions data updated
- [x] No other files need similar fixes

[QF-3857]: https://quranfoundation.atlassian.net/browse/QF-3857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced question metadata validation to prevent edge cases and ensure question indicators display accurately across all reader views, particularly when handling missing or undefined data.

* **Refactor**
  * Improved internal data structures and type definitions for question tracking to provide better robustness and consistent null-value handling throughout the Quran reader components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->