### PR TITLE
Added "Page not found" text when the status code is 404

### DIFF
--- a/locales/en/error.json
+++ b/locales/en/error.json
@@ -2,5 +2,6 @@
   "go-back": "Go Back",
   "if-persist": "If the issue persists, please",
   "report-cta": "report a bug",
+  "not-found-title": "Page not found",
   "title": "Sorry, something went wrong"
 }

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -18,9 +18,10 @@ type ErrorProps = {
   hasFullWidth?: boolean;
 };
 
-const Error = ({ hasFullWidth = true }: ErrorProps) => {
+const Error = ({ statusCode, hasFullWidth = true }: ErrorProps) => {
   const { t } = useTranslation('error');
   const router = useRouter();
+  const isNotFound = statusCode === 404;
 
   // If a previous page exists, go back; otherwise, go to home.
   const onBackButtonClicked = () => {
@@ -37,7 +38,7 @@ const Error = ({ hasFullWidth = true }: ErrorProps) => {
         [styles.withFullWidth]: hasFullWidth,
       })}
     >
-      <h1 className={styles.title}>{t('title')}</h1>
+      <h1 className={styles.title}>{isNotFound ? t('not-found-title') : t('title')}</h1>
       <div className={styles.goBack}>
         <Button onClick={onBackButtonClicked}>{t('go-back')}</Button>
       </div>


### PR DESCRIPTION
# Summary

Changes the generic "Something went wrong" message to "Page not found" when the page status code is 404.  
Note: only the English "Page not found" text has been added. No other languages.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Test plan

Tested on `/not-a-page`.

## Checklist

- [X] My code follows the project’s style guidelines
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code where needed
- [ ] I have updated the documentation
- [ ] I have added tests proving that my fix works
- [X] All unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
| <img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/be7936ad-db8f-4f85-8ab4-a2c25cc8b4a4" /> | <img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/09bcddbf-4014-4dd0-a705-a232e406b03f" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error pages now display a dedicated "Page not found" message for 404 errors, providing clearer feedback when pages cannot be accessed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->