### PR TITLE
feat(notifications): Filter notification preferences by QDC tag

### DIFF
--- a/src/components/Notifications/NotificationSettings/Tabs/CategoriesSettingsTab/index.tsx
+++ b/src/components/Notifications/NotificationSettings/Tabs/CategoriesSettingsTab/index.tsx
@@ -18,6 +18,7 @@ import Error from '@/pages/_error';
 
 const MARKETING_TAG = 'marketing';
 const QDC_TAG = 'QDC';
+const QR_TAG = 'QR';
 
 const CategoriesSettingsTab = () => {
   const { t } = useTranslation('notification-settings');
@@ -40,6 +41,8 @@ const CategoriesSettingsTab = () => {
    * 2. preferences that don't have tags since they cannot be categorized.
    * 3. marketing emails.
    * 4. workflows that don't have the QDC tag (filters out QR workflows).
+   *
+   * Workflows with only marker tags (QDC/QR) are grouped under 'uncategorized'.
    */
   const groupByTags = useMemo(
     () =>
@@ -52,7 +55,13 @@ const CategoriesSettingsTab = () => {
             preference.template.tags.includes(QDC_TAG),
         ),
         // Group by category tags, excluding QDC/QR marker tags
-        (preference) => preference.template.tags.filter((tag) => tag !== QDC_TAG && tag !== 'QR'),
+        (preference) => {
+          const categoryTags = preference.template.tags.filter(
+            (tag) => tag !== QDC_TAG && tag !== QR_TAG,
+          );
+          // Take the first category tag; workflows should have exactly one category tag
+          return categoryTags[0] || 'uncategorized';
+        },
       ),
     [preferences],
   );


### PR DESCRIPTION
## Summary

Closes: [QF-3924](https://quranfoundation.atlassian.net/browse/QF-3924)

Implements tag-based filtering for notification preferences to ensure only QDC workflows are displayed in the Quran.com notification settings. This prevents QR (Quran Reflect) workflows from appearing when users have accounts on both platforms.

## Changes Made

### Code Changes
- **File**: `src/components/Notifications/NotificationSettings/Tabs/CategoriesSettingsTab/index.tsx`
  - Added `QDC_TAG` constant
  - Added filter to only show preferences with `QDC` tag
  - Updated grouping to exclude marker tags (`QDC`, `QR`) from category grouping

## How It Works

Each workflow in Novu is tagged with either `QDC` or `QR` to identify platform ownership:
- `QDC` tag → Shows in Quran.com notification settings
- `QR` tag → Shows in Quran Reflect notification settings

Workflows also have category tags (e.g., `calendar`, `learning-plans`, `qgj`, `streaks`) for grouping in the UI.

## Implementation

```typescript
const QDC_TAG = 'QDC';

preferences?.filter(
  (preference) =>
    preference.template.critical === false &&
    !!preference.template.tags.length &&
    !preference.template.tags.includes(MARKETING_TAG) &&
    preference.template.tags.includes(QDC_TAG), // Only QDC workflows
)
```

## Testing

### Prerequisites
All workflows in Novu dashboard must be tagged:
- QDC workflows: Add `QDC` tag + category tag (e.g., `['QDC', 'calendar']`)
- QR workflows: Add `QR` tag (e.g., `['QR', 'social']`)

### Test Cases
- [x] User with only QDC account sees only QDC preferences
- [x] User with only QR account sees only QR preferences  
- [x] User with both accounts sees correct preferences in each platform
- [x] Categories display correctly (calendar, learning-plans, qgj, streaks)
- [x] No QR workflows appear in QDC notification settings

### Manual Testing Steps
1. Log into Quran.com with test account
2. Navigate to Settings → Notifications
3. Verify only QDC categories appear
4. Verify no QR workflows are visible
5. Test with account that has both QDC and QR accounts

## Benefits
✅ Simple one-tag filtering approach  
✅ Explicit platform ownership  
✅ Scalable - add categories without code changes  
✅ Clean separation between QDC and QR workflows

## Migration Required
After merging, all workflows in Novu dashboard need to be tagged:
1. Add `QDC` tag to all Quran.com workflows
2. Add `QR` tag to all Quran Reflect workflows
3. Verify each workflow has at least one category tag

[QF-3924]: https://quranfoundation.atlassian.net/browse/QF-3924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated notification preference filtering and category organization in settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->