### PR TITLE
Made Collection's verses expanded by default

### DIFF
--- a/src/components/Collection/CollectionDetail/CollectionDetail.tsx
+++ b/src/components/Collection/CollectionDetail/CollectionDetail.tsx
@@ -44,7 +44,7 @@ const CollectionDetail = ({
   onItemDeleted,
   isOwner,
 }: CollectionDetailProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const { t, lang } = useTranslation();
   const confirm = useConfirm();
 


### PR DESCRIPTION
## Summary

Collection verses now open by default

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Test Plan

I visually checked that the collection is expanded by default.
I could NOT make a playwright test for that as the testing DB does not contain by default any collection,

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed

**Testing steps:**

1. Go to a collection (for me it was `/collections/abc-jl1m4z9ajk9top0ckx9btm0l`)
2. Verified that the verses are open by default
3. Verify that the button shows "Collapse all verses" by default

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Remove if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1919" height="446" alt="image" src="https://github.com/user-attachments/assets/73ac1fe6-d9ef-409a-b4fd-1bbf3864d875" />|   <img width="1914" height="495" alt="image" src="https://github.com/user-attachments/assets/e9ebaa3b-a21f-4b02-b295-3b6172833831" />   |

## AI Assistance Disclosure

- [X] AI tools were NOT used for this PR
- [ ] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
