### PR TITLE
QF-4028 - Change order of the sections on QDC homepage for guest user in responsive view 

### DIFF
--- a/src/components/HomePage/MobileHomepageSections/index.tsx
+++ b/src/components/HomePage/MobileHomepageSections/index.tsx
@@ -8,24 +8,16 @@ import LearningPlansSection from '../LearningPlansSection';
 import QuranGrowthJourneySection from '../QuranGrowthJourneySection';
 import QuranInYearSection from '../QuranInYearSection';
 
-import ChapterAndJuzListWrapper from '@/components/chapters/ChapterAndJuzList';
 import styles from '@/pages/index.module.scss';
-import Chapter from 'types/Chapter';
 import ChaptersData from 'types/ChaptersData';
 
 type Props = {
   isUserLoggedIn: boolean;
   todayAyah: { chapter: number; verse: number } | null;
   chaptersData?: ChaptersData;
-  chapters?: Chapter[];
 };
 
-const MobileHomepageSections: React.FC<Props> = ({
-  isUserLoggedIn,
-  todayAyah,
-  chaptersData,
-  chapters = [],
-}) => {
+const MobileHomepageSections: React.FC<Props> = ({ isUserLoggedIn, todayAyah, chaptersData }) => {
   return isUserLoggedIn ? (
     <>
       {todayAyah && (
@@ -41,12 +33,6 @@ const MobileHomepageSections: React.FC<Props> = ({
       </div>
       <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
         <ExploreTopicsSection />
-      </div>
-      <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
-        <QuranGrowthJourneySection />
-      </div>
-      <div className={styles.flowItem}>
-        <ChapterAndJuzListWrapper chapters={chapters} />
       </div>
     </>
   ) : (
@@ -67,9 +53,6 @@ const MobileHomepageSections: React.FC<Props> = ({
       </div>
       <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
         <CommunitySection />
-      </div>
-      <div className={styles.flowItem}>
-        <ChapterAndJuzListWrapper chapters={chapters} />
       </div>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -62,7 +62,6 @@ const Index: NextPage<IndexProps> = ({
                 isUserLoggedIn={isUserLoggedIn}
                 todayAyah={todayAyah}
                 chaptersData={chaptersData}
-                chapters={chapters}
               />
             ) : (
               <>
@@ -128,11 +127,9 @@ const Index: NextPage<IndexProps> = ({
               </>
             )}
 
-            {!isMobile() && (
-              <div className={styles.flowItem}>
-                <ChapterAndJuzListWrapper chapters={chapters} />
-              </div>
-            )}
+            <div className={styles.flowItem}>
+              <ChapterAndJuzListWrapper chapters={chapters} />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Change order of the sections on QDC homepage for guest user in responsive view to be the following:
- Continue reading
- QGJ
- Explore topics
- Quran in a Year
- Learning Plans 
- Community 
- Surah list 

Closes: [QF-4028](https://quranfoundation.atlassian.net/browse/QF-4028)

## Type of Change

- [X] ♻️ Refactoring (no functional changes)

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed

I manually checked both homepages (logged out and logged in). When logged in, the homepage didn’t change. When using a guest account, it changed to the given list.

### Code Quality

- [X] I have performed a **self-review** of my code (file by file)
- [X] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [X] No unused code, imports, or dead code included

### Testing & Validation

- [X] All tests pass locally (`yarn test`)
- [X] Linting passes (`yarn lint`)
- [X] Build succeeds (`yarn build`)
- [X] Edge cases and error scenarios are handled
Checked RTL, logged-in, logged-out, verified desktop didn't changed.

### Localization (if UI changes)

- [X] RTL layout verified

## Screenshots/Videos

| Before | After |
| ------ | ----- |
|  logged out <img width="397" height="1654" alt="TEST QURAN COM MOBILE LOGGED OUT" src="https://github.com/user-attachments/assets/0d4f025d-0021-4700-b12c-660d9922b353" />   |  logged out   <img width="397" height="1764" alt="LOCALHOST LOGGED OUT" src="https://github.com/user-attachments/assets/1d978eb8-553e-4249-a7bc-195dda921de7" />   |
| logged in <img width="397" height="1657" alt="TEST QURAN COM MOBILE LOGGED IN" src="https://github.com/user-attachments/assets/4067e212-2009-4ecb-8c8c-761865aa33ba" />  |  logged in <img width="397" height="1641" alt="LOCALHOST LOGGED IN" src="https://github.com/user-attachments/assets/a6436c27-f150-4394-9f3d-d6ae8cfdc645" /> |
| desktop logged out <img width="1911" height="2312" alt="TEST QURAN COM DESKTOP LOGGED OUT" src="https://github.com/user-attachments/assets/4ba0ad2a-d11b-4c4b-aa3a-f7f032c0bc5f" />  | desktop logged out <img width="1912" height="1974" alt="LOCALHOST DESKTOP LOGGED OUT" src="https://github.com/user-attachments/assets/cf386dbd-7996-4e92-b15a-bfa90042d463" /> |
| desktop logged in <img width="1911" height="2249" alt="TEST QURAN COM DESKTOP LOGGED IN " src="https://github.com/user-attachments/assets/f818e4e5-2b8c-436a-93c5-4a273976558d" /> | desktop logged in <img width="1912" height="1994" alt="LOCALHOST DEKSTOP LOGGED IN" src="https://github.com/user-attachments/assets/c35a62a2-f8a9-4d2c-8686-8f92e7391815" />   |

## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR
- [X] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4028]: https://quranfoundation.atlassian.net/browse/QF-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ