### PR TITLE
Fix ChapterHeader centering in Safari and Firefox

### DIFF
--- a/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
+++ b/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
@@ -1,4 +1,4 @@
-@use "src/styles/breakpoints";
+@use 'src/styles/breakpoints';
 
 $chapterHeaderContainerMaxInlineSize: 450px;
 $changeTranslationButtonInlineSize: 310px;
@@ -24,7 +24,7 @@ $bismillahSvgInlineSizeMobile: 148px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-self: center;
+  margin-inline: auto;
   inline-size: 100%;
   max-inline-size: $chapterHeaderContainerMaxInlineSize;
   margin-block-start: var(--spacing-medium2);
@@ -152,8 +152,8 @@ $bismillahSvgInlineSizeMobile: 148px;
 
   @include breakpoints.smallerThanTablet {
     svg {
-      width: var(--spacing-small);
-      height: var(--spacing-small);
+      inline-size: var(--spacing-small);
+      block-size: var(--spacing-small);
     }
   }
 }
@@ -243,7 +243,7 @@ $bismillahSvgInlineSizeMobile: 148px;
   justify-content: center;
   align-items: center;
   // setting the value below to avoid the CLS issue when the surahnames font has not loaded yet
-  min-height: calc(3.75 * var(--spacing-medium));
+  min-block-size: calc(3.75 * var(--spacing-medium));
 }
 
 .chapterIconContainer {


### PR DESCRIPTION
## Summary

**Jira:** [QF-3926](https://quranfoundation.atlassian.net/browse/QF-3926)

Fixes the ChapterHeader component being left-aligned in Safari and Firefox instead of centered.

**Root Cause:** The `.container` class used `justify-self: center` which only works in CSS Grid contexts. Chrome has non-standard support for it in other layouts, but Safari and Firefox follow the CSS spec strictly and ignore it.

**Solution:** Replace `justify-self: center` with `margin-inline: auto`, which is the standard cross-browser way to horizontally center a block element with a max-width.

Also fixes pre-existing stylelint warnings by converting physical CSS properties to logical ones (`width` → `inline-size`, `height` → `block-size`, `min-height` → `min-block-size`).

## Images

| Before | After |
|---|---|
| <img width="1440" height="900" alt="Screenshot 2025-12-14 at 10 58 00 AM" src="https://github.com/user-attachments/assets/99f6ffe1-f543-4792-809a-80ba7811b0ed" /> | <img width="1440" height="900" alt="Screenshot 2025-12-14 at 10 56 57 AM" src="https://github.com/user-attachments/assets/a7bd86cb-e9a0-4a4c-835c-eb9958b7ea1e" /> |

## Test Plan

- [x] Open any Surah page (e.g., `/71`) in **Safari** and verify ChapterHeader is centered
- [x] Open any Surah page in **Firefox** and verify ChapterHeader is centered
- [x] Open any Surah page in **Chrome** to verify no regression
- [x] Test in both Translation and Reading views
- [x] Test in both RTL/LTR
- [x] Test on mobile viewport sizes in all three browsers
- [x] Verify the Bismillah section remains centered below the chapter title

[QF-3926]: https://quranfoundation.atlassian.net/browse/QF-3926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ