### PR TITLE
fix: show yellow lightbulb icon for clarification questions

### DIFF
--- a/src/hooks/auth/useCountRangeQuestions.ts
+++ b/src/hooks/auth/useCountRangeQuestions.ts
@@ -4,6 +4,7 @@ import useSWRImmutable from 'swr/immutable';
 import Language from '@/types/Language';
 import { countQuestionsWithinRange, QuestionsData } from '@/utils/auth/api';
 import { makeCountQuestionsWithinRangeUrl } from '@/utils/auth/apiPaths';
+import { normalizeQuestionsData } from '@/utils/questions';
 
 type Range = {
   from: string;
@@ -14,33 +15,6 @@ type CountRangeQuestionsResponse = {
   data: Record<string, QuestionsData>;
   isLoading: boolean;
   error: Error | null;
-};
-
-/**
- * Normalize type keys to uppercase to handle API response inconsistencies.
- * The API may return keys like "cLARIFICATION" instead of "CLARIFICATION".
- * @param {Record<string, QuestionsData>} data - The questions data to normalize.
- * @returns {Record<string, QuestionsData>} The normalized questions data.
- */
-export const normalizeQuestionsData = (
-  data: Record<string, QuestionsData>,
-): Record<string, QuestionsData> => {
-  const normalized: Record<string, QuestionsData> = {};
-
-  Object.entries(data).forEach(([verseKey, questionsData]) => {
-    const normalizedTypes: Record<string, number> = {};
-
-    Object.entries(questionsData.types || {}).forEach(([typeKey, count]) => {
-      normalizedTypes[typeKey.toUpperCase()] = count;
-    });
-
-    normalized[verseKey] = {
-      ...questionsData,
-      types: normalizedTypes,
-    };
-  });
-
-  return normalized;
 };
 
 const useCountRangeQuestions = (questionsRange: Range): CountRangeQuestionsResponse => {

--- a/src/utils/questions.test.ts
+++ b/src/utils/questions.test.ts
@@ -1,10 +1,7 @@
 /* eslint-disable react-func/max-lines-per-function */
 import { describe, it, expect } from 'vitest';
 
-import { normalizeQuestionsData } from './useCountRangeQuestions';
-
-// Local type definition to avoid importing from api.ts which has complex dependencies
-type QuestionsData = { types: Record<string, number>; total: number };
+import { normalizeQuestionsData, QuestionsData } from './questions';
 
 describe('normalizeQuestionsData', () => {
   it('should normalize lowercase first letter type keys to uppercase', () => {

--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -1,0 +1,34 @@
+/**
+ * Type for questions data returned by the API.
+ */
+export type QuestionsData = {
+  types: Record<string, number>;
+  total: number;
+};
+
+/**
+ * Normalize type keys to uppercase to handle API response inconsistencies.
+ * The API may return keys like "cLARIFICATION" instead of "CLARIFICATION".
+ * @param {Record<string, QuestionsData>} data - The questions data to normalize.
+ * @returns {Record<string, QuestionsData>} The normalized questions data.
+ */
+export const normalizeQuestionsData = (
+  data: Record<string, QuestionsData>,
+): Record<string, QuestionsData> => {
+  const normalized: Record<string, QuestionsData> = {};
+
+  Object.entries(data).forEach(([verseKey, questionsData]) => {
+    const normalizedTypes: Record<string, number> = {};
+
+    Object.entries(questionsData.types || {}).forEach(([typeKey, count]) => {
+      normalizedTypes[typeKey.toUpperCase()] = count;
+    });
+
+    normalized[verseKey] = {
+      ...questionsData,
+      types: normalizedTypes,
+    };
+  });
+
+  return normalized;
+};


### PR DESCRIPTION
## Summary

Fixes the issue where the yellow lightbulb icon was not showing for verses with clarification questions in the bottom actions "Answers" tab.

**Jira:** [QF-2960](https://quranfoundation.atlassian.net/browse/QF-2960)

## Problem

The `questions/count-within-range` API returns type keys with incorrect casing (e.g., `cLARIFICATION` instead of `CLARIFICATION`). The frontend checks for uppercase enum values, causing the clarification check to always fail.

## Solution

Added a normalization function that converts API response type keys to uppercase before using them.

## Screenshots

| Before | After |
|--------|-------|
| <img width="1214" height="459" alt="Screenshot 2025-12-14 at 1 43 26 PM" src="https://github.com/user-attachments/assets/583d7c0d-c28b-4916-835c-719fb51217a4" /> | <img width="1214" height="459" alt="Screenshot 2025-12-14 at 1 41 52 PM" src="https://github.com/user-attachments/assets/a3bd2240-bf7e-413f-b2a0-3b39219f4b42" /> |

## Test Plan

- [x] Navigate to a page with verses that have clarification questions (e.g., `/page/3`)
- [x] Verify verses 2:6, 2:7, and 2:8 show the **yellow lightbulb icon** in the Answers tab
- [x] Verify verses without clarification questions show the **outline lightbulb icon**
- [x] Click on Answers tab and verify the modal opens correctly
- [x] Verify no regressions in Reading View word actions menu

[QF-2960]: https://quranfoundation.atlassian.net/browse/QF-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ