### PR TITLE
fix(markdown-editor): increase blockquote line-height for Urdu RTL

### DIFF
--- a/src/components/MarkdownEditor/MarkdownEditor.module.scss
+++ b/src/components/MarkdownEditor/MarkdownEditor.module.scss
@@ -76,6 +76,11 @@
       font-weight: var(--font-weight-semibold);
       line-height: var(--line-height-xlarge);
       text-align: center;
+
+      // For Urdu in RTL pages, increase line-height to reduce glyph collisions inside the blockquote.
+      :global(html[lang='ur'][dir='rtl']) & {
+        line-height: 160%;
+      }
     }
   }
   img {


### PR DESCRIPTION
- Increase blockquote paragraph line-height for Urdu RTL pages to prevent glyph collisions in large Urdu text.
- This applies a language- and direction-specific override without affecting LTR or non-Urdu content.

