### PR TITLE
[QF-4260] Update OrText color to medium gray

### DIFF
--- a/src/components/Login/login.module.scss
+++ b/src/components/Login/login.module.scss
@@ -303,7 +303,7 @@ $container-width: 370px;
 
 .orText {
   font-size: var(--font-size-small);
-  color: var(--color-border-gray-lighter);
+  color: var(--color-border-gray-medium);
   font-weight: var(--font-weight-normal);
   text-transform: uppercase;
   padding-inline: var(--spacing-small);


### PR DESCRIPTION
## Summary

This PR changes auth ui Or Separator Text color to be `--color-border-gray-medium` from `--color-border-gray-lighter`

Fixes: [QF-4260](https://quranfoundation.atlassian.net/browse/QF-4260)
Related: [QF-3991](https://quranfoundation.atlassian.net/browse/QF-3991)

Test Plan
1. It's looking good on all theme (dark, light, sepia)
2. It's looking good on all screen sizes (mobile, tablet, laptop, desktop)

[QF-3991]: https://quranfoundation.atlassian.net/browse/QF-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QF-4260]: https://quranfoundation.atlassian.net/browse/QF-4260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ