### PR TITLE
Open Apps Portal in new tab from Developers page

### DIFF
--- a/src/components/AppPortalSection/index.tsx
+++ b/src/components/AppPortalSection/index.tsx
@@ -19,7 +19,7 @@ const AppPortalSection = ({ variant = 'drawer' }: AppPortalSectionProps) => {
       {variant === 'drawer' && <div>{t('app-portal.description')}</div>}
       <div>{t('app-portal.oauth-pitch')}</div>
       <div className={styles.actions}>
-        <Button href="/apps-portal" type={ButtonType.Success}>
+        <Button isNewTab href="/apps-portal" type={ButtonType.Success}>
           {t('app-portal.cta-explore')}
         </Button>
         <Button


### PR DESCRIPTION
- Open the Apps Portal link in a new browser tab to avoid navigating users away from the Developers page.

