### PR TITLE
[QF-2770] Update sample-verse.json to reflect new verse data for 1:1

### DIFF
--- a/src/utils/sample-verse.json
+++ b/src/utils/sample-verse.json
@@ -1,149 +1,129 @@
 {
-    "id": 12,
-    "verseNumber": 5,
-    "verseKey": "2:5",
+    "id": 1,
+    "verseNumber": 1,
+    "verseKey": "1:1",
     "juzNumber": 1,
     "hizbNumber": 1,
     "rubNumber": 1,
-    "textUthmani": "أُو۟لَـٰٓئِكَ عَلَىٰ هُدًى مِّن رَّبِّهِمْ ۖ وَأُو۟لَـٰٓئِكَ هُمُ ٱلْمُفْلِحُونَ",
-    "chapterId": 2,
-    "pageNumber": 2,
-    "verseIndex": 5,
+    "rubElHizbNumber": 1,
+    "pageNumber": 1,
+    "verseIndex": 1,
     "words": [
-        {
-            "id": 5544,
-            "position": 1,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:1",
-            "codeV1": "ﭳ",
-            "codeV2": "ﱣ",
-            "pageNumber": 2,
-            "lineNumber": 7,
-            "qpcUthmaniHafs": "أُوْلَٰٓئِكَ",
-            "text": "أُوْلَٰٓئِكَ",
-            "textImage": "w/rq-color/2/5/1.png"
+      {
+        "position": 1,
+        "charTypeName": "word",
+        "verseKey": "1:1",
+        "location": "1:1:1",
+        "codeV1": "ﭑ",
+        "codeV2": "ﱁ",
+        "pageNumber": 1,
+        "lineNumber": 9,
+        "hizbNumber": 1,
+        "qpcUthmaniHafs": "بِسۡمِ",
+        "text": "بِسْمِ",
+        "audioUrl": null,
+        "translation": {
+          "text": "In (the) name",
+          "languageId": 38
         },
-        {
-            "id": 5545,
-            "position": 2,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:2",
-            "codeV1": "ﭴ",
-            "codeV2": "ﱤ",
-            "pageNumber": 2,
-            "lineNumber": 7,
-            "qpcUthmaniHafs": "عَلَىٰ",
-            "text": "عَلَىٰ",
-            "textImage": "w/rq-color/2/5/2.png"
-        },
-        {
-            "id": 5546,
-            "position": 3,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:3",
-            "codeV1": "ﭵ",
-            "codeV2": "ﱥ",
-            "pageNumber": 2,
-            "lineNumber": 7,
-            "qpcUthmaniHafs": "هُدٗى",
-            "text": "هُدٗى",
-            "textImage": "w/rq-color/2/5/3.png"
-        },
-        {
-            "id": 5547,
-            "position": 4,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:4",
-            "codeV1": "ﭶ",
-            "codeV2": "ﱦ",
-            "pageNumber": 2,
-            "lineNumber": 7,
-            "qpcUthmaniHafs": "مِّن",
-            "text": "مِّن",
-            "textImage": "w/rq-color/2/5/4.png"
-        },
-        {
-            "id": 5548,
-            "position": 5,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:5",
-            "codeV1": "ﭷ",
-            "codeV2": "ﱧ",
-            "pageNumber": 2,
-            "lineNumber": 7,
-            "qpcUthmaniHafs": "رَّبِّهِمۡۖ",
-            "text": "رَّبِّهِمۡۖ",
-            "textImage": "w/rq-color/2/5/5.png"
-        },
-        {
-            "id": 5550,
-            "position": 6,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:6",
-            "codeV1": "ﭹ",
-            "codeV2": "ﱩ",
-            "pageNumber": 2,
-            "lineNumber": 7,
-            "qpcUthmaniHafs": "وَأُوْلَٰٓئِكَ",
-            "text": "وَأُوْلَٰٓئِكَ",
-            "textImage": "w/rq-color/2/5/6.png"
-        },
-        {
-            "id": 5551,
-            "position": 7,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:7",
-            "codeV1": "ﭺ",
-            "codeV2": "ﱪ",
-            "pageNumber": 2,
-            "lineNumber": 8,
-            "qpcUthmaniHafs": "هُمُ",
-            "text": "هُمُ",
-            "textImage": "w/rq-color/2/5/7.png"
-        },
-        {
-            "id": 5552,
-            "position": 8,
-            "charTypeName": "word",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:8",
-            "codeV1": "ﭻ",
-            "codeV2": "ﱫ",
-            "pageNumber": 2,
-            "lineNumber": 8,
-            "qpcUthmaniHafs": "ٱلۡمُفۡلِحُونَ",
-            "text": "ٱلۡمُفۡلِحُونَ",
-            "textImage": "w/rq-color/2/5/8.png"
-        },
-        {
-            "id": 5553,
-            "position": 9,
-            "charTypeName": "end",
-            "verseKey": "2:5",
-            "verseId": 12,
-            "location": "2:5:10",
-            "codeV1": "ﭼ",
-            "codeV2": "ﱬ",
-            "pageNumber": 2,
-            "lineNumber": 8,
-            "qpcUthmaniHafs": "٥",
-            "text": "٥",
-            "textImage": "w/common/5.png"
+        "transliteration": {
+          "text": "bis'mi",
+          "languageId": 38
         }
+      },
+      {
+        "position": 2,
+        "charTypeName": "word",
+        "verseKey": "1:1",
+        "location": "1:1:2",
+        "codeV1": "ﭒ",
+        "codeV2": "ﱂ",
+        "pageNumber": 1,
+        "lineNumber": 9,
+        "hizbNumber": 1,
+        "qpcUthmaniHafs": "ٱللَّهِ",
+        "text": "ٱللَّهِ",
+        "audioUrl": null,
+        "translation": {
+          "text": "(of) Allah",
+          "languageId": 38
+        },
+        "transliteration": {
+          "text": "l-lahi",
+          "languageId": 38
+        }
+      },
+      {
+        "position": 3,
+        "charTypeName": "word",
+        "verseKey": "1:1",
+        "location": "1:1:3",
+        "codeV1": "ﭓ",
+        "codeV2": "ﱃ",
+        "pageNumber": 1,
+        "lineNumber": 9,
+        "hizbNumber": 1,
+        "qpcUthmaniHafs": "ٱلرَّحۡمَٰنِ",
+        "text": "ٱلرَّحْمَـٰنِ",
+        "audioUrl": null,
+        "translation": {
+          "text": "the Most Gracious",
+          "languageId": 38
+        },
+        "transliteration": {
+          "text": "l-raḥmāni",
+          "languageId": 38
+        }
+      },
+      {
+        "position": 4,
+        "charTypeName": "word",
+        "verseKey": "1:1",
+        "location": "1:1:4",
+        "codeV1": "ﭔ",
+        "codeV2": "ﱄ",
+        "pageNumber": 1,
+        "lineNumber": 9,
+        "hizbNumber": 1,
+        "qpcUthmaniHafs": "ٱلرَّحِيمِ",
+        "text": "ٱلرَّحِيمِ",
+        "audioUrl": null,
+        "translation": {
+          "text": "the Most Merciful",
+          "languageId": 38
+        },
+        "transliteration": {
+          "text": "l-raḥīmi",
+          "languageId": 38
+        }
+      },
+      {
+        "position": 5,
+        "charTypeName": "end",
+        "verseKey": "1:1",
+        "location": "1:1:5",
+        "codeV1": "ﭕ",
+        "codeV2": "ﱅ",
+        "pageNumber": 1,
+        "lineNumber": 9,
+        "hizbNumber": 1,
+        "qpcUthmaniHafs": "١",
+        "text": "١",
+        "audioUrl": null,
+        "translation": {
+          "text": "(1)",
+          "languageId": 38
+        },
+        "transliteration": {
+          "text": null,
+          "languageId": 38
+        }
+      }
+    ],
+    "translations": [
+      {
+        "text": "In the Name of Allah—the Most Compassionate, Most Merciful.",
+        "languageId": 38
+      }
     ]
-}
+  }


### PR DESCRIPTION
## Summary

Updates the sample verse data in `sample-verse.json` from verse 2:5 to verse 1:1 (Bismillah). This
change ensures the verse preview in the Settings Drawer displays the first verse of the Quran, which
is more appropriate for showcasing font styles and settings. The update includes proper structure
with words, translations, transliterations, and all required metadata fields.

part of : [QF-2770](https://quranfoundation.atlassian.net/browse/QF-2770)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring (no functional changes)

## Environment Variables

<!-- List any new environment variables introduced. Remove this section if not applicable. -->

N/A - No environment variables introduced.

## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. **Settings Drawer Verse Preview**

   - Navigate to the Settings Drawer (gear icon in navbar)
   - Verify the verse preview displays verse 1:1 (Bismillah) correctly
   - Confirm the Arabic text renders properly: "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ"
   - Verify the verse number "١" appears at the end

2. **Font Style Preview**

   - Change Quran font settings (e.g., Uthmani, Indopak, QCF fonts)
   - Verify the sample verse preview updates correctly with each font
   - Confirm all words render properly with different font styles
   - Test with different font sizes

3. **Theme Compatibility**

   - Switch between light, dark, and sepia themes
   - Verify the verse preview displays correctly in all themes
   - Confirm text is readable and properly styled in each theme

4. **RTL Layout**

   - Verify the verse preview maintains proper RTL (right-to-left) layout
   - Confirm Arabic text flows correctly from right to left
   - Test on different screen sizes (mobile, tablet, desktop)

5. **Data Structure Validation**

   - Verify the JSON structure matches the expected `Verse` type
   - Confirm all required fields are present (id, verseKey, words, translations, etc.)
   - Check that word-by-word data includes translation and transliteration
   - Validate page number, juz number, and other metadata fields


## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [x] README updated (if adding features or setup changes)
- [x] Inline comments added for complex logic

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] Only English locale files modified (Lokalise handles others)
- [x] RTL layout verified

### Accessibility (if UI changes)

- [x] Semantic HTML elements used
- [x] ARIA attributes added where needed
- [x] Keyboard navigation works

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Remove if not applicable. -->

| Before                  | After                                  |
| ----------------------- | -------------------------------------- |
| <img width="672" height="577" alt="image" src="https://github.com/user-attachments/assets/ed6ef5ba-4998-4557-bc9e-c65376cef5b3" /> | https://github.com/user-attachments/assets/5c1422dc-cc53-4ba2-b895-6e1474234e45 |




## Related PRs
https://github.com/quran/quran.com-frontend-next/pull/2636
https://github.com/quran/quran.com-frontend-next/pull/2663
https://github.com/quran/quran.com-frontend-next/pull/2635


## AI Assistance Disclosure

<!-- If AI tools were used, confirm you have reviewed and understand all generated code -->

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-2770]: https://quranfoundation.atlassian.net/browse/QF-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ