### PR TITLE
[QF-4284] Fix answers button flickering in TranslationView

### DIFF
--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -101,6 +101,13 @@ const TranslationView = ({
   const [accumulatedQuestionsData, setAccumulatedQuestionsData] = useState<
     Record<string, QuestionsData>
   >({});
+
+  // Reset accumulated questions data when the resource context changes
+  // to avoid leaking stale data across chapters/pages and unbounded growth.
+  useEffect(() => {
+    setAccumulatedQuestionsData({});
+  }, [resourceId]);
+
   useEffect(() => {
     if (pageVersesQuestionsData) {
       setAccumulatedQuestionsData((prev) => ({


### PR DESCRIPTION
## Summary

Fixes: [QF-4284](https://quranfoundation.atlassian.net/browse/QF-4284)
- Fixed flickering issue where the answers button would temporarily disappear when scrolling through verses in the TranslationView
- Implemented state accumulation for questions data to preserve existing entries when new verses are loaded
- When the verse range changes, SWR fetches new data with an undefined initial state - by merging new data with existing data, we now maintain visibility of the answers button

## Test plan
- [x] Open a page with verses that have associated questions (answers button visible)
- [x] Scroll through the verses to trigger loading of new verse ranges
- [x] Verify the answers button remains visible without flickering
- [x] Confirm questions data is properly accumulated and displayed for all loaded verses

[QF-4284]: https://quranfoundation.atlassian.net/browse/QF-4284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ