### PR TITLE
[QF-4115] fix when open the side menu then close it, app reset the view of the header

### DIFF
--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -58,7 +58,7 @@
 
 .bodyContainer {
   flex: 1;
-  margin-block-start: var(--navbar-container-height);
+  margin-block-start: var(--navbar-height);
   padding-block-start: var(--spacing-small);
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
@@ -79,7 +79,7 @@
   font-size: var(--font-size-large);
   width: 100%;
   position: fixed;
-  height: var(--navbar-container-height);
+  height: var(--navbar-height);
   border-block-end: 1px var(--color-borders-hairline) solid;
   display: flex;
   flex-direction: row;
@@ -117,5 +117,5 @@
 }
 
 .navbarInvisible {
-  transform: translate3d(0, 0 + var(--navbar-container-height), 0);
+  padding-block-start: var(--navbar-container-height);
 }

--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -19,7 +19,7 @@ import {
   setIsNavigationDrawerOpen,
   setIsSearchDrawerOpen,
   setIsSettingsDrawerOpen,
-  setIsVisible,
+  setLockVisibilityState,
 } from '@/redux/slices/navbar';
 import { logEvent } from '@/utils/eventLogger';
 
@@ -127,11 +127,16 @@ const Drawer: React.FC<Props> = ({
   );
 
   useEffect(() => {
-    // Keep nav bar visible when drawer is open
+    // Lock navbar visibility state when drawer is open to prevent scroll-based changes
+    // Unlock when drawer is closed to restore normal scroll behavior
     if (isOpen) {
-      dispatch(setIsVisible(true));
+      dispatch(setLockVisibilityState(true));
+    } else {
+      dispatch(setLockVisibilityState(false));
     }
+  }, [dispatch, isOpen]);
 
+  useEffect(() => {
     // Hide navbar after successful navigation
     const handleRouteChange = () => {
       if (isOpen && closeOnNavigation) {
@@ -145,7 +150,7 @@ const Drawer: React.FC<Props> = ({
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange);
     };
-  }, [closeDrawer, dispatch, router.events, isNavbarVisible, isOpen, closeOnNavigation]);
+  }, [closeDrawer, router.events, isOpen, closeOnNavigation]);
 
   useOutsideClickDetector(
     drawerRef,


### PR DESCRIPTION
## Summary

 Fixed navbar visibility flicker and positioning issues when opening/closing drawers. When users scrolled down (navbar hidden) and opened any drawer (Navigation, translation , or Settings), the navbar would become visible with a flicker, and when closing the drawer, the navbar would stay visible instead of returning to its scroll-based state. 
Additionally, drawer positioning was incorrect when the navbar was hidden.

Closes: [QF-4115](https://quranfoundation.atlassian.net/browse/QF-4115)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Test Plan

  [x]  Manual testing performed
  - All drawer types tested (Navigation, Search, Settings)
  - Mobile and desktop breakpoints tested

## Testing Steps
First go to `/1` or any surah 

  Test 1: Drawer opens without navbar flicker when scrolled down
  1. Scroll down until navbar hides
  2. Click to open setting (Gear icon) 
  3. ✅ Expected: Drawer opens smoothly, navbar stays hidden, no flicker

  Test 2: Drawer opens normally when navbar visible
  1. Stay at top of page (navbar visible)
  2. Click to open Search drawer
  3. ✅ Expected: Drawer opens normally, no extra spacing

  Test 3: Navbar restores scroll state after drawer closes
  1. Scroll down until navbar hides
  2. Open Settings drawer
  3. Close drawer
  4. ✅ Expected: Navbar stays hidden (scroll-based behavior restored)

  Test 4: All drawer content visible when navbar hidden
  1. Scroll down until navbar hides
  2. Open Settings drawer
  3. Navigate through all tabs (Body, Translation, Reciter, etc.)
  4. ✅ Expected: All content visible and accessible, proper scrolling, no cut-off

  Test 5: Mobile behavior
  1. Switch to mobile viewport (< 768px)
  2. Scroll down, open any drawer
  3. ✅ Expected: Same behavior as desktop

  Test 6: Scroll while drawer open
  1. Open any drawer
  2. Try scrolling the page
  3. ✅ Expected: Navbar doesn't change visibility (locked while drawer is open)


## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [ ] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [ ] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)
- [ ] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [ ] README updated (if adding features or setup changes)
- [ ] Inline comments added for complex logic

### Localization (if UI changes)

- [ ] All user-facing text uses `next-translate`
- [ ] Only English locale files modified (Lokalise handles others)
- [ ] RTL layout verified

### Accessibility (if UI changes)

- [ ] Semantic HTML elements used
- [ ] ARIA attributes added where needed
- [ ] Keyboard navigation works

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Remove if not applicable. -->

| Before | After |
| ------ | ----- |
|   https://www.awesomescreenshot.com/video/47222587?key=a1c59d9a5ffb5fa3b9108f220d4564c9  | https://github.com/user-attachments/assets/11bdd1bc-c40d-47e5-a70d-43d8bc059cab | 

 
## Related PRs

<!-- Link any related PRs here. Remove if not applicable. -->

## AI Assistance Disclosure

<!-- If AI tools were used, confirm you have reviewed and understand all generated code -->

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4115]: https://quranfoundation.atlassian.net/browse/QF-4115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ