### PR TITLE
[QF-4361] Show Corner Case Validation Error To User

### DIFF
--- a/src/components/Verse/TranslationFeedback/types.ts
+++ b/src/components/Verse/TranslationFeedback/types.ts
@@ -4,6 +4,7 @@ export enum FormErrorId {
   RequiredField = 'required-field',
   MinimumLength = 'minimum-length',
   MaximumLength = 'maximum-length',
+  UnknownError = 'unknown-error',
 }
 
 export interface FormError {
@@ -19,8 +20,4 @@ export interface TranslationFeedbackFormErrors {
 export interface UseTranslationFeedbackFormProps {
   verse: WordVerse;
   onClose: () => void;
-}
-
-export interface FeedbackValidationErrorResponse {
-  details?: { error?: { code?: string; details?: { feedback?: string } } };
 }

--- a/src/components/Verse/TranslationFeedback/validation.test.ts
+++ b/src/components/Verse/TranslationFeedback/validation.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention, react-func/max-lines-per-function */
+/* eslint-disable @typescript-eslint/naming-convention, react-func/max-lines-per-function, max-lines */
 import { Translate } from 'next-translate';
 import { describe, it, expect } from 'vitest';
 
@@ -29,12 +29,12 @@ describe('getTranslationFeedbackErrors', () => {
   }) as Translate;
 
   it('returns empty errors when all fields are valid', () => {
-    const errors = getTranslationFeedbackErrors('1', 'Valid feedback text', mockT);
+    const errors = getTranslationFeedbackErrors('1', 'Valid feedback text', mockT, 'en');
     expect(errors).toEqual({});
   });
 
   it('returns translation error when translation is not selected', () => {
-    const errors = getTranslationFeedbackErrors('', 'Valid feedback text', mockT);
+    const errors = getTranslationFeedbackErrors('', 'Valid feedback text', mockT, 'en');
     expect(errors).toEqual({
       translation: {
         id: FormErrorId.RequiredField,
@@ -44,7 +44,7 @@ describe('getTranslationFeedbackErrors', () => {
   });
 
   it('returns feedback error when feedback is empty', () => {
-    const errors = getTranslationFeedbackErrors('1', '', mockT);
+    const errors = getTranslationFeedbackErrors('1', '', mockT, 'en');
     expect(errors).toEqual({
       feedback: {
         id: FormErrorId.RequiredField,
@@ -54,7 +54,7 @@ describe('getTranslationFeedbackErrors', () => {
   });
 
   it('returns feedback error when feedback is only whitespace', () => {
-    const errors = getTranslationFeedbackErrors('1', '   ', mockT);
+    const errors = getTranslationFeedbackErrors('1', '   ', mockT, 'en');
     expect(errors).toEqual({
       feedback: {
         id: FormErrorId.RequiredField,
@@ -65,7 +65,7 @@ describe('getTranslationFeedbackErrors', () => {
 
   it('returns feedback error when feedback is too short', () => {
     const shortFeedback = 'a'.repeat(MIN_FEEDBACK_CHARS - 1);
-    const errors = getTranslationFeedbackErrors('1', shortFeedback, mockT);
+    const errors = getTranslationFeedbackErrors('1', shortFeedback, mockT, 'en');
 
     if (MIN_FEEDBACK_CHARS > 1) {
       expect(errors).toEqual({
@@ -86,17 +86,17 @@ describe('getTranslationFeedbackErrors', () => {
 
   it('returns feedback error when feedback is too long', () => {
     const longFeedback = 'a'.repeat(MAX_FEEDBACK_CHARS + 1);
-    const errors = getTranslationFeedbackErrors('1', longFeedback, mockT);
+    const errors = getTranslationFeedbackErrors('1', longFeedback, mockT, 'en');
     expect(errors).toEqual({
       feedback: {
         id: FormErrorId.MaximumLength,
-        message: 'The feedback field must be at most 10000 characters',
+        message: 'The feedback field must be at most 10,000 characters',
       },
     });
   });
 
   it('returns multiple errors when both fields are invalid', () => {
-    const errors = getTranslationFeedbackErrors('', '', mockT);
+    const errors = getTranslationFeedbackErrors('', '', mockT, 'en');
     expect(errors).toEqual({
       translation: {
         id: FormErrorId.RequiredField,
@@ -110,7 +110,12 @@ describe('getTranslationFeedbackErrors', () => {
   });
 
   it('returns all validation errors when multiple issues exist', () => {
-    const errors = getTranslationFeedbackErrors('', 'a'.repeat(MAX_FEEDBACK_CHARS + 1), mockT);
+    const errors = getTranslationFeedbackErrors(
+      '',
+      'a'.repeat(MAX_FEEDBACK_CHARS + 1),
+      mockT,
+      'en',
+    );
     expect(errors).toEqual({
       translation: {
         id: FormErrorId.RequiredField,
@@ -118,7 +123,7 @@ describe('getTranslationFeedbackErrors', () => {
       },
       feedback: {
         id: FormErrorId.MaximumLength,
-        message: 'The feedback field must be at most 10000 characters',
+        message: 'The feedback field must be at most 10,000 characters',
       },
     });
   });

--- a/src/components/Verse/TranslationFeedback/validation.ts
+++ b/src/components/Verse/TranslationFeedback/validation.ts
@@ -2,8 +2,67 @@ import { Translate } from 'next-translate';
 
 import { FormErrorId, TranslationFeedbackFormErrors } from './types';
 
+import { BASE_SERVER_ERRORS_MAP, ServerErrorCodes } from '@/types/auth/error';
+import { isValidationError } from '@/utils/error';
+import { toLocalizedNumber } from '@/utils/locale';
+
 export const MAX_FEEDBACK_CHARS = 10000;
 export const MIN_FEEDBACK_CHARS = 1;
+
+/**
+ * Validates feedback field and returns error if any.
+ * @returns {FormError | null} Error object or null if valid.
+ */
+const getFeedbackError = (feedback: string, t: Translate, lang: string) => {
+  const feedbackText = t('translation-feedback.feedback');
+  const trimmedFeedbackLength = feedback.trim().length;
+
+  if (trimmedFeedbackLength === 0) {
+    return {
+      id: FormErrorId.RequiredField,
+      message: t('validation.required-field', { field: feedbackText }),
+    };
+  }
+
+  if (trimmedFeedbackLength < MIN_FEEDBACK_CHARS) {
+    return {
+      id: FormErrorId.MinimumLength,
+      message: t('validation.minimum-length', {
+        field: feedbackText,
+        value: toLocalizedNumber(MIN_FEEDBACK_CHARS, lang),
+      }),
+    };
+  }
+
+  if (trimmedFeedbackLength > MAX_FEEDBACK_CHARS) {
+    return {
+      id: FormErrorId.MaximumLength,
+      message: t('validation.maximum-length', {
+        field: feedbackText,
+        value: toLocalizedNumber(MAX_FEEDBACK_CHARS, lang),
+      }),
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Validates translation field and returns error if any.
+ * @returns {FormError | null} Error object or null if valid.
+ */
+const getTranslationError = (selectedTranslationId: string, t: Translate) => {
+  const translationText = t('translation-feedback.translation');
+
+  if (!selectedTranslationId) {
+    return {
+      id: FormErrorId.RequiredField,
+      message: t('validation.required-field', { field: translationText }),
+    };
+  }
+
+  return null;
+};
 
 /**
  * Build translation feedback validation errors for the current form state.
@@ -17,37 +76,13 @@ export const getTranslationFeedbackErrors = (
   selectedTranslationId: string,
   feedback: string,
   t: Translate,
+  lang: string,
 ): TranslationFeedbackFormErrors => {
   const errors: TranslationFeedbackFormErrors = {};
-  const trimmedFeedbackLength = feedback.trim().length;
-
-  const translationText = t('translation-feedback.translation');
-  const feedbackText = t('translation-feedback.feedback');
-
-  if (!selectedTranslationId) {
-    errors.translation = {
-      id: FormErrorId.RequiredField,
-      message: t('validation.required-field', { field: translationText }),
-    };
-  }
-
-  if (trimmedFeedbackLength === 0) {
-    errors.feedback = {
-      id: FormErrorId.RequiredField,
-      message: t('validation.required-field', { field: feedbackText }),
-    };
-  } else if (trimmedFeedbackLength < MIN_FEEDBACK_CHARS) {
-    errors.feedback = {
-      id: FormErrorId.MinimumLength,
-      message: t('validation.minimum-length', { field: feedbackText, value: MIN_FEEDBACK_CHARS }),
-    };
-  } else if (trimmedFeedbackLength > MAX_FEEDBACK_CHARS) {
-    errors.feedback = {
-      id: FormErrorId.MaximumLength,
-      message: t('validation.maximum-length', { field: feedbackText, value: MAX_FEEDBACK_CHARS }),
-    };
-  }
-
+  const translationError = getTranslationError(selectedTranslationId, t);
+  if (translationError) errors.translation = translationError;
+  const feedbackError = getFeedbackError(feedback, t, lang);
+  if (feedbackError) errors.feedback = feedbackError;
   return errors;
 };
 
@@ -59,3 +94,85 @@ export const getTranslationFeedbackErrors = (
  */
 export const isTranslationFeedbackValid = (errors: TranslationFeedbackFormErrors) =>
   Object.keys(errors).length === 0;
+
+/**
+ * Maps FormErrorId to validation translation keys
+ */
+const FORM_ERROR_ID_TO_TRANSLATION_KEY = {
+  [BASE_SERVER_ERRORS_MAP.MAX_LENGTH]: {
+    id: FormErrorId.MaximumLength,
+    key: 'validation.maximum-length',
+    query: (locale: string) => ({ value: toLocalizedNumber(MAX_FEEDBACK_CHARS, locale) }),
+  },
+  [BASE_SERVER_ERRORS_MAP.MIN_LENGTH]: {
+    id: FormErrorId.MinimumLength,
+    key: 'validation.minimum-length',
+    query: (locale: string) => ({ value: toLocalizedNumber(MIN_FEEDBACK_CHARS, locale) }),
+  },
+  [BASE_SERVER_ERRORS_MAP.MISSING]: {
+    id: FormErrorId.RequiredField,
+    key: 'validation.required-field',
+    query: () => ({}),
+  },
+};
+
+const FIELD_KEY_MAP = {
+  translationId: 'translation',
+  feedback: 'feedback',
+};
+
+/**
+ * Extracts server validation errors from API response and converts them to form errors.
+ * Dynamically handles any validation error code returned by the backend without requiring code changes.
+ * New error codes can be handled by adding appropriate translation keys to the locale files.
+ *
+ * @param {unknown} response - The API error response
+ * @param {Translate} t - Translation function for localized error messages
+ * @returns {TranslationFeedbackFormErrors | null} Form errors object if validation errors are found, null otherwise
+ */
+export const getTranslationFeedbackServerErrors = (
+  response: unknown,
+  t: Translate,
+  lang: string,
+): TranslationFeedbackFormErrors | null => {
+  if (!isValidationError(response)) return null;
+
+  const errors: TranslationFeedbackFormErrors = {};
+  const errorFields = response.details.error.details;
+
+  Object.entries(errorFields).forEach(([field, errorCode]) => {
+    const fieldKey = FIELD_KEY_MAP[field as keyof typeof FIELD_KEY_MAP];
+    if (!fieldKey) return;
+
+    const fieldName = t(`translation-feedback.${fieldKey}`);
+
+    const normalizedErrorCode = String(errorCode).toUpperCase();
+
+    const localizeKey = BASE_SERVER_ERRORS_MAP[normalizedErrorCode as ServerErrorCodes];
+    const translationFeedbackError = FORM_ERROR_ID_TO_TRANSLATION_KEY[localizeKey];
+
+    if (translationFeedbackError && localizeKey) {
+      errors[fieldKey] = {
+        id: translationFeedbackError.id,
+        message: t(translationFeedbackError.key, {
+          ...translationFeedbackError.query(lang),
+          field: fieldName,
+        }),
+      };
+    } else if (localizeKey) {
+      // The error is not common Translation Feedback Error, We are fallback to global errors
+      const localizeText = t(localizeKey, {
+        fieldName,
+        min: toLocalizedNumber(MIN_FEEDBACK_CHARS, lang),
+        max: toLocalizedNumber(MAX_FEEDBACK_CHARS, lang),
+      });
+
+      // If same that means we don't have a translation for this error code
+      if (localizeText !== localizeKey) {
+        errors[fieldKey] = { id: FormErrorId.UnknownError, message: localizeText };
+      }
+    }
+  });
+
+  return isTranslationFeedbackValid(errors) ? null : errors;
+};

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -6,3 +6,20 @@ export const throwIfError = (res: BaseResponse) => {
     throw new Error('internal server error');
   }
 };
+
+export interface APIErrorResponse {
+  details: {
+    error: {
+      code: string;
+      details: Record<string, string>;
+    };
+  };
+}
+
+export const isValidationError = (response: unknown): response is APIErrorResponse => {
+  if (typeof response !== 'object' || response === null) return false;
+  const error = response as APIErrorResponse;
+  const detailsError = error.details?.error;
+
+  return detailsError?.code === 'ValidationError' && !!detailsError?.details;
+};

--- a/tests/integration/loggedin/translation-feedback.spec.ts
+++ b/tests/integration/loggedin/translation-feedback.spec.ts
@@ -310,6 +310,7 @@ test.describe('Translation Feedback - Logged In Users', () => {
                 code: 'ValidationError',
                 details: {
                   feedback: 'MAX_LENGTH',
+                  translationId: 'MISSING',
                 },
               },
             },
@@ -335,6 +336,8 @@ test.describe('Translation Feedback - Logged In Users', () => {
 
       // Should show specific validation error message instead of generic error
       await expect(page.getByTestId('feedback-error-maximum-length')).toBeVisible();
+      await expect(page.getByTestId('translation-error-required-field')).toBeVisible();
+      await expect(page.getByTestId('error-toast')).not.toBeVisible();
 
       // Modal should remain open so user can correct the feedback
       const modal = page.getByTestId('modal-content');


### PR DESCRIPTION
## Summary

This PR fixes a bug where feedback submissions could fail due to server-side HTML entity encoding causing the feedback length to exceed the maximum allowed characters. The client enforces MAX_FEEDBACK_CHARS, but server sanitization can transform characters into longer HTML entities, triggering validation errors that weren't properly handled.

Closes: [QF-4361](https://quranfoundation.atlassian.net/browse/QF-4361)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)


## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**
1. Submit 9950 lenght feedback containing HTML multiple &, <, >.
2. Verify that after fail request we are seeing validation error msg bottom of textarea
3. Confirm successful submissions still work normally

## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [ ] README updated (if adding features or setup changes)
- [x] Inline comments added for complex logic

## Related PRs
https://github.com/quran/quran.com-frontend-next/pull/2707

## AI Assistance Disclosure

<!-- If AI tools were used, confirm you have reviewed and understand all generated code -->

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4361]: https://quranfoundation.atlassian.net/browse/QF-4361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ