### PR TITLE
[QF-4240] fix language switch flicker

### DIFF
--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -117,16 +117,20 @@ const getStore = (
   detectedLanguage?: string,
   detectedCountry?: string,
 ) => {
-  const initialState =
+  const baseInitialState =
     preloadedState ||
     getStoreInitialState(locale, countryPreference, detectedLanguage, detectedCountry);
 
   // Preserve persisted theme synchronously to prevent flash during language switching.
   // Redux-persist's REHYDRATE is async, so we read localStorage before store creation.
+  let initialState = baseInitialState;
   if (typeof window !== 'undefined') {
     const persistedTheme = getPersistedTheme();
     if (persistedTheme) {
-      initialState[SliceName.THEME] = persistedTheme;
+      initialState = {
+        ...baseInitialState,
+        [SliceName.THEME]: persistedTheme,
+      };
     }
   }
 

--- a/src/redux/utils/getPersistedTheme.ts
+++ b/src/redux/utils/getPersistedTheme.ts
@@ -1,6 +1,9 @@
 import { RootState } from '../RootState';
 import SliceName from '../types/SliceName';
 
+// NOTE: This key must stay in sync with `persistConfig.key` in `store.ts`.
+// `redux-persist` prefixes the key with `persist:`, so if `persistConfig.key`
+// changes from 'root', this constant must be updated accordingly.
 const PERSIST_KEY = 'persist:root';
 
 /**
@@ -28,6 +31,9 @@ const getPersistedTheme = (): RootState[SliceName.THEME] | null => {
 
     return JSON.parse(themeState);
   } catch (error) {
+    // Log the error to aid diagnosing issues with localStorage access or corrupted persisted state.
+    // eslint-disable-next-line no-console -- Console logging is acceptable here for debugging persistence issues.
+    console.error('Failed to get persisted theme from localStorage', error);
     return null;
   }
 };


### PR DESCRIPTION
## Summary

Fixed theme flicker/flash issue that occurred when switching languages. The Redux store is recreated on language change, and Redux-persist's async REHYDRATE was causing a brief flash of the default theme before the persisted theme loaded. This fix synchronously reads the persisted theme from localStorage before store creation to preserve the user's theme preference immediately.

Closes: [QF-4240](https://quranfoundation.atlassian.net/browse/QF-4240)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Environment Variables

<!-- List any new environment variables introduced. Remove this section if not applicable. -->

N/A

## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. Set the theme to dark mode (or light mode if default is dark)
2. Switch to a different language using the language switcher
3. Verify that the theme remains consistent without any flash/flicker
4. Verify that the theme preference is still correctly applied after language change
5. Test with both logged-in and logged-out users
6. Test switching between multiple languages in succession
7. Verify that the theme persists correctly on page reload after language change

## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [ ] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [ ] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [ ] README updated (if adding features or setup changes)
- [x] Inline comments added for complex logic

### Localization (if UI changes)

- [ ] All user-facing text uses `next-translate`
- [ ] Only English locale files modified (Lokalise handles others)
- [ ] RTL layout verified

### Accessibility (if UI changes)

- [ ] Semantic HTML elements used
- [ ] ARIA attributes added where needed
- [ ] Keyboard navigation works

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Remove if not applicable. -->

| Before | After |
| ------ | ----- |
|<video src="https://github.com/user-attachments/assets/ec1a7674-f9db-4cf4-a5bd-49ab30929e83" width="300" />|<video src="https://github.com/user-attachments/assets/71d0e043-bc83-414c-8cc0-aa775b431528" width="300" />|

## Related PRs

<!-- Link any related PRs here. Remove if not applicable. -->

N/A

## AI Assistance Disclosure

<!-- If AI tools were used, confirm you have reviewed and understand all generated code -->

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code



[QF-4240]: https://quranfoundation.atlassian.net/browse/QF-4240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ