### PR TITLE
Attach userId to GA

### DIFF
--- a/src/utils/eventLogger.ts
+++ b/src/utils/eventLogger.ts
@@ -26,6 +26,10 @@ export const logEvent = async (eventName: string, params?: { [key: string]: any 
   if (isFirebaseEnabled) {
     import('src/lib/firebase').then((firebaseModule) => {
       const userId = getUserIdCookie();
+      // Set GA4 User-ID (idempotent, safe to call on every event)
+      if (userId) {
+        firebaseModule.analytics().setUserId(userId);
+      }
       const eventParams = {
         ...params,
         ...(userId && { user_id: userId }),


### PR DESCRIPTION
Closes [#QF-2193](https://quranfoundation.atlassian.net/browse/QF-2193)

### Problem
When querying the number of logged-in users in Google Analytics 4, the metric showed 0 even though `user_id` was being passed as an event parameter. This is because GA4's "logged-in users" metric requires using the `setUserId()` API, not just passing `user_id` as an event parameter.

### Solution
- Added `setAnalyticsUserId()` helper function to `firebase.ts`
- Call `setUserId()` before every event in `eventLogger.ts` to ensure GA4 recognizes the session as belonging to a specific user

This enables:
- Cross-device tracking in GA4
- "Logged-in users" metrics in GA4 dashboards
- User-ID based reporting

### Changes
- `src/lib/firebase.ts`: Added `setAnalyticsUserId()` export
- `src/utils/eventLogger.ts`: Call `setUserId()` before logging each event
