### PR TITLE
[QF-4170] Implement Study Mode modal

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBody.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBody.module.scss
@@ -1,0 +1,16 @@
+.container {
+  padding: 0;
+}
+
+.arabicVerseContainer {
+  margin: var(--spacing-xlarge-px) 0;
+  padding: var(--spacing-medium);
+  border-bottom: 1px solid var(--color-borders-hairline);
+}
+
+.translationsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+  padding: var(--spacing-medium);
+}

--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBody.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBody.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { shallowEqual, useSelector } from 'react-redux';
+
+import getTranslationsLabelString from '../utils/translation';
+import styles from './StudyModeBody.module.scss';
+
+import TopActions from '@/components/QuranReader/TranslationView/TopActions';
+import TranslationText from '@/components/QuranReader/TranslationView/TranslationText';
+import PlainVerseText from '@/components/Verse/PlainVerseText';
+import { selectQuranReaderStyles } from '@/redux/slices/QuranReader/styles';
+import { constructWordVerse, getVerseWords } from '@/utils/verse';
+import Translation from 'types/Translation';
+import Verse from 'types/Verse';
+
+interface StudyModeBodyProps {
+  verse: Verse;
+  bookmarksRangeUrl?: string;
+  hasNotes?: boolean;
+  highlightedWordLocation?: string;
+}
+
+const StudyModeBody: React.FC<StudyModeBodyProps> = ({
+  verse,
+  bookmarksRangeUrl = '',
+  hasNotes = false,
+  highlightedWordLocation,
+}) => {
+  const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
+  const translationsLabel = getTranslationsLabelString(verse.translations);
+  const translationsCount = verse.translations?.length || 0;
+  const wordVerse = constructWordVerse(verse, translationsLabel, translationsCount);
+
+  return (
+    <div className={styles.container}>
+      <TopActions verse={wordVerse} bookmarksRangeUrl={bookmarksRangeUrl} hasNotes={hasNotes} />
+      <div className={styles.arabicVerseContainer}>
+        <PlainVerseText words={getVerseWords(verse)} highlightedWordLocation={highlightedWordLocation} />
+      </div>
+      <div className={styles.translationsContainer}>
+        {verse.translations?.map((translation: Translation) => (
+          <div key={translation.id} className={styles.translationContainer}>
+            <TranslationText
+              translationFontScale={quranReaderStyles.translationFontScale}
+              text={translation.text}
+              languageId={translation.languageId}
+              resourceName={verse.translations?.length > 1 ? translation.resourceName : null}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default StudyModeBody;

--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeModal.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeModal.module.scss
@@ -1,13 +1,51 @@
+$study-mode-modal-width: 1310px;
+$study-mode-modal-content-width: 1230px;
+
 .container {
-  padding: var(--spacing-large);
-  min-height: 300px;
+  padding: 0;
+  min-width: $study-mode-modal-width;
 }
 
 .contentModal {
-  max-width: 800px;
-  width: 100%;
+  padding: var(--spacing-xlarge-px);
+  min-width: $study-mode-modal-content-width;
 }
 
 .innerContent {
   padding: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small-px);
+  width: 100%;
+  margin-block-end: var(--spacing-xlarge-px);
+}
+
+.selectionWrapper {
+  display: flex;
+}
+
+.navButton {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: var(--spacing-small-px);
+    height: var(--spacing-small-px);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.prevButton {
+  svg {
+    transform: scaleX(-1);
+  }
 }

--- a/src/components/QuranReader/ReadingView/StudyModeModal/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/index.tsx
@@ -1,41 +1,149 @@
-import React from 'react';
+import React, { useState, useCallback, useContext, useEffect } from 'react';
 
 import useTranslation from 'next-translate/useTranslation';
+import { shallowEqual, useSelector } from 'react-redux';
+import useSWR from 'swr';
 
+import StudyModeBody from './StudyModeBody';
 import styles from './StudyModeModal.module.scss';
 
+import SurahAndAyahSelection from '@/components/QuranReader/TafsirView/SurahAndAyahSelection';
+import Button, { ButtonSize, ButtonVariant } from '@/dls/Button/Button';
 import ContentModal from '@/dls/ContentModal/ContentModal';
+import Spinner from '@/dls/Spinner/Spinner';
+import ArrowIcon from '@/icons/arrow.svg';
+import { selectQuranReaderStyles } from '@/redux/slices/QuranReader/styles';
+import { selectSelectedTranslations } from '@/redux/slices/QuranReader/translations';
+import { getDefaultWordFields, getMushafId } from '@/utils/api';
+import { makeByVerseKeyUrl } from '@/utils/apiPaths';
+import { getChapterNumberFromKey, getVerseNumberFromKey } from '@/utils/verse';
+import { fetcher } from 'src/api';
+import DataContext from 'src/contexts/DataContext';
+import Verse from 'types/Verse';
 import Word from 'types/Word';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   word: Word;
+  verse?: Verse;
+  highlightedWordLocation?: string;
 }
 
-/**
- * Study Mode modal for verse study and analysis
- * Displays study tools and resources for the selected verse
- * @param {Props} props - Component props
- * @returns React component for study mode modal
- */
-const StudyModeModal: React.FC<Props> = ({ isOpen, onClose, word }) => {
-  const { t } = useTranslation('common');
-  const { verse } = word;
+interface VerseResponse {
+  verse: Verse;
+}
 
-  if (!verse) return null;
+const StudyModeModal: React.FC<Props> = ({ isOpen, onClose, word, verse: initialVerse, highlightedWordLocation }) => {
+  const { t } = useTranslation('common');
+  const chaptersData = useContext(DataContext);
+  const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
+  const selectedTranslations = useSelector(selectSelectedTranslations, shallowEqual);
+  const initialChapterId = getChapterNumberFromKey(word.verseKey).toString();
+  const initialVerseNumber = getVerseNumberFromKey(word.verseKey).toString();
+  const [selectedChapterId, setSelectedChapterId] = useState(initialChapterId);
+  const [selectedVerseNumber, setSelectedVerseNumber] = useState(initialVerseNumber);
+
+  useEffect(() => {
+    let isMounted = true;
+    if (isOpen && isMounted) {
+      setSelectedChapterId(initialChapterId);
+      setSelectedVerseNumber(initialVerseNumber);
+    }
+    return () => { isMounted = false; };
+  }, [isOpen, initialChapterId, initialVerseNumber]);
+
+  const verseKey = `${selectedChapterId}:${selectedVerseNumber}`;
+  const queryKey = isOpen ? makeByVerseKeyUrl(verseKey, {
+    words: true,
+    translationFields: 'resource_name,language_id',
+    translations: selectedTranslations.join(','),
+    ...getDefaultWordFields(quranReaderStyles.quranFont),
+    ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
+  }) : null;
+
+  const { data, isValidating } = useSWR<VerseResponse>(queryKey, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    dedupingInterval: 2000,
+  });
+
+  const currentVerse = data?.verse || (verseKey === `${initialChapterId}:${initialVerseNumber}` ? initialVerse : undefined);
+  const handleChapterChange = useCallback((newChapterId: string) => {
+    setSelectedChapterId(newChapterId);
+    setSelectedVerseNumber('1');
+  }, []);
+  const handleVerseChange = useCallback((newVerseNumber: string) => setSelectedVerseNumber(newVerseNumber), []);
+  const handlePreviousVerse = useCallback(() => {
+    const currentVerseNum = Number(selectedVerseNumber);
+    if (currentVerseNum > 1) {
+      setSelectedVerseNumber(String(currentVerseNum - 1));
+    } else {
+      const prevChapterId = Number(selectedChapterId) - 1;
+      if (prevChapterId >= 1 && chaptersData[prevChapterId]) {
+        setSelectedChapterId(String(prevChapterId));
+        setSelectedVerseNumber(String(chaptersData[prevChapterId]?.versesCount || 1));
+      }
+    }
+  }, [selectedChapterId, selectedVerseNumber, chaptersData]);
+  const handleNextVerse = useCallback(() => {
+    const currentVerseNum = Number(selectedVerseNumber);
+    const currentChapter = chaptersData[Number(selectedChapterId)];
+    if (currentChapter && currentVerseNum < currentChapter.versesCount) {
+      setSelectedVerseNumber(String(currentVerseNum + 1));
+    } else {
+      const nextChapterId = Number(selectedChapterId) + 1;
+      if (nextChapterId <= 114 && chaptersData[nextChapterId]) {
+        setSelectedChapterId(String(nextChapterId));
+        setSelectedVerseNumber('1');
+      }
+    }
+  }, [selectedChapterId, selectedVerseNumber, chaptersData]);
+
+  const canNavigatePrev = Number(selectedChapterId) > 1 || Number(selectedVerseNumber) > 1;
+  const canNavigateNext = Number(selectedChapterId) < 114 ||
+    (Number(selectedChapterId) === 114 && Number(selectedVerseNumber) < (chaptersData[114]?.versesCount || 0));
+
+  const header = (
+    <div className={styles.header}>
+      <div className={styles.selectionWrapper}>
+        <SurahAndAyahSelection
+          selectedChapterId={selectedChapterId}
+          selectedVerseNumber={selectedVerseNumber}
+          onChapterIdChange={handleChapterChange}
+          onVerseNumberChange={handleVerseChange}
+        />
+      </div>
+      <Button size={ButtonSize.Small} variant={ButtonVariant.Ghost} onClick={handlePreviousVerse}
+        className={`${styles.navButton} ${styles.prevButton}`} ariaLabel="Previous verse" isDisabled={!canNavigatePrev}>
+        <ArrowIcon />
+      </Button>
+      <Button size={ButtonSize.Small} variant={ButtonVariant.Ghost} onClick={handleNextVerse}
+        className={styles.navButton} ariaLabel="Next verse" isDisabled={!canNavigateNext}>
+        <ArrowIcon />
+      </Button>
+    </div>
+  );
+
+  if (!isOpen || !chaptersData) return null;
+
+  const renderContent = () => {
+    if (isValidating && !data) return <div className={styles.loadingContainer}><Spinner /></div>;
+    if (currentVerse) return <StudyModeBody verse={currentVerse} bookmarksRangeUrl="" highlightedWordLocation={highlightedWordLocation} />;
+    return <div className={styles.errorContainer}><p>{t('error:general')}</p></div>;
+  };
 
   return (
     <ContentModal
       isOpen={isOpen}
       onClose={onClose}
       onEscapeKeyDown={onClose}
-      header={t('study-mode')}
+      header={header}
       hasCloseButton
       contentClassName={styles.contentModal}
       innerContentClassName={styles.innerContent}
     >
-      <div className={styles.container}>{/* Content will be built in future PR */}</div>
+      {renderContent()}
     </ContentModal>
   );
 };

--- a/src/components/Verse/PlainVerseText/PlainVerseTextWord/PlainVerseTextWord.module.scss
+++ b/src/components/Verse/PlainVerseText/PlainVerseTextWord/PlainVerseTextWord.module.scss
@@ -6,6 +6,10 @@
   margin-block-end: var(--spacing-xsmall);
 }
 
+.highlighted {
+  color: var(--color-success-medium);
+}
+
 .plainVerseWbwText {
   margin-block: var(--spacing-xxsmall);
   margin-inline: var(--spacing-xxsmall);

--- a/src/components/Verse/PlainVerseText/PlainVerseTextWord/index.tsx
+++ b/src/components/Verse/PlainVerseText/PlainVerseTextWord/index.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode } from 'react';
 
+import classNames from 'classnames';
+
 import styles from './PlainVerseTextWord.module.scss';
 
 import InlineWordByWord from '@/dls/InlineWordByWord';
@@ -10,6 +12,7 @@ interface Props {
   children: ReactNode;
   shouldShowWordByWordTranslation: boolean;
   shouldShowWordByWordTransliteration: boolean;
+  isHighlighted?: boolean;
 }
 
 const PlainVerseTextWord: React.FC<Props> = ({
@@ -17,9 +20,12 @@ const PlainVerseTextWord: React.FC<Props> = ({
   children,
   shouldShowWordByWordTransliteration,
   shouldShowWordByWordTranslation,
+  isHighlighted = false,
 }) => {
   return (
-    <div className={styles.plainVerseWordContainer} key={word.location}>
+    <div className={classNames(styles.plainVerseWordContainer, {
+      [styles.highlighted]: isHighlighted,
+    })} key={word.location}>
       {children}
       {shouldShowWordByWordTranslation && (
         <InlineWordByWord className={styles.plainVerseWbwText} text={word?.translation?.text} />

--- a/src/components/Verse/PlainVerseText/index.tsx
+++ b/src/components/Verse/PlainVerseText/index.tsx
@@ -24,6 +24,7 @@ type Props = {
   fontScale?: number;
   titleText?: string;
   quranFont?: QuranFont;
+  highlightedWordLocation?: string;
 };
 
 /**
@@ -41,6 +42,7 @@ const PlainVerseText: React.FC<Props> = ({
   fontScale,
   titleText,
   quranFont: quranFontFromProps,
+  highlightedWordLocation,
 }: Props): JSX.Element => {
   const {
     quranFont: quranFontFromStore,
@@ -75,6 +77,7 @@ const PlainVerseText: React.FC<Props> = ({
           translate="no"
         >
           {words?.map((word) => {
+            const isHighlighted = highlightedWordLocation && word.location === highlightedWordLocation;
             if (isQcfFont) {
               return (
                 <PlainVerseTextWord
@@ -82,6 +85,7 @@ const PlainVerseText: React.FC<Props> = ({
                   word={word}
                   shouldShowWordByWordTranslation={shouldShowWordByWordTranslation}
                   shouldShowWordByWordTransliteration={shouldShowWordByWordTransliteration}
+                  isHighlighted={isHighlighted}
                 >
                   <GlyphWord
                     font={quranFont}
@@ -90,6 +94,7 @@ const PlainVerseText: React.FC<Props> = ({
                     textCodeV1={word.codeV1}
                     textCodeV2={word.codeV2}
                     isFontLoaded={isFontLoaded}
+                    isHighlighted={isHighlighted}
                   />
                 </PlainVerseTextWord>
               );
@@ -100,6 +105,7 @@ const PlainVerseText: React.FC<Props> = ({
                 word={word}
                 shouldShowWordByWordTranslation={shouldShowWordByWordTranslation}
                 shouldShowWordByWordTransliteration={shouldShowWordByWordTransliteration}
+                isHighlighted={isHighlighted}
               >
                 <TextWord font={quranFont} text={word.text} charType={word.charTypeName} />
               </PlainVerseTextWord>


### PR DESCRIPTION
## Summary

  Implements Study Mode modal that allows users to study Quranic verses in detail with navigation, translations, and word highlighting.

  **Key features:**
  - Opens when clicking words or ayah numbers in Translation mode
  - Navigate between verses using prev/next arrows or chapter/verse selection
  - Displays Arabic text with selected translations
  - Highlights clicked word 
  - Uses `PlainVerseText` component 
  - Fetches verse data with SWR (with proper cleanup)
  - Lazy loaded to break circular dependencies

  part of [QF-4170](https://quranfoundation.atlassian.net/browse/QF-4170)

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Test Plan

  ### Manual Testing Performed

  **Opening Study Mode:**
  1. Navigate to any chapter in Translation mode
  2. Click on a word → Study Mode modal opens with that word highlighted in green
  3. Click on ayah number (end marker) → Study Mode modal opens without word highlighting
  4. Click tooltip arrow icon on word → Study Mode modal opens with word highlighted

  **Navigation:**
  5. Use prev arrow button → navigates to previous verse
  6. Use next arrow button → navigates to next verse
  7. Navigate from last verse of a chapter → goes to first verse of next chapter
  8. Navigate from first verse of a chapter → goes to last verse of previous chapter
  9. Use chapter dropdown → changes to selected chapter (resets to verse 1)
  10. Use verse dropdown → changes to selected verse within current chapter

  **Edge Cases:**
  11. Verify prev button is disabled on first verse (1:1)
  12. Verify next button is disabled on last verse (114:6)
  13. Click words inside modal → verify no nested modals open (interactions disabled)
  14. Close and reopen modal → verify state resets correctly
  15. Navigate while modal is open → verify verse data fetches and displays correctly

  **Display:**
  16. Verify Arabic text displays correctly with selected font
  17. Verify all selected translations display below Arabic text
  18. Verify TopActions (bookmark, play, etc.) work correctly
  19. Verify word highlighting persists when navigating away and back to same verse
  20. Verify highlighting clears when opening from ayah number

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [x] README updated (if adding features or setup changes)
  - [x] Inline comments added for complex logic

  ### Localization (if UI changes)

  - [x] All user-facing text uses `next-translate`
  - [x] Only English locale files modified (Lokalise handles others)
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] ARIA attributes added where needed
  - [x] Keyboard navigation works

## Screenshots/Videos

| Before | After |
| ------ | ----- |
|  study mode opened from  tooltip   |  <img width="1058" height="346" alt="image" src="https://github.com/user-attachments/assets/ea66758f-253d-4157-8367-04c7a1cdfbd7" />     |
| footnote| <img width="994" height="400" alt="image" src="https://github.com/user-attachments/assets/9c1d9541-7765-474e-a697-2c073eff3eac" /> |
| study mode opened from ayah number| <img width="1031" height="334" alt="image" src="https://github.com/user-attachments/assets/3c85c1d3-fa31-4e58-8933-2cce973b0e0a" />|

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4170]: https://quranfoundation.atlassian.net/browse/QF-4170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ