### PR TITLE
Render learning plans as HTML only

### DIFF
--- a/src/components/Course/CourseDetails/Tabs/MainDetails/index.tsx
+++ b/src/components/Course/CourseDetails/Tabs/MainDetails/index.tsx
@@ -1,13 +1,11 @@
 /* eslint-disable unicorn/no-array-reduce */
 import React from 'react';
 
-import { MilkdownProvider } from '@milkdown/react';
 import useTranslation from 'next-translate/useTranslation';
 
 import DetailSection from './DetailSection';
 import styles from './MainDetails.module.scss';
 
-import MarkdownEditor from '@/components/MarkdownEditor';
 import HtmlContent from '@/components/RichText/HtmlContent';
 import { Course } from '@/types/auth/Course';
 
@@ -24,9 +22,6 @@ const MainDetails: React.FC<Props> = ({ course }) => {
   //   return `${acc}, ${currentValue}`;
   // }, '');
 
-  // FIXME: remove once markdown in api is converted to html
-  const shouldUseMilkdown = /(^|\n)\s*#/m.test(description ?? '') || /\\$/m.test(description ?? '');
-
   return (
     <>
       <DetailSection
@@ -36,23 +31,14 @@ const MainDetails: React.FC<Props> = ({ course }) => {
           days: lessons.length,
         })}.`}
       />
-      {shouldUseMilkdown ? (
-        <MilkdownProvider>
-          <DetailSection
-            title={t('description')}
-            description={<MarkdownEditor isEditable={false} defaultValue={description} />}
-          />
-        </MilkdownProvider>
-      ) : (
-        <DetailSection
-          title={t('description')}
-          description={
-            <div className={styles.htmlDescription}>
-              <HtmlContent html={description} />
-            </div>
-          }
-        />
-      )}
+      <DetailSection
+        title={t('description')}
+        description={
+          <div className={styles.htmlDescription}>
+            <HtmlContent html={description} />
+          </div>
+        }
+      />
     </>
   );
 };

--- a/src/components/Course/LessonView/index.tsx
+++ b/src/components/Course/LessonView/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import { MilkdownProvider } from '@milkdown/react';
 import useTranslation from 'next-translate/useTranslation';
 
 import ActionButtons from './ActionButtons';
@@ -8,7 +7,6 @@ import CourseMaterial from './CourseMaterial';
 import styles from './Lesson.module.scss';
 
 import ContentContainer from '@/components/Course/ContentContainer';
-import MarkdownEditor from '@/components/MarkdownEditor';
 import PageContainer from '@/components/PageContainer';
 import HtmlContent from '@/components/RichText/HtmlContent';
 import Button, { ButtonVariant } from '@/dls/Button/Button';
@@ -38,9 +36,6 @@ const LessonView: React.FC<Props> = ({ lesson, courseSlug, lessonSlugOrId }) => 
     logButtonClick('course_material', { lessonSlugOrId, courseSlug });
     setCourseMaterialModalOpen(true);
   };
-
-  // FIXME: remove once markdown in api is converted to html
-  const shouldUseMilkdown = /(^|\n)\s*#/m.test(content ?? '') || /\\$/m.test(content ?? '');
 
   return (
     <ContentContainer>
@@ -90,20 +85,8 @@ const LessonView: React.FC<Props> = ({ lesson, courseSlug, lessonSlugOrId }) => 
                 {`: ${title}`}
               </p>
             </div>
-            <div
-              className={
-                shouldUseMilkdown
-                  ? styles.contentContainer
-                  : `${styles.contentContainer} ${styles.htmlContent}`
-              }
-            >
-              {shouldUseMilkdown ? (
-                <MilkdownProvider>
-                  <MarkdownEditor isEditable={false} defaultValue={content} />
-                </MilkdownProvider>
-              ) : (
-                <HtmlContent html={content} />
-              )}
+            <div className={`${styles.contentContainer} ${styles.htmlContent}`}>
+              <HtmlContent html={content} />
             </div>
             <ActionButtons lesson={lesson} courseSlug={courseSlug} />
           </PageContainer>


### PR DESCRIPTION
## Summary
- always render learning plan content as HTML
- remove Milkdown rendering paths from course views

## Testing
- not run (not requested)