### PR TITLE
[QF-4413] Disable Submit Button During Translation Feedback Submission

### DIFF
--- a/src/components/Verse/TranslationFeedback/TranslationFeedbackModal.tsx
+++ b/src/components/Verse/TranslationFeedback/TranslationFeedbackModal.tsx
@@ -77,6 +77,7 @@ const TranslationFeedbackModal: React.FC<TranslationFeedbackModalProps> = ({ ver
           isLoading={isSubmitting}
           size={ButtonSize.Small}
           className={styles.reportButton}
+          isDisabled={isSubmitting}
           data-testid="translation-feedback-submit-button"
         >
           {t('translation-feedback.report')}


### PR DESCRIPTION
This PR fixes a bug where the submit button in the translation feedback modal could be clicked multiple times during form submission, potentially causing duplicate submissions.

Closes: [QF-4413](https://quranfoundation.atlassian.net/browse/QF-4413)

[QF-4413]: https://quranfoundation.atlassian.net/browse/QF-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ