### PR TITLE
fix: improve RTL support for surah header components

### DIFF
--- a/src/components/QuranReader/PlayButton.module.scss
+++ b/src/components/QuranReader/PlayButton.module.scss
@@ -32,5 +32,7 @@ $playChapterAudioButtonMinInlineSize: 95px;
     @include customButton;
     min-inline-size: $playChapterAudioButtonMinInlineSize;
     font-size: var(--font-size-small);
+    padding-inline: var(--spacing-small-px);
+    white-space: nowrap;
   }
 }

--- a/src/components/QuranReader/PlayChapterAudioButton.tsx
+++ b/src/components/QuranReader/PlayChapterAudioButton.tsx
@@ -9,6 +9,7 @@ import Spinner from '../dls/Spinner/Spinner';
 import styles from './PlayButton.module.scss';
 
 import Button, { ButtonShape, ButtonSize, ButtonType } from '@/dls/Button/Button';
+import useDirection from '@/hooks/useDirection';
 import useGetQueryParamOrXstateValue from '@/hooks/useGetQueryParamOrXstateValue';
 import PauseIcon from '@/icons/pause.svg';
 import PlayIcon from '@/icons/play-arrow.svg';
@@ -29,6 +30,8 @@ const PlayChapterAudioButton: React.FC<Props> = ({ chapterId }) => {
   const { t } = useTranslation('common');
   const chaptersData = useContext(DataContext);
   const chapterData = getChapterData(chaptersData, chapterId.toString());
+  const direction = useDirection();
+  const isRTL = direction === 'rtl';
 
   const audioService = useContext(AudioPlayerMachineContext);
   const isLoadingCurrentChapter = useSelector(audioService, (state) =>
@@ -68,7 +71,8 @@ const PlayChapterAudioButton: React.FC<Props> = ({ chapterId }) => {
           type={ButtonType.Secondary}
           shape={ButtonShape.Pill}
           size={ButtonSize.Small}
-          prefix={<Spinner />}
+          prefix={isRTL ? undefined : <Spinner />}
+          suffix={isRTL ? <Spinner /> : undefined}
           hasSidePadding={false}
           shouldFlipOnRTL={false}
           isDisabled
@@ -86,7 +90,8 @@ const PlayChapterAudioButton: React.FC<Props> = ({ chapterId }) => {
           type={ButtonType.Secondary}
           shape={ButtonShape.Pill}
           size={ButtonSize.Small}
-          prefix={<PauseIcon />}
+          prefix={isRTL ? undefined : <PauseIcon />}
+          suffix={isRTL ? <PauseIcon /> : undefined}
           onClick={pause}
           hasSidePadding={false}
           shouldFlipOnRTL={false}
@@ -98,7 +103,8 @@ const PlayChapterAudioButton: React.FC<Props> = ({ chapterId }) => {
           type={ButtonType.Secondary}
           shape={ButtonShape.Pill}
           size={ButtonSize.Small}
-          prefix={<PlayIcon />}
+          prefix={isRTL ? undefined : <PlayIcon />}
+          suffix={isRTL ? <PlayIcon /> : undefined}
           onClick={play}
           hasSidePadding={false}
           shouldFlipOnRTL={false}

--- a/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
+++ b/src/components/QuranReader/ReadingPreferenceSwitcher/ReadingPreference.module.scss
@@ -1,16 +1,16 @@
-@use "src/styles/breakpoints";
-@use "src/styles/theme";
+@use 'src/styles/breakpoints';
+@use 'src/styles/theme';
 
 .container {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
+  inline-size: 100%;
   transition: all 0.3s ease;
   cursor: pointer;
 
   &:hover .unselected {
-    opacity: 0.9;
+    opacity: 0.6;
   }
 }
 
@@ -25,7 +25,7 @@
 
 .iconContainer {
   & > svg {
-    width: 15px;
+    inline-size: 15px;
     display: block;
     margin: auto;
   }
@@ -120,8 +120,6 @@
 }
 
 .unselected {
-  opacity: 0.7;
-
   rect:first-child {
     fill: none;
     stroke: #666666;

--- a/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
+++ b/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
@@ -27,7 +27,7 @@ $bismillahSvgInlineSizeMobile: 148px;
   margin-inline: auto;
   inline-size: 100%;
   max-inline-size: $chapterHeaderContainerMaxInlineSize;
-  margin-block-start: var(--spacing-medium2);
+  margin-block-start: var(--spacing-mega);
 }
 
 .topControls {


### PR DESCRIPTION
## Summary

Fixes RTL layout issues in surah header components including play button icon positioning, reading preference icons styling, and Tajweed bar overlap.

Closes: [QF-4342](https://quranfoundation.atlassian.net/browse/QF-4342)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. Switch language to Arabic (RTL)
2. Navigate to any Surah page
3. Verify play button shows icon first (on the right in RTL), then label
4. Verify reading/translation mode icons show #666666 color when unselected
5. Hover over unselected icons and verify opacity reduces
6. Enable Tajweed mushaf and verify the Tajweed bar toggle doesn't overlap the surah header

### Edge Cases Verified

- [x] 👤 Logged-in vs guest behavior (if applicable)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [x] Linting passes (`yarn lint`)

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] Only English locale files modified (Lokalise handles others)
- [x] RTL layout verified

## Screenshots/Videos

| Before | After |
| ------ | ----- |
| Play button icon appears after label in RTL | Play button icon appears first (right side) in RTL |
| Unselected icons have 0.7 opacity by default | Unselected icons show full #666666, opacity on hover |
| Tajweed bar overlaps surah header | Proper spacing between Tajweed bar and header |

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4342]: https://quranfoundation.atlassian.net/browse/QF-4342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ