### PR TITLE
 QF-3105 - Prod

### DIFF
--- a/src/hooks/useAddQueryParamsToUrl.ts
+++ b/src/hooks/useAddQueryParamsToUrl.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { buildUrlWithParams } from '@/utils/navigation';
+
 /**
  * A hook that appends query parameters to the url. We could've used shallow routing for Next.js
  * but it causes re-rendering to the whole app @see https://github.com/vercel/next.js/discussions/18072

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -430,6 +430,25 @@ export const getQuranMediaMakerNavigationUrl = (params?: ParsedUrlQuery) => {
 };
 
 /**
+ * Build a url with query parameters
+ *
+ * @param {string} baseUrl
+ * @param {Record<string, unknown>} params
+ * @returns {string}
+ */
+export const buildUrlWithParams = (baseUrl: string, params: Record<string, unknown>): string => {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
+    searchParams.set(key, String(value));
+  });
+
+  const queryString = searchParams.toString();
+  return `${baseUrl}${queryString ? `?${queryString}` : ''}`;
+};
+
+/**
  * Update the browser history with the new url.
  * without actually navigating into that url.
  * So it does not trigger re render or page visit on Next.js


### PR DESCRIPTION
IMPORTANT:
I also had to cherry-pick the `buildUrlWithParams` function added in this commit https://github.com/quran/quran.com-frontend-next/commit/8e43f77da1709b06fcfe61eb7819a16b649e6d6d because it was not on production branch

I've tested the fix and it works.