### PR TITLE
remove unnecessary padding in hero section

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -4,10 +4,6 @@
 $list-max-width: 80rem;
 
 .pageContainer {
-  @include breakpoints.smallerThanTablet {
-    padding-block-start: var(--banner-height);
-  }
-  padding-block-end: var(--spacing-small);
   padding-inline-start: 0;
   padding-inline-end: 0;
 }


### PR DESCRIPTION
Remove unnecessary padding in hero section on the homepage

|Before|After|
|---|---|
|<img width="662" height="1415" alt="image" src="https://github.com/user-attachments/assets/eaea62b7-305d-4991-8ae4-5352c9de95a8" />|<img width="662" height="1415" alt="image" src="https://github.com/user-attachments/assets/5940ab9b-6c6b-4e40-92db-c2f23c0e9cce" />|