### PR TITLE
fix: Answers button not showing in Translation View

### DIFF
--- a/src/components/QuranReader/TranslationView/BottomActions.tsx
+++ b/src/components/QuranReader/TranslationView/BottomActions.tsx
@@ -35,6 +35,10 @@ interface BottomActionsProps {
    * Whether this is in translation view
    */
   isTranslationView?: boolean;
+  /**
+   * Whether this verse has questions (passed from parent to ensure memo re-renders)
+   */
+  hasQuestions?: boolean;
 }
 
 /**
@@ -42,12 +46,18 @@ interface BottomActionsProps {
  * @param {BottomActionsProps} props - Component props
  * @returns {JSX.Element} The rendered component
  */
-const BottomActions = ({ verseKey, isTranslationView = true }: BottomActionsProps): JSX.Element => {
+const BottomActions = ({
+  verseKey,
+  isTranslationView = true,
+  hasQuestions: hasQuestionsProp,
+}: BottomActionsProps): JSX.Element => {
   const { t, lang } = useTranslation('common');
   const tafsirs = useSelector(selectSelectedTafsirs);
   const [chapterId, verseNumber] = getVerseAndChapterNumbersFromKey(verseKey);
   const questionsData = usePageQuestions();
-  const hasQuestions = questionsData?.[verseKey]?.total > 0;
+  // Use prop if provided (from memoized parent), otherwise compute from context
+  // Only show Answers tab when we confirm questions exist (not while loading)
+  const hasQuestions = hasQuestionsProp ?? questionsData?.[verseKey]?.total > 0;
   const isClarificationQuestion = !!questionsData?.[verseKey]?.types?.[QuestionType.CLARIFICATION];
   const isMobile = useIsMobile(MobileSizeVariant.SMALL);
   // Modal state using enum

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -38,6 +38,7 @@ type TranslationViewCellProps = {
   verseIndex: number;
   bookmarksRangeUrl: string;
   hasNotes?: boolean;
+  hasQuestions?: boolean;
 };
 
 const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
@@ -46,6 +47,7 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
   verseIndex,
   bookmarksRangeUrl,
   hasNotes,
+  hasQuestions,
 }) => {
   const router = useRouter();
   const { startingVerse } = router.query;
@@ -123,7 +125,7 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
             ))}
           </div>
         </div>
-        <BottomActions verseKey={verse.verseKey} />
+        <BottomActions verseKey={verse.verseKey} hasQuestions={hasQuestions} />
       </div>
       <Separator className={styles.verseSeparator} />
     </>
@@ -153,6 +155,7 @@ const areVersesEqual = (
 ): boolean =>
   prevProps.verse.id === nextProps.verse.id &&
   prevProps.hasNotes === nextProps.hasNotes &&
+  prevProps.hasQuestions === nextProps.hasQuestions &&
   !verseFontChanged(
     prevProps.quranReaderStyles,
     nextProps.quranReaderStyles,
@@ -161,6 +164,5 @@ const areVersesEqual = (
   ) &&
   !verseTranslationChanged(prevProps.verse, nextProps.verse) &&
   !verseTranslationFontChanged(prevProps.quranReaderStyles, nextProps.quranReaderStyles) &&
-  prevProps.bookmarksRangeUrl === nextProps.bookmarksRangeUrl &&
-  prevProps.hasNotes === nextProps.hasNotes;
+  prevProps.bookmarksRangeUrl === nextProps.bookmarksRangeUrl;
 export default memo(TranslationViewCell, areVersesEqual);

--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
@@ -8,6 +8,7 @@ import getTranslationNameString from '@/components/QuranReader/ReadingView/utils
 import useCountRangeNotes from '@/hooks/auth/useCountRangeNotes';
 import QuranReaderStyles from '@/redux/types/QuranReaderStyles';
 import Verse from '@/types/Verse';
+import { QuestionsData } from '@/utils/auth/api';
 
 interface TranslationPageVerse {
   verse: Verse;
@@ -19,6 +20,7 @@ interface TranslationPageVerse {
     from: string;
     to: string;
   } | null;
+  questionsData?: Record<string, QuestionsData>;
 }
 
 const TranslationPageVerse: React.FC<TranslationPageVerse> = ({
@@ -28,11 +30,15 @@ const TranslationPageVerse: React.FC<TranslationPageVerse> = ({
   quranReaderStyles,
   isLastVerseInView,
   notesRange,
+  questionsData,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { verseKeysQueue } = useVerseTrackerContext();
 
   const { data: notesCount } = useCountRangeNotes(notesRange);
+
+  // Only show Answers tab when we confirm questions exist
+  const hasQuestions = questionsData?.[verse.verseKey]?.total > 0;
 
   useEffect(() => {
     let observer: IntersectionObserver = null;
@@ -83,6 +89,7 @@ const TranslationPageVerse: React.FC<TranslationPageVerse> = ({
         quranReaderStyles={quranReaderStyles}
         bookmarksRangeUrl={bookmarksRangeUrl}
         hasNotes={hasNotes}
+        hasQuestions={hasQuestions}
       />
     </div>
   );

--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/index.tsx
@@ -10,6 +10,7 @@ import TranslationPageVerse from './TranslationPageVerse';
 import QuranReaderStyles from '@/redux/types/QuranReaderStyles';
 import { QuranReaderDataType } from '@/types/QuranReader';
 import { getMushafId } from '@/utils/api';
+import { QuestionsData } from '@/utils/auth/api';
 import { VersesResponse } from 'types/ApiResponses';
 import Verse from 'types/Verse';
 
@@ -24,6 +25,7 @@ interface Props {
   initialData: VersesResponse;
   verseIdx: number;
   totalVerses: number;
+  questionsData?: Record<string, QuestionsData>;
 }
 
 const TranslationViewVerse: React.FC<Props> = ({
@@ -37,6 +39,7 @@ const TranslationViewVerse: React.FC<Props> = ({
   selectedTranslations,
   verseIdx,
   totalVerses,
+  questionsData,
 }) => {
   const mushafId = getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines).mushaf;
 
@@ -70,6 +73,7 @@ const TranslationViewVerse: React.FC<Props> = ({
         quranReaderStyles={quranReaderStyles}
         bookmarksRangeUrl={bookmarksRangeUrl}
         notesRange={notesRange}
+        questionsData={questionsData}
       />
     </div>
   );

--- a/src/components/QuranReader/TranslationView/index.tsx
+++ b/src/components/QuranReader/TranslationView/index.tsx
@@ -127,32 +127,51 @@ const TranslationView = ({
     return result;
   }, [pageQuestionsMap]);
 
-  const itemContentRenderer = (verseIdx: number) => {
-    if (verseIdx === versesCount) {
+  // Wrap in useCallback with accumulatedQuestionsData as dependency.
+  // This ensures Virtuoso re-renders items when questions data changes,
+  // fixing the issue where Answers buttons wouldn't appear after async data loads.
+  const itemContentRenderer = useCallback(
+    (verseIdx: number) => {
+      if (verseIdx === versesCount) {
+        return (
+          <EndOfScrollingControls
+            quranReaderDataType={quranReaderDataType}
+            lastVerse={verses[verses.length - 1]}
+            initialData={initialData}
+          />
+        );
+      }
+
       return (
-        <EndOfScrollingControls
+        <TranslationViewVerse
+          verseIdx={verseIdx}
+          totalVerses={versesCount}
           quranReaderDataType={quranReaderDataType}
-          lastVerse={verses[verses.length - 1]}
+          quranReaderStyles={quranReaderStyles}
+          setApiPageToVersesMap={setApiPageToVersesMap}
+          selectedTranslations={selectedTranslations}
+          wordByWordLocale={wordByWordLocale}
+          reciterId={reciterId}
           initialData={initialData}
+          resourceId={resourceId}
+          questionsData={accumulatedQuestionsData}
         />
       );
-    }
-
-    return (
-      <TranslationViewVerse
-        verseIdx={verseIdx}
-        totalVerses={versesCount}
-        quranReaderDataType={quranReaderDataType}
-        quranReaderStyles={quranReaderStyles}
-        setApiPageToVersesMap={setApiPageToVersesMap}
-        selectedTranslations={selectedTranslations}
-        wordByWordLocale={wordByWordLocale}
-        reciterId={reciterId}
-        initialData={initialData}
-        resourceId={resourceId}
-      />
-    );
-  };
+    },
+    [
+      versesCount,
+      quranReaderDataType,
+      verses,
+      initialData,
+      accumulatedQuestionsData,
+      quranReaderStyles,
+      setApiPageToVersesMap,
+      selectedTranslations,
+      wordByWordLocale,
+      reciterId,
+      resourceId,
+    ],
+  );
 
   const shouldShowQueryParamMessage =
     translationsQueryParamDifferent ||


### PR DESCRIPTION
## Summary

Closes: [QF-4421](https://quranfoundation.atlassian.net/browse/QF-4421)

- Fixed Answers button not appearing in Translation View while working correctly in Reading View
- Root cause: React.memo and Virtuoso list optimization prevented re-renders when async questions data loaded
- Solution: Wrap itemContentRenderer in useCallback with proper dependencies and pass questionsData as props through component chain

## Test plan
- [x] Navigate to a chapter with verses that have questions (e.g., 2:6)
- [x] Switch between Reading View and Translation View
- [x] Verify Answers button appears consistently in both views
- [x] Verify Answers button appears on initial page load without needing refresh
- [x] Verify Answers button appears when navigating between chapters

[QF-4421]: https://quranfoundation.atlassian.net/browse/QF-4421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ