### PR TITLE
fix: correct RTL icon order in translation view bottom actions

### DIFF
--- a/src/components/QuranReader/TranslationView/BottomActionsTabs.tsx
+++ b/src/components/QuranReader/TranslationView/BottomActionsTabs.tsx
@@ -58,7 +58,7 @@ const BottomActionsTabs: React.FC<BottomActionsTabsProps> = ({ tabs, isTranslati
           .map((tab, index, filteredTabs) => (
             <React.Fragment key={tab.id}>
               <div
-                className={classNames(styles.tabItem, { [styles.tabItemRTL]: isRTL })}
+                className={styles.tabItem}
                 data-testid={`bottom-action-tab-${tab.id}`}
                 onClick={(e) => handleTabClick(e, tab.onClick)}
                 onKeyDown={(e) => handleTabKeyDown(e, tab.onClick)}

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.module.scss
@@ -175,10 +175,6 @@ $arabicVerseTopMargin: 2.75rem;
   }
 }
 
-.tabItemRTL {
-  flex-direction: row-reverse;
-}
-
 .tabIcon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Closes: [QF-4448](https://quranfoundation.atlassian.net/browse/QF-4448)
- Fix incorrect icon placement in RTL mode for bottom action tabs (Tafsir, Reflections, Answers)
- Remove `row-reverse` flex direction that was causing icons to appear before text in Arabic
- In RTL reading order (right-to-left), users now correctly see text first, then icon

## Test plan
- [x] Switch site language to Arabic
- [x] Navigate to translation view
- [x] Verify the bottom action tabs (Tafsir, Reflections, Answers) show text before icons when reading RTL

[QF-4448]: https://quranfoundation.atlassian.net/browse/QF-4448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ