### PR TITLE
fix: show settings button on mobile when navbar is visible

### DIFF
--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -1,13 +1,13 @@
-@use "src/styles/breakpoints";
-@use "src/styles/constants";
+@use 'src/styles/breakpoints';
+@use 'src/styles/constants';
 
 .container {
   display: flex;
   flex-direction: column;
   background: var(--color-background-elevated);
   position: fixed;
-  height: 100vh;
-  width: 100%;
+  block-size: 100vh;
+  inline-size: 100%;
   inset-block: 0;
   z-index: var(--z-index-header);
   transition: var(--transition-regular);
@@ -16,7 +16,7 @@
   overflow-x: hidden;
   overscroll-behavior-y: contain !important;
   @include breakpoints.tablet {
-    width: constants.$side-menu-desktop-width;
+    inline-size: constants.$side-menu-desktop-width;
   }
   &.left {
     inset-inline-start: -100%;
@@ -49,16 +49,16 @@
 .searchContainer {
   display: flex;
   flex-direction: column;
-  min-height: calc(100% - calc(var(--navbar-container-height) + calc(4 * var(--spacing-mega))));
+  min-block-size: calc(100% - calc(var(--navbar-container-height) + calc(4 * var(--spacing-mega))));
   @include breakpoints.tablet {
-    min-height: calc(100% - calc(var(--navbar-container-height) + var(--spacing-small)));
+    min-block-size: calc(100% - calc(var(--navbar-container-height) + var(--spacing-small)));
   }
   justify-content: space-between;
 }
 
 .bodyContainer {
   flex: 1;
-  margin-block-start: var(--navbar-container-height);
+  margin-block-start: var(--navbar-height);
   padding-block-start: var(--spacing-small);
   padding-inline-start: var(--spacing-small);
   padding-inline-end: var(--spacing-small);
@@ -77,15 +77,15 @@
 
 .header {
   font-size: var(--font-size-large);
-  width: 100%;
+  inline-size: 100%;
   position: fixed;
-  height: var(--navbar-container-height);
+  block-size: var(--navbar-height);
   border-block-end: 1px var(--color-borders-hairline) solid;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   @include breakpoints.tablet {
-    width: constants.$side-menu-desktop-width;
+    inline-size: constants.$side-menu-desktop-width;
   }
   z-index: var(--z-index-header);
 }
@@ -94,7 +94,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: 100%;
+  inline-size: 100%;
   background-color: var(--color-background-elevated);
 }
 
@@ -117,5 +117,5 @@
 }
 
 .navbarInvisible {
-  transform: translate3d(0, 0 + var(--navbar-container-height), 0);
+  padding-block-start: var(--navbar-container-height);
 }

--- a/src/components/Navbar/Drawer/index.tsx
+++ b/src/components/Navbar/Drawer/index.tsx
@@ -19,7 +19,7 @@ import {
   setIsNavigationDrawerOpen,
   setIsSearchDrawerOpen,
   setIsSettingsDrawerOpen,
-  setIsVisible,
+  setLockVisibilityState,
 } from '@/redux/slices/navbar';
 import { logEvent } from '@/utils/eventLogger';
 
@@ -125,11 +125,16 @@ const Drawer: React.FC<Props> = ({
   );
 
   useEffect(() => {
-    // Keep nav bar visible when drawer is open
+    // Lock navbar visibility state when drawer is open to prevent scroll-based changes
+    // Unlock when drawer is closed to restore normal scroll behavior
     if (isOpen) {
-      dispatch(setIsVisible(true));
+      dispatch(setLockVisibilityState(true));
+    } else {
+      dispatch(setLockVisibilityState(false));
     }
+  }, [dispatch, isOpen]);
 
+  useEffect(() => {
     // Hide navbar after successful navigation
     const handleRouteChange = () => {
       if (isOpen && closeOnNavigation) {
@@ -143,7 +148,7 @@ const Drawer: React.FC<Props> = ({
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange);
     };
-  }, [closeDrawer, dispatch, router.events, isNavbarVisible, isOpen, closeOnNavigation]);
+  }, [closeDrawer, router.events, isOpen, closeOnNavigation]);
 
   useOutsideClickDetector(
     drawerRef,

--- a/src/components/QuranReader/ContextMenu/index.tsx
+++ b/src/components/QuranReader/ContextMenu/index.tsx
@@ -87,19 +87,21 @@ const ContextMenu: React.FC = (): JSX.Element | null => {
       <div className={styles.sectionsContainer}>
         {/* Chapter Navigation Section */}
         <div className={styles.section}>
-          <div className={styles.row}>
+          <div className={classNames(styles.row, { [styles.mobileNavRow]: showNavbar })}>
             <ChapterNavigation
               chapterName={chapterData.transliteratedName}
               isSidebarNavigationVisible={isSidebarNavigationVisible}
               onToggleSidebar={handleSidebarToggle}
               chapterNumber={getChapterNumberFromKey(verseKey)}
             />
+            {/* Settings button for mobile when navbar is visible */}
+            {showNavbar && <SettingsButton className={styles.mobileSettingsButton} />}
           </div>
         </div>
 
         {/* Page Information Section (default, not mobile scrolled view) */}
         {!isMobileScrolledView && (
-          <div className={classNames(styles.section)}>
+          <div className={classNames(styles.section, styles.pageInfoSectionDesktop)}>
             <div className={styles.row}>
               <p className={styles.alignCenter} />
               <PageInfo

--- a/src/components/QuranReader/ContextMenu/styles/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu/styles/ContextMenu.module.scss
@@ -84,6 +84,12 @@ $pixel: 1px;
   }
 }
 
+.pageInfoSectionDesktop {
+  @include breakpoints.smallerThanTablet {
+    display: none;
+  }
+}
+
 .pageInfoCustomContainerMobileScrolled {
   display: flex;
   align-items: center;
@@ -127,6 +133,21 @@ $pixel: 1px;
   justify-content: space-between;
   flex-direction: column;
   inline-size: 100%;
+}
+
+.mobileNavRow {
+  @include breakpoints.smallerThanTablet {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.mobileSettingsButton {
+  display: none;
+
+  @include breakpoints.smallerThanTablet {
+    display: inline-flex;
+  }
 }
 
 .pageInfoContainer {


### PR DESCRIPTION
## Summary

Closes: [QF-4114](https://quranfoundation.atlassian.net/browse/QF-4114)  and [QF-2755](https://quranfoundation.atlassian.net/browse/QF-2755)

- Fix settings button not showing on mobile when scrolling up (navbar visible)
- Add settings button to chapter navigation section that only appears on mobile when navbar is visible
- Include navbar visibility lock fix from commit a2b3c06 to prevent navbar expanding when settings drawer opens

## Changes
- **ContextMenu**: Add settings button in chapter navigation row for mobile view
- **ContextMenu.module.scss**: Add `.mobileNavRow`, `.mobileSettingsButton`, and `.pageInfoSectionDesktop` styles
- **Drawer**: Use `setLockVisibilityState` instead of `setIsVisible` to lock navbar state while drawer is open
- **Drawer.module.scss**: Update CSS variables and `.navbarInvisible` styling

## Test plan
- [x] On mobile, scroll down then scroll up - settings button should appear next to chapter name
- [x] On mobile, scroll down - settings button should appear next to reading preference switcher
- [x] On desktop, layout should remain unchanged
- [x] Open settings drawer - navbar should not expand/collapse unexpectedly
- [x] Close settings drawer - normal scroll behavior should resume

[QF-4114]: https://quranfoundation.atlassian.net/browse/QF-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QF-2755]: https://quranfoundation.atlassian.net/browse/QF-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ