### PR TITLE
QF-4443 - Fix wbw Translation LTR/RTL in inline and tooltip

### DIFF
--- a/src/components/dls/InlineWordByWord/index.tsx
+++ b/src/components/dls/InlineWordByWord/index.tsx
@@ -23,8 +23,12 @@ type Props = {
 
 const InlineWordByWord: React.FC<Props> = ({ text, className }) => {
   const wordByWordFontScale = useSelector(selectWordByWordFontScale, shallowEqual);
+
   return (
-    <p className={classNames(styles.word, className, FONT_SIZE_CLASS_MAP[wordByWordFontScale])}>
+    <p
+      className={classNames(styles.word, className, FONT_SIZE_CLASS_MAP[wordByWordFontScale])}
+      dir="auto"
+    >
       {text}
     </p>
   );

--- a/src/components/dls/QuranWord/getToolTipText.tsx
+++ b/src/components/dls/QuranWord/getToolTipText.tsx
@@ -15,7 +15,7 @@ import Word from 'types/Word';
 const getTooltipText = (showTooltipFor: WordByWordType[], word: Word): ReactNode => (
   <>
     {showTooltipFor.map((tooltipTextType) => (
-      <p key={tooltipTextType} className={styles.tooltipText}>
+      <p key={tooltipTextType} className={styles.tooltipText} dir="auto">
         {word[tooltipTextType].text}
       </p>
     ))}


### PR DESCRIPTION
## Summary

Added `dir="auto"` to **WBW inline** and **tooltip translations** to fix punctuation issues in translated words.

Closes: [QF-4443](https://quranfoundation.atlassian.net/browse/QF-4443)

## Type of Change

- [X] 🐛 Bug fix (non-breaking change)

## Scope Confirmation

- [X] This PR addresses **one** fix only  
- [X] Any additional changes would be split into separate PRs

## Rollback Safety

- [X] Can be safely reverted without data issues or migrations

## Test Plan

- [ ] Unit tests added/updated  
- [ ] Integration tests added/updated  
- [X] Manual testing performed  

### Testing steps

1. Selected **French** WBW translation  
2. Verified punctuation and layout display correctly  

3. Selected **Urdu** WBW translation  
4. Verified punctuation and layout display correctly  

This was repeated for **all available languages**.

## Testing & Validation

- [X] All tests pass locally (`yarn test`)  
- [X] Linting passes (`yarn lint`)  
- [X] Build succeeds (`yarn build`)  
- [X] Edge cases and error scenarios handled  

## Localization (UI changes)

- [X] RTL layout verified  

## Screenshots / Videos

| Before | After |
| ------ | ----- |
| <img width="654" height="300" src="https://github.com/user-attachments/assets/c58aa35c-790c-4a9c-86a3-6dff41693064" /> | <img width="603" height="276" src="https://github.com/user-attachments/assets/e3e7745e-39e7-40e6-b4df-bb760e14f467" /> |
| <img width="531" height="281" src="https://github.com/user-attachments/assets/108a977d-6c30-4994-bd33-c671a5ccd0e5" /> | <img width="492" height="247" src="https://github.com/user-attachments/assets/c37784bb-e4e4-4261-a0b4-e0f1c0b1832d" /> |
| <img width="539" height="243" src="https://github.com/user-attachments/assets/ef8f9ea8-9a84-41b5-8c38-fb06b763204b" /> | <img width="509" height="234" src="https://github.com/user-attachments/assets/3c340f62-f659-4349-9e02-313e468e761a" /> |
| <img width="1089" height="177" src="https://github.com/user-attachments/assets/9868eb57-a2fa-4b62-bc26-dc187c79b32a" /> | <img width="1019" height="181" src="https://github.com/user-attachments/assets/2524a4f2-a7bc-415e-bc5a-df9fd4435574" /> |

## Reviewer Notes

I’m not entirely sure if using `dir="auto"` is the best long-term approach, but the alternative would require passing language metadata into the component and manually handling RTL/LTR logic.

After reviewing how `dir="auto"` works, it should behave correctly for this use case:  
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/dir

## AI Assistance Disclosure

- [X] AI tools were NOT used for this PR  
- [ ] AI tools were used, and I have **thoroughly reviewed and validated** all generated code  


[QF-4443]: https://quranfoundation.atlassian.net/browse/QF-4443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ