### PR TITLE
fix sidebar height

### DIFF
--- a/src/components/Navbar/NavbarBody/NavbarBody.module.scss
+++ b/src/components/Navbar/NavbarBody/NavbarBody.module.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  block-size: 100%;
+  block-size: var(--navbar-height);
   background-color: var(--color-background-elevated);
 
   svg,

--- a/src/components/QuranReader/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu.module.scss
@@ -1,7 +1,6 @@
 @use 'src/styles/constants';
 @use 'src/styles/breakpoints';
 
-$sections-container-height: 2.25rem;
 $pixel: 1px;
 
 .container {
@@ -69,7 +68,7 @@ $pixel: 1px;
 }
 
 .sectionsContainer {
-  block-size: $sections-container-height;
+  block-size: var(--sections-container-height);
   inline-size: 100%;
   padding-block-start: var(--spacing-micro);
   padding-block-end: var(--spacing-micro);

--- a/src/components/QuranReader/ContextMenu/styles/ContextMenu.module.scss
+++ b/src/components/QuranReader/ContextMenu/styles/ContextMenu.module.scss
@@ -1,7 +1,6 @@
 @use 'src/styles/constants';
 @use 'src/styles/breakpoints';
 
-$sections-container-height: 2rem;
 $pixel: 1px;
 
 .container {
@@ -58,7 +57,7 @@ $pixel: 1px;
 }
 
 .sectionsContainer {
-  block-size: $sections-container-height;
+  block-size: var(--sections-container-height);
   padding-block: calc(var(--spacing-medium) / 2);
   display: flex;
   align-items: center;

--- a/src/components/QuranReader/ContextMenu/styles/ProgressBar.module.scss
+++ b/src/components/QuranReader/ContextMenu/styles/ProgressBar.module.scss
@@ -1,30 +1,29 @@
-@use "src/styles/breakpoints";
+@use 'src/styles/breakpoints';
 
 .container {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
+  inset-block-end: 0;
+  inset-inline: 0;
+  inline-size: 100%;
   z-index: var(--z-index-sticky);
 }
 
 .track {
-  width: 100%;
-  height: 3px;
+  inline-size: 100%;
+  block-size: var(--progress-bar-height);
   background-color: var(--color-separators-new);
   position: relative;
 }
 
 .indicator {
   position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  block-size: 100%;
   background-color: var(--color-success-deep);
   transition: width var(--transition-fast);
   transition-timing-function: linear;
-  min-width: 0;
+  min-inline-size: 0;
 }
 
 .hide {
@@ -35,7 +34,7 @@
 // Ensure it works properly on mobile
 @include breakpoints.smallerThanTablet {
   .container {
-    bottom: 0;
+    inset-block-end: 0;
     transform: none;
   }
 }

--- a/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss
+++ b/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss
@@ -30,10 +30,12 @@ $isNavbarVisible: var(--isNavbarVisible);
     @include breakpoints.smallerThanTablet {
       // TODO: we should add the banner height here if it's shown
       // transform: translateX(-100%) translateY(calc($top-menu-height-home + var(--banner-height)));
-      transform: translateX(-100%) translateY(calc($top-menu-height-home));
+      transform: translateX(-100%)
+        translateY(calc($top-menu-height-home + var(--mobile-reading-mode-tabs-height)));
       [dir='rtl'] & {
         // transform: translateX(100%) translateY(calc($top-menu-height-home + var(--banner-height)));
-        transform: translateX(100%) translateY(calc($top-menu-height-home));
+        transform: translateX(100%)
+          translateY(calc($top-menu-height-home + var(--mobile-reading-mode-tabs-height)));
       }
     }
   }
@@ -47,10 +49,12 @@ $isNavbarVisible: var(--isNavbarVisible);
     @include breakpoints.smallerThanTablet {
       // TODO: we should add the banner height here if it's shown
       // transform: translateX(-100%) translateY(calc($top-menu-height + var(--banner-height)));
-      transform: translateX(-100%) translateY($top-menu-height);
+      transform: translateX(-100%)
+        translateY(calc($top-menu-height + var(--mobile-reading-mode-tabs-height)));
       [dir='rtl'] & {
         // transform: translateX(100%) translateY(calc($top-menu-height + var(--banner-height)));
-        transform: translateX(100%) translateY($top-menu-height);
+        transform: translateX(100%)
+          translateY(calc($top-menu-height + var(--mobile-reading-mode-tabs-height)));
       }
     }
   }
@@ -66,10 +70,12 @@ $isNavbarVisible: var(--isNavbarVisible);
     @include breakpoints.smallerThanTablet {
       // TODO: we should add the banner height here if it's shown
       // transform: translateX(-100%) translateY(calc($top-menu-height-home + var(--banner-height)));
-      transform: translateX(-100%) translateY($top-menu-height-home);
+      transform: translateX(-100%)
+        translateY(calc($top-menu-height-home + var(--mobile-reading-mode-tabs-height)));
       [dir='rtl'] & {
         // transform: translateX(100%) translateY(calc($top-menu-height-home + var(--banner-height)));
-        transform: translateX(100%) translateY($top-menu-height-home);
+        transform: translateX(100%)
+          translateY(calc($top-menu-height-home + var(--mobile-reading-mode-tabs-height)));
       }
     }
   }
@@ -78,6 +84,25 @@ $isNavbarVisible: var(--isNavbarVisible);
     transform: translateX(-100%) translateY($top-menu-height);
     [dir='rtl'] & {
       transform: translateX(100%) translateY($top-menu-height);
+    }
+
+    @include breakpoints.smallerThanTablet {
+      transform: translateX(-100%)
+        translateY(
+          calc(
+            $top-menu-height + var(--sections-container-height) + var(--progress-bar-height) +
+              0.6rem
+          )
+        );
+      [dir='rtl'] & {
+        transform: translateX(100%)
+          translateY(
+            calc(
+              $top-menu-height + var(--sections-container-height) + var(--progress-bar-height) +
+                0.6rem
+            )
+          );
+      }
     }
   }
 }
@@ -133,10 +158,10 @@ $isNavbarVisible: var(--isNavbarVisible);
     @include breakpoints.smallerThanTablet {
       // TODO: we should add the banner height here if it's shown
       // transform: translateY(calc($top-menu-height + var(--banner-height)));
-      transform: translateY($top-menu-height);
+      transform: translateY(calc($top-menu-height + var(--mobile-reading-mode-tabs-height)));
       [dir='rtl'] & {
         // transform: translateY(calc($top-menu-height + var(--banner-height)));
-        transform: translateY($top-menu-height);
+        transform: translateY(calc($top-menu-height + var(--mobile-reading-mode-tabs-height)));
       }
     }
   }
@@ -156,6 +181,23 @@ $isNavbarVisible: var(--isNavbarVisible);
     transform: translateY($context-menu-height);
     [dir='rtl'] & {
       transform: translateY($context-menu-height);
+    }
+
+    @include breakpoints.smallerThanTablet {
+      transform: translateY(
+        calc(
+          $context-menu-height + var(--sections-container-height) + var(--progress-bar-height) +
+            0.6rem
+        )
+      );
+      [dir='rtl'] & {
+        transform: translateY(
+          calc(
+            $context-menu-height + var(--sections-container-height) + var(--progress-bar-height) +
+              0.6rem
+          )
+        );
+      }
     }
   }
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -7,6 +7,8 @@
   // TODO: migrate constants.scss to use css variables
   --navbar-height: 3.6rem;
   --context-menu-container-height: 3rem;
+  --sections-container-height: 2rem;
+  --progress-bar-height: 3px;
   --mobile-reading-mode-tabs-height: 3.25rem;
   --navbar-container-height: var(--navbar-height);
   --banner-height: 3rem;


### PR DESCRIPTION
## Fix SidebarNavigation translateY alignment with MobileReadingTabs on mobile

### Note
this problem also occurs when we disabled/not show the banner

### Problem

On mobile view, the `SidebarNavigation` component's `translateY` positioning was not properly aligned with the UI elements above it. There were two main issues:

1. **When navbar is expanded (scroll down)**: The sidebar `translateY` didn't account for the [MobileReadingTabs](cci:1://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/components/QuranReader/ContextMenu/components/MobileReadingTabs.tsx:19:0-81:2) component height, causing the sidebar to overlap with it.

2. **When navbar is collapsed (scroll up)**: The sidebar `translateY` only used the context menu height and didn't include the `sectionsContainer` and `progressBar` heights that are still visible on mobile, resulting in misalignment.

### Solution

1. **Centralized CSS variables**: Added new CSS variables in [variables.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/styles/variables.scss:0:0-0:0) for consistent height values:
   - `--sections-container-height: 2rem`
   - `--progress-bar-height: 3px`

2. **Updated SidebarNavigation mobile breakpoints**:
   - **Expanded state**: Added `var(--mobile-reading-mode-tabs-height)` to translateY calculations
   - **Collapsed state**: Added `var(--sections-container-height) + var(--progress-bar-height) + 0.6rem` to translateY calculations

3. **Refactored ContextMenu and ProgressBar styles**: Replaced hardcoded SCSS variables with centralized CSS variables for better maintainability

4. **Fixed NavbarBody height**: Changed from `100%` to `var(--navbar-height)` for consistent sizing

### Files Changed
- [src/styles/variables.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/styles/variables.scss:0:0-0:0)
- [src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/components/QuranReader/SidebarNavigation/SidebarNavigation.module.scss:0:0-0:0)
- [src/components/QuranReader/ContextMenu.module.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/components/QuranReader/ContextMenu.module.scss:0:0-0:0)
- [src/components/QuranReader/ContextMenu/styles/ContextMenu.module.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/components/QuranReader/ContextMenu/styles/ContextMenu.module.scss:0:0-0:0)
- [src/components/QuranReader/ContextMenu/styles/ProgressBar.module.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/components/QuranReader/ContextMenu/styles/ProgressBar.module.scss:0:0-0:0)
- [src/components/Navbar/NavbarBody/NavbarBody.module.scss](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/components/Navbar/NavbarBody/NavbarBody.module.scss:0:0-0:0)

|||
|---|---|
| same problem with banner off | <img width="637" height="1380" alt="image" src="https://github.com/user-attachments/assets/ea610b11-fa8d-40e4-99f7-24ba5246205f" /> |
| scroll down | <img width="637" height="1380" alt="image" src="https://github.com/user-attachments/assets/622b4d06-22c7-45a9-9a67-716d39a30d85" /> |
| scroll up | <img width="637" height="1380" alt="image" src="https://github.com/user-attachments/assets/9a06a101-d06f-4221-8fa5-e5bd65fb4e4a" /> |