### PR TITLE
QF-4498 - Fix second-scroll issue when startingVerse is set

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.tsx
@@ -3,7 +3,6 @@ import React, { memo, useContext } from 'react';
 
 import { useSelector as useSelectorXstate } from '@xstate/react';
 import classNames from 'classnames';
-import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 
 import getTranslationsLabelString from '../ReadingView/utils/translation';
@@ -46,9 +45,6 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
   bookmarksRangeUrl,
   hasNotes,
 }) => {
-  const router = useRouter();
-  const { startingVerse } = router.query;
-
   const audioService = useContext(AudioPlayerMachineContext);
   const isHighlighted = useSelectorXstate(audioService, (state) => {
     const { ayahNumber, surah } = state.context;
@@ -62,14 +58,11 @@ const TranslationViewCell: React.FC<TranslationViewCellProps> = ({
   // Use our custom hook that handles scrolling with context menu offset
   const [scrollToSelectedItem, selectedItemRef] = useScrollWithContextMenuOffset<HTMLDivElement>();
 
-  const shouldTrigger =
-    (isHighlighted && enableAutoScrolling) || Number(startingVerse) === verseIndex + 1;
+  const shouldTrigger = isHighlighted && enableAutoScrolling;
   useNavbarAutoHide(shouldTrigger, scrollToSelectedItem, [
     enableAutoScrolling,
     isHighlighted,
     scrollToSelectedItem,
-    startingVerse,
-    verseIndex,
   ]);
   const translationsLabel = getTranslationsLabelString(verse.translations);
   const translationsCount = verse.translations?.length || 0;


### PR DESCRIPTION
## Summary

Fixed a re-scroll bug in Translation View where scrolling back to the `startingVerse` would snap the page back to that verse.

The problem was in `TranslationViewCell.tsx`. Each verse cell was checking if it matched `startingVerse` and triggering a scroll when rendered. Since `startingVerse` stays in the URL, this created a scroll trap whenever the verse came back into view.

Removed this check since `useScrollToVirtualizedVerse` already handles the initial scroll. Now the user can scroll freely after the page loads.

Closes: [QF-4498](https://quranfoundation.atlassian.net/browse/QF-4498)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

I have asked Claude to generate me a list of manual testing I can do to ensure there's no regression and that everything works :

| Test # | Test Name | Result | Notes |
|--------|-----------|-------------------|-------|
| 1 | Basic Re-scroll Bug Fix | ✅ Pass | Verified on Surah 1:7 |
| 2 | Re-scroll Bug Fix (Long) | ✅ Pass | Verified on Surah 67:20 |
| 3 | Re-scroll Bug Fix (Middle) | ✅ Pass | Verified on Surah 2:100 |
| 4 | Initial Scroll Works | ✅ Pass | |
| 5 | Initial Scroll First Verse | ✅ Pass | |
| 6 | Initial Scroll Last Verse | ✅ Pass | |
| 7 | Navigation Between Verses | ✅ Pass | |
| 8 | Audio Player Scroll | ✅ Pass | Auto-scroll on play still works |
| 9 | Audio + Manual Scroll | ✅ Pass | |
| 10 | Invalid startingVerse | ✅ Pass | |
| 11 | No startingVerse | ✅ Pass | |
| 12 | Rapid Navigation | ✅ Pass | |
| 13 | Scroll Performance | ✅ Pass | |
| 14 | Translation Change | ✅ Pass | |

### Edge Cases Verified

- [x] ⏳ Loading state handled
- [x] ❌ Error state handled
- [x] 📭 Empty state handled
- [x] 👤 Logged-in vs guest behavior (if applicable)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [ ] README updated (if adding features or setup changes)
- [ ] Inline comments added for complex logic

## Screenshots/Videos


https://github.com/user-attachments/assets/4fec29e1-2c05-49b7-a805-c79520ff6637



## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4498]: https://quranfoundation.atlassian.net/browse/QF-4498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ