### PR TITLE
fix: responsive banner text

### DIFF
--- a/src/components/Banner/Banner.module.scss
+++ b/src/components/Banner/Banner.module.scss
@@ -13,17 +13,19 @@
 }
 
 .text {
+  text-align: center;
   color: var(--color-text-default-new);
   font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-small-px);
+  font-size: clamp(var(--font-size-xsmall-px), 2.5vw, var(--font-size-small-px));
 }
 
 .cta {
+  text-align: center;
   padding-inline: var(--spacing-xsmall-px);
   padding-block: var(--spacing-micro2-px);
   background-color: var(--color-success-faded);
   color: var(--color-text-link-new);
-  font-size: var(--font-size-small-px);
+  font-size: clamp(var(--font-size-xsmall-px), 2.5vw, var(--font-size-small-px));
   font-weight: var(--font-weight-medium);
   display: flex;
   justify-content: center;


### PR DESCRIPTION
# Summary

This PR updates the Banner component styles to improve responsiveness. Specifically, it implements fluid typography using `clamp()` for the banner text and CTA button to ensure they scale appropriately on different screen sizes. It also centers the text and CTA content.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test plan

- **Visual Verification**: Resized the browser window to verify that the banner text and CTA font sizes scale smoothly between `xsmall` and `small` variables.
- **Alignment**: Confirmed that the banner text and CTA are centered.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots or videos

| Before | After |
| ------ | ------ |
|<img width="660" height="455" alt="image" src="https://github.com/user-attachments/assets/40dadca5-6e86-400f-a735-bf2aee1a03e2" />|<img width="660" height="455" alt="image" src="https://github.com/user-attachments/assets/599558b0-aec5-4d30-8d48-5dedc6823372" />|