### PR TITLE
 Fix reset settings failing due to missing selectedReadingTranslation

### DIFF
--- a/src/redux/defaultSettings/defaultSettings.ts
+++ b/src/redux/defaultSettings/defaultSettings.ts
@@ -73,7 +73,7 @@ const READING_PREFERENCES_INITIAL_STATE: ReadingPreferences = {
   wordByWordInlineContentType: [],
   wordByWordDisplay: [WordByWordDisplay.TOOLTIP],
   wordClickFunctionality: WordClickFunctionality.PlayAudio,
-  selectedReadingTranslation: null,
+  selectedReadingTranslation: String(DEFAULT_TRANSLATIONS[0]),
   lastUsedReadingMode: ReadingPreference.Reading,
 };
 

--- a/src/utils/auth/preferencesMapper.ts
+++ b/src/utils/auth/preferencesMapper.ts
@@ -59,6 +59,7 @@ const getPreferenceGroupValue = (
       // Deprecated - keep for backward compatibility during transition
       wordByWordContentType: prefs.wordByWordTooltipContentType,
       // wordByWordDisplay is now auto-computed, don't send
+      selectedReadingTranslation: prefs.selectedReadingTranslation,
     };
   }
 


### PR DESCRIPTION
## Summary

  When a logged-in user attempts to reset their settings, the API call to `/preferences/bulk` fails with a validation error: `"reading.selectedReadingTranslation" is required`.

  **Root Cause:**
  1. The `selectedReadingTranslation` field was not being included in the reading preferences sent to the backend (`preferencesMapper.ts`)
  2. The default value was `null`, which the backend validation rejects

  **Fix:**
  1. Added `selectedReadingTranslation` to the preferences mapper so it's included in API requests
  2. Changed the default value from `null` to `"131"` (Dr. Mustafa Khattab, the Clear Quran) - the same as the first default translation, maintaining consistent behavior

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Sign in to your account
  2. Go to Settings
  3. Click "Reset Settings"
  4. Verify no error toast appears and settings reset successfully
  5. Verify the Reading Translation mode still works correctly with the default translation

  ### Edge Cases Verified

  - [ ] ⏳ Loading state handled
  - [x] ❌ Error state handled
  - [ ] 📭 Empty state handled
  - [x] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [ ] Inline comments added for complex logic

  ### Localization (if UI changes)

  - N/A (no UI changes)

  ### Accessibility (if UI changes)

  - N/A (no UI changes)

  ## Reviewer Notes

  The fix uses `String(DEFAULT_TRANSLATIONS[0])` instead of hardcoding `"131"` to ensure the value stays in sync if the default translation ever changes.

  The dropdown already had fallback logic to use `selectedTranslations[0]` when `selectedReadingTranslation` was `null`, so this change maintains the same user-facing behavior while satisfying the backend validation.

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

  ---
  Summary of Changes
  File: src/redux/defaultSettings/defaultSettings.ts:76
  Change: Changed selectedReadingTranslation from null to String(DEFAULT_TRANSLATIONS[0]) (= "131")
  ────────────────────────────────────────
  File: src/utils/auth/preferencesMapper.ts:62
  Change: Added selectedReadingTranslation to the reading preferences sent to the backend
