### PR TITLE
[QF-4569] Show Arabic name on Urdu and Arabic

### DIFF
--- a/src/utils/verseKeys.ts
+++ b/src/utils/verseKeys.ts
@@ -3,7 +3,7 @@ import range from 'lodash/range';
 import { getChapterData } from './chapter';
 
 import ChaptersData from '@/types/ChaptersData';
-import { shouldUseMinimalLayout, toLocalizedVerseKey } from '@/utils/locale';
+import { toLocalizedVerseKey } from '@/utils/locale';
 
 /**
  * Generate the verse keys between two verse keys.
@@ -147,15 +147,10 @@ export const readableVerseRangeKeys = (
       const from = parsedRange[0];
       const to = parsedRange[1];
 
-      const showMinimalUi = shouldUseMinimalLayout(lang);
-
       const chapterData = getChapterData(chaptersData, from.chapter.toString());
       if (!chapterData) return null;
 
-      const chapterName = showMinimalUi
-        ? chapterData.translatedName
-        : chapterData.transliteratedName;
-
+      const chapterName = chapterData.transliteratedName;
       const titleForm = `${chapterName} ${toLocalizedVerseKey(from.verseKey, lang)}`;
 
       if (from.chapter === to.chapter && from.verse === to.verse) {


### PR DESCRIPTION
## Summary

Fix surah name display in Urdu and Arabic locale to always show Arabic transliterated name instead of translated name in MyNotes.

Closes: [QF-4569](https://quranfoundation.atlassian.net/browse/QF-4569)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**
1. Change locale to Urdu or Arabic
2. Open My Notes
3. Check the surah name in note cards - should be in Arabic


## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Delete section if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1167" height="607" alt="image" src="https://github.com/user-attachments/assets/0cdcd245-a60e-48cc-b6da-24ef0ca97e6b" /> | <img width="1116" height="754" alt="image" src="https://github.com/user-attachments/assets/7cbbf7ce-fa0d-4d4c-a141-9dc1d5be326c" /> |



[QF-4569]: https://quranfoundation.atlassian.net/browse/QF-4569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ