### PR TITLE
fix(QF-4006): add 20px spacing for subsequent surah headers on multi-surah pages

### DIFF
--- a/src/components/QuranReader/ReadingView/TranslationPage.tsx
+++ b/src/components/QuranReader/ReadingView/TranslationPage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-import pageStyles from './Page.module.scss';
 import TranslatedAyah from './TranslatedAyah';
 import styles from './TranslationPage.module.scss';
 import getTranslationNameString from './utils/translation';
@@ -64,7 +63,6 @@ const TranslationPage: React.FC<TranslationPageProps> = ({
               translationsCount={translationsCount}
               chapterId={chapterId}
               isTranslationView={false}
-              className={pageStyles.chapterHeaderNoTopMargin}
             />
           )}
           <TranslatedAyah


### PR DESCRIPTION
## Summary
- Remove `chapterHeaderNoTopMargin` class from inline ChapterHeader components in TranslationPage
- This allows the default 20px margin for subsequent surahs on multi-surah pages (e.g., Al-Falaq and An-Nas on page 604)

## Test plan
- [ ] Navigate to page 604 in Reading-Translation mode
- [ ] Verify Al-Ikhlas header has 20px from navbar (page padding)
- [ ] Verify Al-Falaq and An-Nas headers have 20px spacing above them