### PR TITLE
[QF-4600] Fix Breakpoint Issue

### DIFF
--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -5,6 +5,8 @@ $breakpoints-mobileL: 425px;
 $breakpoints-tablet: 768px;
 $breakpoints-desktop: 1024px;
 
+$breakpoint-buffer-max-width: 1px;
+
 @mixin mobileS {
   @media only screen and (min-width: $breakpoints-mobileS) {
     @content;
@@ -12,7 +14,7 @@ $breakpoints-desktop: 1024px;
 }
 
 @mixin smallerThanMobileS {
-  @media only screen and (max-width: $breakpoints-mobileS) {
+  @media only screen and (max-width: ($breakpoints-mobileS - $breakpoint-buffer-max-width)) {
     @content;
   }
 }
@@ -24,7 +26,7 @@ $breakpoints-desktop: 1024px;
 }
 
 @mixin smallerThanMobileM {
-  @media only screen and (max-width: $breakpoints-mobileM) {
+  @media only screen and (max-width: ($breakpoints-mobileM - $breakpoint-buffer-max-width)) {
     @content;
   }
 }
@@ -36,7 +38,7 @@ $breakpoints-desktop: 1024px;
 }
 
 @mixin smallerThanMobileL {
-  @media only screen and (max-width: $breakpoints-mobileL) {
+  @media only screen and (max-width: ($breakpoints-mobileL - $breakpoint-buffer-max-width)) {
     @content;
   }
 }
@@ -48,7 +50,7 @@ $breakpoints-desktop: 1024px;
 }
 
 @mixin smallerThanTablet {
-  @media only screen and (max-width: $breakpoints-tablet) {
+  @media only screen and (max-width: ($breakpoints-tablet - $breakpoint-buffer-max-width)) {
     @content;
   }
 }
@@ -60,7 +62,7 @@ $breakpoints-desktop: 1024px;
 }
 
 @mixin smallerThanDesktop {
-  @media only screen and (max-width: $breakpoints-desktop) {
+  @media only screen and (max-width: ($breakpoints-desktop - $breakpoint-buffer-max-width)) {
     @content;
   }
 }


### PR DESCRIPTION
## Summary

***Problem***: 
Breakpoint overlap causing UI conflicts at exact breakpoint values

The current breakpoint mixins had an overlap issue where at exact breakpoint values (like `768px` for `tablet`), both `min-width` and `max-width` media queries would be true simultaneously. This caused CSS conflicts and broken UI.

***Root Cause***: 
When mixing `min-width` and `max-width` media queries without gaps, both conditions can be true at the exact breakpoint value, leading to conflicting styles.

***Solution***: 
Added a `$breakpoint-buffer-max-width: 1px` variable and subtracted `1px` from all max-width breakpoints to create a `1px` gap, eliminating the overlap while maintaining responsive behavior.

Now `smallerThanTablet` mean `smaller than tablet` not `smaller than or equal to tablet`, (same for all other break point)

***Changes Made***:
Added `$breakpoint-buffer-max-width: 1px` variable
Updated all `smallerThan`* mixins (smallerThanMobileS, smallerThanMobileM, smallerThanMobileL, smallerThanTablet, smallerThanDesktop) to use (`$breakpoint - $breakpoint-buffer-max-width`)

***Side Effects***:
- ***Minimal impact*** - Only affects `1px` at each breakpoint boundary (767px, 424px, etc.)
- ***Fixes existing issues*** - Any UI that was breaking at exact breakpoint values will now work correctly
- ***Rare edge cases*** - Only affects developers who were explicitly depending on both mobile and tablet styles applying simultaneously at the exact breakpoint (which was already problematic behavior)

No breaking changes - All existing functionality remains intact

---

Closes: [QF-4600](https://quranfoundation.atlassian.net/browse/QF-4600)
Part of: [QF-4570](https://quranfoundation.atlassian.net/browse/QF-4570)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

### If Breaking Change

<!-- What breaks? What coordination is needed with backend/infra? Delete section if not applicable -->

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs


## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):


## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

```scss
$breakpoints-mobileS: 320px;
$breakpoints-mobileM: 375px;
$breakpoints-mobileL: 425px;
$breakpoints-tablet: 768px;
$breakpoints-desktop: 1024px;
```

1. Test UI on exact breakpoint values (768px, 425px, etc.) especially on tablets
2. Check that no unintended style changes occurred at breakpoint boundaries

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [x] README updated (if adding features or setup changes)
- [x] Inline comments added for complex logic

## Screenshots/Videos
There are hundreds of thousands of issues, just providing two samples.

| Before | After |
| ------ | ----- |
| <img width="876" height="646" alt="image" src="https://github.com/user-attachments/assets/bf3889d5-97ff-4f62-a82b-c5d989fdffab" /> | <img width="994" height="582" alt="image" src="https://github.com/user-attachments/assets/5996d437-243b-43f3-a862-834faf826114" /> |
| <img width="940" height="769" alt="image" src="https://github.com/user-attachments/assets/a1fbac83-1fdc-421b-bcb3-d352747daada" /> | <img width="893" height="834" alt="image" src="https://github.com/user-attachments/assets/a12795a7-152d-475f-b7f1-e082de7102cd" /> |


[QF-4600]: https://quranfoundation.atlassian.net/browse/QF-4600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ