### PR TITLE
[QF-4570] Improve Readability of Mixed RTL and LTR text

### DIFF
--- a/src/components/Notes/modal/MyNotes/MyNotes.module.scss
+++ b/src/components/Notes/modal/MyNotes/MyNotes.module.scss
@@ -138,3 +138,7 @@ div.container {
     outline-offset: var(--spacing-micro-px);
   }
 }
+
+.bidiText {
+  unicode-bidi: plaintext;
+}

--- a/src/components/Notes/modal/MyNotes/QrButton.tsx
+++ b/src/components/Notes/modal/MyNotes/QrButton.tsx
@@ -30,7 +30,7 @@ const QRButton: React.FC<QRButtonProps> = ({ note, postUrl, onPostToQrClick }) =
       shape={ButtonShape.Square}
       isNewTab
       href={postUrl}
-      tooltip={t('view-on-qr')}
+      tooltip={<span className={styles.bidiText}>{t('view-on-qr')}</span>}
       ariaLabel={t('view-on-qr')}
       onClick={() => logButtonClick('my_notes_view_on_qr')}
       data-testid="qr-view-button"

--- a/src/components/Notes/modal/NoteFormModal.module.scss
+++ b/src/components/Notes/modal/NoteFormModal.module.scss
@@ -128,6 +128,12 @@ div.textArea {
 
 .button {
   border-radius: var(--border-radius-medium-px);
+
+  &,
+  span {
+    unicode-bidi: plaintext;
+  }
+
   span {
     white-space: break-spaces;
     line-height: 1;


### PR DESCRIPTION
## Summary

Improve readability of mixed RTL (right-to-left) and LTR (left-to-right) text in notes modal components by applying unicode-bidi: plaintext CSS property to ensure proper text direction handling.

Part of: [QF-4570](https://quranfoundation.atlassian.net/browse/QF-4570)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

### If Breaking Change

<!-- What breaks? What coordination is needed with backend/infra? Delete section if not applicable -->

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs


## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

<!-- If complex rollback needed, describe steps. Delete section if straightforward. -->

## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. Open the notes modal
2. Check button text in note form modal displays with proper direction
2. Go to my notes and verify tooltip text renders correctly

## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Delete section if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="630" height="305" alt="image" src="https://github.com/user-attachments/assets/1ecf15b4-9390-4b27-a553-609bd1fc3458" /> | <img width="579" height="258" alt="image" src="https://github.com/user-attachments/assets/bec62e7a-ebb1-4ae6-bafb-60e51a17dc65" /> |

[QF-4570]: https://quranfoundation.atlassian.net/browse/QF-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ