### PR TITLE
fix: add defensive checks for courses data in LearningPlansSection

### DIFF
--- a/src/components/HomePage/LearningPlansSection/index.tsx
+++ b/src/components/HomePage/LearningPlansSection/index.tsx
@@ -47,7 +47,11 @@ const LearningPlansSection = () => {
       fetcher={privateFetcher}
       queryKey={makeGetCoursesUrl({ myCourses: false, languages: [lang] })}
       render={(data: CoursesResponse) => {
-        const sortedCourses = [...data.data].sort(learningPlansSorter);
+        const courses = data?.data;
+        if (!courses || !Array.isArray(courses) || courses.length === 0) {
+          return null;
+        }
+        const sortedCourses = [...courses].sort(learningPlansSorter);
         const firstNonEnrolledIndex = sortedCourses.findIndex(
           (course) => typeof course.isCompleted === 'undefined',
         );


### PR DESCRIPTION
## Summary

Adds defensive null checks for the courses data in `LearningPlansSection` to prevent potential runtime errors when the API returns unexpected data.

---

## Problems & Root Causes

### 1. Potential Runtime Error on Invalid Data

**Problem:** If the API returned `null`, `undefined`, or a non-array value for `data.data`, the component would crash when attempting to spread and sort the courses.

**Root Cause:** The code assumed `data.data` would always be a valid array without validation. Network issues, API changes, or edge cases could result in unexpected data shapes.

---

## Solution Approach

### 1. Defensive Data Validation

Added checks before processing the courses data:
- Validates `data?.data` exists
- Confirms it's an array using `Array.isArray()`
- Checks that the array has items

If any check fails, the component returns `null` early, preventing the crash.

```typescript
const courses = data?.data;
if (!courses || !Array.isArray(courses) || courses.length === 0) {
  return null;
}
const sortedCourses = [...courses].sort(learningPlansSorter);
```

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. Navigate to the homepage
2. Verify the Learning Plans section renders correctly when courses are available
3. Verify no errors occur if the courses API returns empty data

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code
- [x] My code follows the project style guidelines
- [x] No `any` types used
- [x] No unused code or imports

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code