### PR TITLE
fix(QF-4598): standardize ChapterHeader button heights and styling

### DIFF
--- a/src/components/QuranReader/PlayButton.module.scss
+++ b/src/components/QuranReader/PlayButton.module.scss
@@ -3,7 +3,7 @@
 $playChapterAudioButtonMinInlineSize: 95px;
 
 @mixin customButton {
-  border: none;
+  border: 1px solid transparent;
   background-color: var(--color-background-elevated-new);
   box-shadow: var(--shadow-small-new);
 
@@ -31,11 +31,9 @@ $playChapterAudioButtonMinInlineSize: 95px;
   button {
     @include customButton;
     min-inline-size: $playChapterAudioButtonMinInlineSize;
-    // Match ReadingModeActions button styling
-    block-size: auto;
     font-size: var(--font-size-small);
     font-weight: var(--font-weight-medium);
-    padding: var(--spacing-xxsmall-px) var(--spacing-small2-px);
+    padding-inline: var(--spacing-small2-px);
     white-space: nowrap;
   }
 }

--- a/src/components/QuranReader/PlayChapterAudioButton.tsx
+++ b/src/components/QuranReader/PlayChapterAudioButton.tsx
@@ -8,7 +8,7 @@ import Spinner from '../dls/Spinner/Spinner';
 
 import styles from './PlayButton.module.scss';
 
-import Button, { ButtonShape, ButtonSize, ButtonType } from '@/dls/Button/Button';
+import Button, { ButtonShape, ButtonSize, ButtonVariant } from '@/dls/Button/Button';
 import useDirection from '@/hooks/useDirection';
 import useGetQueryParamOrXstateValue from '@/hooks/useGetQueryParamOrXstateValue';
 import PauseIcon from '@/icons/pause.svg';
@@ -68,9 +68,9 @@ const PlayChapterAudioButton: React.FC<Props> = ({ chapterId }) => {
     return (
       <div className={classNames(styles.container, styles.playChapterAudioButton)}>
         <Button
-          type={ButtonType.Secondary}
+          variant={ButtonVariant.ModeToggle}
           shape={ButtonShape.Pill}
-          size={ButtonSize.Small}
+          size={ButtonSize.XSmall}
           prefix={isRTL ? undefined : <Spinner />}
           suffix={isRTL ? <Spinner /> : undefined}
           hasSidePadding={false}
@@ -87,23 +87,24 @@ const PlayChapterAudioButton: React.FC<Props> = ({ chapterId }) => {
     <div className={classNames(styles.container, styles.playChapterAudioButton)}>
       {isPlayingCurrentChapter ? (
         <Button
-          type={ButtonType.Secondary}
+          variant={ButtonVariant.ModeToggle}
           shape={ButtonShape.Pill}
-          size={ButtonSize.Small}
+          size={ButtonSize.XSmall}
           prefix={isRTL ? undefined : <PauseIcon />}
           suffix={isRTL ? <PauseIcon /> : undefined}
           onClick={pause}
           hasSidePadding={false}
           shouldFlipOnRTL={false}
+          isSelected
           data-testid="pause-button"
         >
           {t('listen')}
         </Button>
       ) : (
         <Button
-          type={ButtonType.Secondary}
+          variant={ButtonVariant.ModeToggle}
           shape={ButtonShape.Pill}
-          size={ButtonSize.Small}
+          size={ButtonSize.XSmall}
           prefix={isRTL ? undefined : <PlayIcon />}
           suffix={isRTL ? <PlayIcon /> : undefined}
           onClick={play}

--- a/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
+++ b/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
@@ -71,7 +71,19 @@ $bismillahSvgInlineSizeMobile: 148px;
 }
 
 .translationsCount {
-  margin-inline-start: var(--spacing-micro2-px);
+  margin-inline-start: var(--spacing-micro-px);
+}
+
+.dropdownIcon {
+  inline-size: var(--spacing-medium-px);
+  block-size: var(--spacing-medium-px);
+  flex-shrink: 0;
+  margin-inline-start: var(--spacing-xxsmall-px);
+  align-self: center;
+
+  path {
+    fill: var(--color-text-default-new);
+  }
 }
 
 .titleContainer {

--- a/src/components/chapters/ChapterHeader/ReadingModeActions.module.scss
+++ b/src/components/chapters/ChapterHeader/ReadingModeActions.module.scss
@@ -10,51 +10,17 @@ $translation-button-max-width-mobile: 150px;
   margin-inline-start: var(--spacing-small-px);
 }
 
-.modeButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-xxsmall-px);
-  padding: var(--spacing-xxsmall-px) var(--spacing-small2-px);
-  border-radius: var(--border-radius-pill);
-  font-family: var(--font-family);
-  font-size: var(--font-size-small);
-  font-weight: var(--font-weight-medium);
-  cursor: pointer;
-  transition: background-color var(--transition-regular), color var(--transition-regular);
-  white-space: nowrap;
-  border: none;
-  box-shadow: var(--shadow-small-new);
-}
-
-.modeButtonSelected {
-  background-color: var(--color-text-default-new);
-  color: var(--color-background-elevated);
-
-  &:hover {
-    opacity: 0.9;
-  }
-}
-
-.modeButtonUnselected {
-  background-color: var(--color-background-elevated-new);
-  color: var(--color-text-faded-new);
-
-  &:hover {
-    color: var(--color-text-default-new);
-  }
-}
-
-.translationButtonWrapper {
-  position: relative;
-}
-
 .translationButton {
   max-inline-size: $translation-button-max-width-desktop;
 
   @include breakpoints.smallerThanTablet {
     max-inline-size: $translation-button-max-width-mobile;
   }
+}
+
+.translationButtonContent {
+  min-inline-size: 0;
+  overflow: hidden;
 }
 
 .translationText {

--- a/src/components/chapters/ChapterHeader/ReadingModeActions.tsx
+++ b/src/components/chapters/ChapterHeader/ReadingModeActions.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 
-import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 import { useSelector } from 'react-redux';
 
@@ -8,6 +7,7 @@ import styles from './ReadingModeActions.module.scss';
 import TranslationModeButton from './TranslationModeButton';
 
 import DataFetcher from '@/components/DataFetcher';
+import Button, { ButtonShape, ButtonSize, ButtonVariant } from '@/dls/Button/Button';
 import useReadingPreferenceSwitcher, {
   SwitcherContext,
 } from '@/hooks/useReadingPreferenceSwitcher';
@@ -56,31 +56,29 @@ const ReadingModeActions: React.FC = () => {
 
   const translationButtonLoading = useCallback(
     () => (
-      <button
-        type="button"
-        className={classNames(styles.modeButton, {
-          [styles.modeButtonSelected]: isTranslationSelected,
-          [styles.modeButtonUnselected]: !isTranslationSelected,
-        })}
+      <Button
+        size={ButtonSize.XSmall}
+        shape={ButtonShape.Pill}
+        variant={ButtonVariant.ModeToggle}
+        isSelected={isTranslationSelected}
       >
         {t('translation')}
-      </button>
+      </Button>
     ),
     [isTranslationSelected, t],
   );
 
   return (
     <div className={styles.container}>
-      <button
-        type="button"
-        className={classNames(styles.modeButton, {
-          [styles.modeButtonSelected]: isArabicSelected,
-          [styles.modeButtonUnselected]: !isArabicSelected,
-        })}
+      <Button
+        size={ButtonSize.XSmall}
+        shape={ButtonShape.Pill}
+        variant={ButtonVariant.ModeToggle}
+        isSelected={isArabicSelected}
         onClick={handleArabicClick}
       >
         {t('reading-preference.arabic')}
-      </button>
+      </Button>
 
       <DataFetcher
         queryKey={makeTranslationsUrl(lang)}

--- a/src/components/chapters/ChapterHeader/TranslationModeButton.tsx
+++ b/src/components/chapters/ChapterHeader/TranslationModeButton.tsx
@@ -8,6 +8,7 @@ import styles from './ReadingModeActions.module.scss';
 
 import PopoverMenu, { PopoverMenuAlign } from '@/components/dls/PopoverMenu/PopoverMenu';
 import TranslationDropdownContent from '@/components/QuranReader/ContextMenu/components/TranslationDropdownContent';
+import Button, { ButtonShape, ButtonSize, ButtonVariant } from '@/dls/Button/Button';
 import useCloseOnScroll from '@/hooks/useCloseOnScroll';
 import useIsMobile from '@/hooks/useIsMobile';
 import ChevronDownIcon from '@/public/icons/chevron-down.svg';
@@ -64,33 +65,32 @@ const TranslationModeButton: React.FC<TranslationModeButtonProps> = ({
   // No translations selected
   if (!hasTranslations) {
     return (
-      <button
-        type="button"
-        className={classNames(styles.modeButton, {
-          [styles.modeButtonSelected]: isTranslationSelected,
-          [styles.modeButtonUnselected]: !isTranslationSelected,
-        })}
+      <Button
+        size={ButtonSize.XSmall}
+        shape={ButtonShape.Pill}
+        variant={ButtonVariant.ModeToggle}
+        isSelected={isTranslationSelected}
         onClick={switchToTranslationMode}
       >
         {t('translation')}: {t('reading-preference.none-selected')}
-      </button>
+      </Button>
     );
   }
 
   // Arabic mode: plain button (no PopoverMenu)
   if (!isTranslationSelected) {
     return (
-      <button
-        type="button"
-        className={classNames(
-          styles.modeButton,
-          styles.translationButton,
-          styles.modeButtonUnselected,
-        )}
+      <Button
+        size={ButtonSize.XSmall}
+        shape={ButtonShape.Pill}
+        variant={ButtonVariant.ModeToggle}
+        isSelected={false}
         onClick={switchToTranslationMode}
+        className={styles.translationButton}
+        contentClassName={styles.translationButtonContent}
       >
         <span className={styles.translationText}>{t('translation')}</span>
-      </button>
+      </Button>
     );
   }
 
@@ -103,23 +103,25 @@ const TranslationModeButton: React.FC<TranslationModeButtonProps> = ({
   return (
     <PopoverMenu
       trigger={
-        <button
-          type="button"
+        <Button
+          size={ButtonSize.XSmall}
+          shape={ButtonShape.Pill}
+          variant={ButtonVariant.ModeToggle}
+          isSelected
           aria-expanded={isDropdownOpen}
           aria-haspopup="listbox"
-          className={classNames(
-            styles.modeButton,
-            styles.translationButton,
-            styles.modeButtonSelected,
-          )}
+          className={styles.translationButton}
+          contentClassName={styles.translationButtonContent}
+          suffix={
+            <ChevronDownIcon
+              className={classNames(styles.dropdownIcon, {
+                [styles.dropdownIconOpen]: isDropdownOpen,
+              })}
+            />
+          }
         >
           <span className={styles.translationText}>{displayText}</span>
-          <ChevronDownIcon
-            className={classNames(styles.dropdownIcon, {
-              [styles.dropdownIconOpen]: isDropdownOpen,
-            })}
-          />
-        </button>
+        </Button>
       }
       isOpen={isDropdownOpen}
       isModal={false}

--- a/src/components/chapters/ChapterHeader/index.tsx
+++ b/src/components/chapters/ChapterHeader/index.tsx
@@ -11,8 +11,9 @@ import ChapterTitle from './components/ChapterTitle';
 import ReadingModeActions from './ReadingModeActions';
 
 import PlayChapterAudioButton from '@/components/QuranReader/PlayChapterAudioButton';
-import Button, { ButtonShape, ButtonSize, ButtonType } from '@/dls/Button/Button';
+import Button, { ButtonShape, ButtonSize, ButtonVariant } from '@/dls/Button/Button';
 import useDirection from '@/hooks/useDirection';
+import ChevronDownIcon from '@/icons/chevron-down.svg';
 import { setIsSettingsDrawerOpen, setSettingsView, SettingsView } from '@/redux/slices/navbar';
 import { selectReadingPreference } from '@/redux/slices/QuranReader/readingPreferences';
 import Language from '@/types/Language';
@@ -74,23 +75,27 @@ const ChapterHeader: React.FC<ChapterHeaderProps> = ({
             <ReadingModeActions />
           ) : (
             <Button
-              type={ButtonType.Secondary}
-              size={ButtonSize.Small}
+              variant={ButtonVariant.ModeToggle}
+              size={ButtonSize.XSmall}
               shape={ButtonShape.Pill}
               onClick={onChangeTranslationClicked}
               ariaLabel={t('change-translation')}
-              tooltip={t('change-translation')}
               className={styles.changeTranslationButton}
               contentClassName={styles.translationName}
               suffix={
-                translationsCount > 1 && (
-                  <span className={styles.translationsCount}>
-                    {`+${toLocalizedNumber(translationsCount - 1, lang)}`}
-                  </span>
-                )
+                <>
+                  {translationsCount > 1 && (
+                    <span className={styles.translationsCount}>
+                      {`+${toLocalizedNumber(translationsCount - 1, lang)}`}
+                    </span>
+                  )}
+                  <ChevronDownIcon className={styles.dropdownIcon} />
+                </>
               }
             >
-              <span>{translationName}</span>
+              <span>
+                {t('common:translation')}: {translationName}
+              </span>
             </Button>
           )}
         </div>

--- a/src/components/dls/Button/Button.module.scss
+++ b/src/components/dls/Button/Button.module.scss
@@ -104,6 +104,10 @@
   font-size: var(--font-size-normal);
   --button-size: calc(2 * var(--spacing-medium));
 }
+.xsmall {
+  font-size: var(--font-size-small);
+  --button-size: 27px;
+}
 
 // shape
 .square {
@@ -173,14 +177,17 @@
 // suffix, prefix and content contaniner
 .suffix {
   display: flex;
+  align-items: center;
   margin-inline-start: calc(0.5 * var(--spacing-medium));
 }
 .prefix {
   display: flex;
+  align-items: center;
   margin-inline-end: calc(0.5 * var(--spacing-medium));
 }
 .content {
   display: flex;
+  align-items: center;
   line-height: normal;
 }
 
@@ -282,5 +289,36 @@
     color: var(--color-text-white);
     background-color: var(--color-streaks-dark);
     opacity: 0.9;
+  }
+}
+
+.mode_toggle {
+  background-color: var(--color-background-elevated-new);
+  color: var(--color-text-faded-new);
+  border: none;
+  box-shadow: var(--shadow-small-new);
+
+  // Disable the default button scale effect on click
+  &:active {
+    transform: none;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      color: var(--color-text-default-new);
+      background-color: var(--color-background-elevated-new);
+    }
+  }
+
+  &.selected {
+    background-color: var(--color-text-default-new);
+    color: var(--color-background-elevated);
+
+    @media (hover: hover) {
+      &:hover {
+        background-color: var(--color-text-default-new);
+        color: var(--color-background-elevated);
+      }
+    }
   }
 }

--- a/src/components/dls/Button/Button.tsx
+++ b/src/components/dls/Button/Button.tsx
@@ -12,6 +12,7 @@ import Tooltip, { ContentSide } from '@/dls/Tooltip';
 import useDirection from '@/hooks/useDirection';
 
 export enum ButtonSize {
+  XSmall = 'xsmall',
   Small = 'small',
   Medium = 'medium',
   Large = 'large',
@@ -41,6 +42,7 @@ export enum ButtonVariant {
   Rounded = 'rounded',
   SimplifiedAccent = 'simplified_accent',
   Accent = 'accent',
+  ModeToggle = 'mode_toggle',
 }
 
 /**
@@ -60,6 +62,7 @@ export type ButtonProps = {
   isLoading?: boolean;
   href?: string;
   isDisabled?: boolean;
+  isSelected?: boolean;
   onClick?: MouseEventHandler;
   tooltip?: string | React.ReactNode;
   tooltipContentSide?: ContentSide;
@@ -92,6 +95,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       isDisabled: disabled = false,
       isLoading,
+      isSelected = false,
       type = ButtonType.Primary,
       size = ButtonSize.Medium,
       shape,
@@ -129,6 +133,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       [styles.large]: size === ButtonSize.Large,
       [styles.normal]: size === ButtonSize.Medium,
       [styles.small]: size === ButtonSize.Small,
+      [styles.xsmall]: size === ButtonSize.XSmall,
 
       // shape
       [styles.square]: shape === ButtonShape.Square,
@@ -144,7 +149,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       [styles.simplified]: variant === ButtonVariant.Simplified,
       [styles.simplified_accent]: variant === ButtonVariant.SimplifiedAccent,
       [styles.accent]: variant === ButtonVariant.Accent,
-      [styles.rounded]: variant === ButtonVariant.Rounded,
+      [styles.mode_toggle]: variant === ButtonVariant.ModeToggle,
+      [styles.selected]: isSelected,
       [styles.disabled]: disabled || isLoading,
       [styles.noSidePadding]: !hasSidePadding,
     });


### PR DESCRIPTION
## Summary

Standardizes button heights and styling across ChapterHeader components to ensure visual consistency. All action buttons (Play, Arabic, Translation) now use the same 27px height with consistent styling through a new reusable Button variant.

Closes: [QF-4598](https://quranfoundation.atlassian.net/browse/QF-4598)

---

## Problems & Root Causes

### 1. Inconsistent Button Heights

**Problem:** The PlayChapterAudioButton and translation button had different heights compared to the Arabic mode toggle button, creating visual inconsistency in the ChapterHeader.

**Root Cause:** Each button used different sizing approaches:
- PlayChapterAudioButton used `block-size: auto` which overrode the intended height
- Translation button used `ButtonSize.Small` instead of matching the Arabic button
- Custom `modeButton` styles were duplicated across components instead of using a shared Button component

### 2. Missing Translation Label and Dropdown Indicator

**Problem:** The translation button in non-reading mode only showed the translation name without context or visual affordance for the dropdown.

**Root Cause:** The button lacked the "Translation:" prefix and dropdown chevron icon that the TranslationModeButton had in reading mode.

### 3. Duplicated Button Styling Code

**Problem:** ReadingModeActions had custom `.modeButton`, `.modeButtonSelected`, and `.modeButtonUnselected` styles that duplicated logic.

**Root Cause:** No reusable Button variant existed for toggle-style buttons with selected/unselected states.

### 4. Button Content Vertical Alignment

**Problem:** Button suffix/prefix content was not vertically centered, especially visible in RTL layouts.

**Root Cause:** The `.suffix`, `.prefix`, and `.content` CSS classes in Button.module.scss lacked `align-items: center`.

---

## Solution Approach

### 1. New Button Size and Variant

Added to the Button component:
- `ButtonSize.XSmall` - 27px height with small font size
- `ButtonVariant.ModeToggle` - toggle button styling with selected/unselected states
- `isSelected` prop - controls visual state for toggle buttons

### 2. Updated PlayChapterAudioButton

- Changed from `ButtonType.Secondary` to `ButtonVariant.ModeToggle`
- Changed from `ButtonSize.Small` to `ButtonSize.XSmall`
- Removed `block-size: auto` CSS override that was preventing correct height
- Added `isSelected` state when playing

### 3. Updated ChapterHeader Translation Button

- Uses `ButtonVariant.ModeToggle` and `ButtonSize.XSmall` for consistent styling
- Added "Translation:" prefix using `t('common:translation')`
- Added `ChevronDownIcon` dropdown indicator
- Styled dropdown icon with proper size, spacing, and color

### 4. Refactored ReadingModeActions

- Replaced custom `<button>` elements with `<Button>` component
- Removed duplicate `.modeButton*` styles from SCSS
- All mode buttons now use the shared `ButtonVariant.ModeToggle`

### 5. Fixed Button Content Alignment

- Added `align-items: center` to `.suffix`, `.prefix`, and `.content` classes in Button.module.scss

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Test Plan

- [ ] Manual testing performed

**Testing steps:**

1. **Button height consistency test:**
   - Navigate to any surah page (e.g., `/al-fatihah`)
   - Verify all ChapterHeader buttons (Play, Arabic/Translation toggles) have the same 27px height
   - Compare visually - they should all align perfectly

2. **Translation button styling test:**
   - In non-reading mode, verify the translation button shows "Translation: {name}"
   - Verify dropdown chevron icon is visible, centered, and has correct color
   - Verify proper spacing between translation name, count badge, and chevron

3. **RTL layout test:**
   - Switch to Arabic language
   - Verify button content (text, icons, badges) is vertically centered
   - Verify proper RTL layout of all elements

4. **Reading mode toggle test:**
   - Click Arabic button - verify it becomes selected (dark background)
   - Click Translation button - verify it becomes selected
   - Verify unselected buttons have light background with faded text

5. **Play button test:**
   - Click Play button - verify it shows pause icon and becomes selected state
   - Click again to pause - verify it returns to unselected state

### Edge Cases Verified

- [ ] Empty state handled
- [ ] Loading state handled
- [ ] Error state handled
- [x] RTL layout verified (if UI changes)
- [ ] Logged-in vs guest behavior (if auth-related)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] RTL layout verified

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4598]: https://quranfoundation.atlassian.net/browse/QF-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ