### PR TITLE
Fix/Settings drawer spacing regression

### DIFF
--- a/src/components/Navbar/Drawer/Drawer.module.scss
+++ b/src/components/Navbar/Drawer/Drawer.module.scss
@@ -81,9 +81,7 @@
   &.navbarInvisible {
     &.settingsDrawer {
       @include breakpoints.smallerThanTablet {
-        inset-block-start: calc(var(--top-bar-height-mobile-collapsed) + var(--navbar-height));
         inset-block-end: auto;
-        block-size: calc(100dvh - var(--context-menu-container-height));
         border-start-start-radius: var(--border-radius-rounded);
         border-start-end-radius: var(--border-radius-rounded);
         padding-block-start: var(--spacing-xxsmall-px);
@@ -249,8 +247,6 @@
 }
 
 .navbarInvisible {
-  padding-block-start: var(--navbar-container-height);
-
   @include breakpoints.smallerThanTablet {
     padding-block-start: 0;
   }


### PR DESCRIPTION
## Summary                                                                                                                          
                                                                                                                                      
 Fixes setting drawer regression introduced by the recent changes                                       
  1. Settings drawer positioning issues on mobile when navbar is invisible (scrolled state)                                           
  2. Unwanted top spacing/padding appearing in the header when users scroll down on both mobile and desktop                           
                                                                                                                                      
  The fix removes incorrect `inset-block-start`, `block-size`, and `padding-block-start` overrides that were conflicting with the     
  drawer's expected positioning behavior.                                                                                             
                                                                                                                                                                                
                                                                                                                                      
  ## Type of Change                                                                                                                   
                                                                                                                                      
  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)                                                                         
  - [ ] ✨ New feature (non-breaking change which adds functionality)                                                                 
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)                           
  - [ ] 📝 Documentation update                                                                                                       
  - [ ] ♻️ Refactoring (no functional changes)                                                                                        
                                                                                                                                      
  ## Scope Confirmation                                                                                                               
                                                                                                                                      
  - [x] This PR addresses **one** feature/fix only                                                                                    
  - [x] If multiple changes were needed, they are split into separate PRs                                                             
                                                                                                                                      
  ## Rollback Safety                                                                                                                  
                                                                                                                                      
  - [x] Can be safely reverted without data issues or migrations                                                                      
  - [ ] Rollback requires special steps (describe below):                                                                             
                                                                                                                                      
  ## Test Plan                                                                                                                        
                                                                                                                                      
  - [ ] Unit tests added/updated                                                                                                      
  - [ ] Integration tests added/updated                                                                                               
  - [x] Manual testing performed                                                                                                      
                                                                                                                                      
  **Testing steps:**                                                                                                                  
                                                                                                                                      
  1. Navigate to any Surah page (e.g., /al-fatihah)                                                                                   
  2. Open the settings drawer from the navbar                                                                                         
  3. Scroll down until the navbar becomes invisible/collapsed                                                                         
  4. Verify the settings drawer displays correctly without extra spacing at top                                                       
  5. Verify no gap appears at the top of the header on both mobile and desktop viewports                                              
                                                                                                                                      
  ### Edge Cases Verified                                                                                                             
                                                                                                                                      
  - [ ] ⏳ Loading state handled                                                                                                      
  - [ ] ❌ Error state handled                                                                                                        
  - [ ] 📭 Empty state handled                                                                                                        
  - [ ] 👤 Logged-in vs guest behavior (if applicable)                                                                                
                                                                                                                                      
  ## Pre-Review Checklist                                                                                                             
                                                                                                                                      
  ### Code Quality                                                                                                                    
                                                                                                                                      
  - [x] I have performed a **self-review** of my code (file by file)                                                                  
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)                                              
  - [x] No `any` types used (or justified if unavoidable)                                                                             
  - [x] No unused code, imports, or dead code included                                                                                
  - [x] Complex logic has inline comments explaining "why"                                                                            
  - [x] Functions are under 30 lines and follow single responsibility                                                                 
                                                                                                                                      
  ### Testing & Validation                                                                                                            
                                                                                                                                      
  - [ ] All tests pass locally (`yarn test`)                                                                                          
  - [ ] Linting passes (`yarn lint`)                                                                                                  
  - [ ] Build succeeds (`yarn build`)                                                                                                 
  - [x] Edge cases and error scenarios are handled                                                                                    
                                                                                                                                      
  ### Documentation                                                                                                                   
                                                                                                                                      
  - [x] Code is self-documenting with clear naming                                                                                    
  - [ ] README updated (if adding features or setup changes)                                                                          
  - [ ] Inline comments added for complex logic                                                                                       
                                                                                                                                      
  ### Localization (if UI changes)                                                                                                    
                                                                                                                                      
  - [ ] All user-facing text uses `next-translate`                                                                                    
  - [ ] Only English locale files modified (Lokalise handles others)                                                                  
  - [ ] RTL layout verified                                                                                                           
                                                                                                                                      
  ### Accessibility (if UI changes)                                                                                                   
                                                                                                                                      
  - [ ] Semantic HTML elements used                                                                                                   
  - [ ] ARIA attributes added where needed                                                                                            
  - [ ] Keyboard navigation works                                                                                                     
                                                                                                                                      
  ## Screenshots/Videos                                                                                                               
                                                                                                                                      
  | Before | After |                                                                                                                  
  | ------ | ----- |                                                                                                                  
  |<img width="1170" height="2532" alt="Screen Shot 2026-01-22 at 18 37 21" src="https://github.com/user-attachments/assets/498bd633-910e-4ca8-9442-6f58aa1c927d" /> | <img width="1170" height="2532" alt="Screen Shot 2026-01-22 at 18 38 26" src="https://github.com/user-attachments/assets/99b2735b-d8aa-465c-9860-7b989588cca7" /> |                                                                         
  | <img width="275" height="702" alt="image" src="https://github.com/user-attachments/assets/8b871ed7-983e-415b-8ed1-010a648f99fc" /> | <img width="362" height="703" alt="image" src="https://github.com/user-attachments/assets/eef95354-e161-4547-abad-2514f8faaa1f" /> |                                                                         
                                                                                                                                                                                                                                                 
  ## Reviewer Notes                                                                                                                   
                                                                                                                                      
  This is a CSS-only fix that reverts problematic style overrides. The removed properties were causing the settings drawer to be      
  incorrectly positioned and adding unwanted padding when the navbar transitions to its collapsed/invisible state on scroll.          
                                                                                                                                      
  ## AI Assistance Disclosure                                                                                                         
                                                                                                                                      
  - [ ] AI tools were NOT used for this PR                                                                                            
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code                                       
                         