### PR TITLE
fix: prevent intermediate proxy caching for API proxy responses

### DIFF
--- a/src/pages/api/proxy/[...path].ts
+++ b/src/pages/api/proxy/[...path].ts
@@ -103,6 +103,13 @@ const apiProxy = createProxyMiddleware<NextApiRequest, NextApiResponse>({
       if (proxyCookies) {
         res.setHeader('Set-Cookie', proxyCookies);
       }
+
+      // Prevent intermediate proxy caching (Traefik, nginx, etc.)
+      // This ensures fresh data flows through from the API Gateway's CF cache
+      // Note: This does NOT affect CF caching at the API Gateway level
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+      res.setHeader('Pragma', 'no-cache');
+      res.setHeader('Expires', '0');
     },
 
     error: (err, req, res) => {


### PR DESCRIPTION
## Problem

The API proxy (`/api/proxy/*`) was returning stale/outdated data even when the upstream API Gateway returned fresh data.

### Symptoms
- Calling `GW/content/api/qdc/resources/translations?language=en` directly returned fresh data (ETag: `4ebd5003647ac86fec1dbf4551fe7bdc`)
- Calling `FE/api/proxy/content/api/qdc/resources/translations?language=en` returned outdated data (ETag: `c117edca985cd42b2bd59a9a0055b46b`)
- The `x-request-id` from proxy responses was identical across multiple requests, indicating cached responses

### Root Cause
The intermediate proxy layer (Traefik via Kamal, or PM2 instances) was caching proxy responses. Since PM2 runs in cluster mode (`-i max`), different instances could have different cached versions, leading to inconsistent data.

## Solution

Add explicit no-cache headers to proxy responses to prevent any intermediate layer from caching:

```typescript
res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
res.setHeader('Pragma', 'no-cache');
res.setHeader('Expires', '0');
```

### Important Notes
- Fresh data still flows through from the API Gateway's CF cache
- Only the intermediate proxy layer is prevented from caching stale responses

## Testing
After deploying, verify:
1. Call the proxy endpoint multiple times
2. Confirm ETags match the upstream API Gateway
3. Confirm `x-request-id` changes with each request (no longer cached)