### PR TITLE
fix: resolve mobile navbar transparency regression and improve translation view spacing

### DIFF
--- a/src/components/Navbar/MobileStickyItemsBar/MobileStickyItemsBar.module.scss
+++ b/src/components/Navbar/MobileStickyItemsBar/MobileStickyItemsBar.module.scss
@@ -22,12 +22,10 @@
 
 .visible {
   transform: translate3d(0, 0, 0);
-  visibility: visible;
 }
 
 .hidden {
   transform: translate3d(0, -100%, 0);
-  visibility: hidden;
 }
 
 .centerVertically {

--- a/src/components/QuranReader/TranslationView/TranslationViewCell.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationViewCell.module.scss
@@ -9,6 +9,10 @@
   padding-block: var(--spacing-medium2-px);
   padding-inline: var(--spacing-small);
   --gap-size: calc(0.5 * var(--spacing-mega));
+
+  @include breakpoints.tablet {
+    padding-block: var(--spacing-large-px);
+  }
 }
 
 .firstCellWithHeader {
@@ -38,10 +42,18 @@
   direction: rtl;
   margin-block-start: var(--spacing-large-px);
   margin-block-end: var(--spacing-medium-plus-px);
+
+  @include breakpoints.tablet {
+    margin-block-start: var(--spacing-xxlarge-px);
+  }
 }
 
 .verseTranslationsContainer {
   margin-block-end: var(--spacing-large-px);
+
+  @include breakpoints.tablet {
+    margin-block-end: var(--spacing-xxlarge-px);
+  }
 }
 
 .verseTranslationContainer {


### PR DESCRIPTION
## Summary

This PR fixes a transparency rendering issue on mobile where a transparent area would appear above the ContextMenu after scrolling up then down, and improves the spacing in TranslationView for better readability on tablet.

Closes: [QF-4598](https://quranfoundation.atlassian.net/browse/QF-4598)

---

## Problems & Root Causes

### 1. Mobile Navbar Transparency Regression

**Problem:** On mobile, after scrolling down → up → down again, a transparent area would appear on top of the ContextMenu (surah info bar), showing page content behind it. This included the status bar region.

**Root Cause:** PR #2892 added `visibility: visible` and `visibility: hidden` properties to the MobileStickyItemsBar's `.visible` and `.hidden` states. When combined with the `transform: translate3d()` transitions and the existing `dimmedOverlay` mixin (which creates a `::before` pseudo-element), this caused GPU compositing/rendering artifacts during the show/hide transitions.

**Reproduction scenario:**
1. Navigate to a Quran reader page on mobile
2. Scroll down (navbar hides, context menu shows)
3. Scroll up (MobileStickyItemsBar appears)
4. Scroll down again (MobileStickyItemsBar hides)
5. Transparent area appears above the ContextMenu

### 2. Translation View Spacing Too Tight on Tablet

**Problem:** The spacing between verses and translations in the TranslationView was optimized for mobile but felt cramped on larger tablet screens.

**Root Cause:** The padding and margin values were uniform across all breakpoints without tablet-specific adjustments.

---

## Solution Approach

### 1. Remove Visibility Properties from MobileStickyItemsBar

Removed the `visibility: visible` and `visibility: hidden` properties that were added in PR #2892. The transform-based hiding (`translate3d(0, -100%, 0)`) is sufficient to hide the element off-screen without causing rendering artifacts.

```scss
.visible {
  transform: translate3d(0, 0, 0);
  // Removed: visibility: visible;
}

.hidden {
  transform: translate3d(0, -100%, 0);
  // Removed: visibility: hidden;
}
```

### 2. Add Tablet-Specific Spacing for TranslationView

Added responsive breakpoints to increase padding and margins on tablet screens for better readability:

- `.cellContainer`: Increased `padding-block` from `medium2` to `large` on tablet
- `.arabicVerseContainer`: Increased `margin-block-start` from `large` to `xxlarge` on tablet
- `.verseTranslationsContainer`: Increased `margin-block-end` from `large` to `xxlarge` on tablet

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Navbar transparency test:**
   - Go to a Quran reader page on mobile (or mobile simulator)
   - Scroll down past the navbar (context menu shows in collapsed mode)
   - Scroll up (MobileStickyItemsBar should appear)
   - Scroll down again
   - **Verify:** No transparent area appears above the ContextMenu

2. **Translation view spacing test:**
   - Open TranslationView on a tablet device or simulator
   - **Verify:** Spacing between verses feels comfortable and not cramped

3. **MobileStickyItemsBar dimmed state test:**
   - On mobile, scroll to show MobileStickyItemsBar
   - Open navigation drawer
   - **Verify:** MobileStickyItemsBar dims correctly behind the drawer

### Edge Cases Verified

- [x] RTL layout verified
- [x] Smooth handoff between MobileStickyItemsBar and full Navbar still works

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code
- [x] My code follows the project style guidelines
- [x] Linting passes (`yarn lint`)

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4598]: https://quranfoundation.atlassian.net/browse/QF-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ