### PR TITLE
fix: preserve physical margins for RTL Arabic text in search results

### DIFF
--- a/src/components/Search/SearchResults/SearchResultItem/SearchResultItem.module.scss
+++ b/src/components/Search/SearchResults/SearchResultItem/SearchResultItem.module.scss
@@ -24,7 +24,10 @@
   direction: rtl;
   inline-size: 100%;
   display: block;
-  margin-inline: auto 0;
+  /* stylelint-disable-next-line csstools/use-logical */
+  margin-left: auto;
+  /* stylelint-disable-next-line csstools/use-logical */
+  margin-right: 0;
 }
 
 .resultText {


### PR DESCRIPTION
## Summary

Fixes Arabic text alignment in search results that was broken by the CSS logical properties migration in #2915.

---

## Problem & Root Cause

**Problem:** Arabic text in search results is pushed to the left instead of staying right-aligned.

**Root Cause:** The `.arabic` class has `direction: rtl` set directly on it. Using `margin-inline: auto 0` with `direction: rtl` causes `margin-inline-start` to map to the physical right side, resulting in `margin-right: auto` which pushes content left—the opposite of the intended behavior.

---

## Solution

Use physical margins with stylelint-disable comments for this specific case where the element needs to stay right-aligned regardless of page direction:

```scss
.arabic {
  direction: rtl;
  /* stylelint-disable-next-line csstools/use-logical */
  margin-left: auto;
  /* stylelint-disable-next-line csstools/use-logical */
  margin-right: 0;
}
```

---

## Test Plan

1. Search for Arabic text (e.g., "الله")
2. Verify Arabic text in search results is **right-aligned**
3. Test in both LTR (English) and RTL (Arabic) site language modes

## Pre-Review Checklist

- [x] Self-review performed
- [x] RTL layout verified