### PR TITLE
[QF-4641] Answer Sync Icon Scaling with Font Size

### DIFF
--- a/src/components/QuestionAndAnswer/QuestionsList/QuestionsList.module.scss
+++ b/src/components/QuestionAndAnswer/QuestionsList/QuestionsList.module.scss
@@ -30,8 +30,24 @@ div.headerClassName {
   align-items: flex-start;
   gap: var(--spacing-xsmall);
 
+  // multiplier for the icon size and margin top
+  $icon-size-multiplier: 0.75;
+  $icon-margin-top-multiplier: 0.45;
+
   & > :nth-child(2) {
     margin-inline-end: 0;
-    margin-block-start: calc(2 * var(--spacing-micro-px));
+    margin-block-start: calc(
+      var(--answer-dynamic-font-size, 1rem) * #{$icon-margin-top-multiplier}
+    );
+
+    --icon-size: calc(var(--answer-dynamic-font-size, 1rem) * #{$icon-size-multiplier});
+    inline-size: var(--icon-size);
+    block-size: var(--icon-size);
+    flex-shrink: 0;
+
+    svg {
+      inline-size: 100%;
+      block-size: 100%;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes arrow icon SVG in QuestionAndAnswer components to scale proportionally with font size changes. Previously, when text increased or decreased in size, the arrow icons remained static, causing visual inconsistency. Now arrow icons sync with font size growth/shrinkage for proper proportional scaling.

Part of: [QF-4641](https://quranfoundation.atlassian.net/browse/QF-4641)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

## Test Plan

**Testing steps:**

1. Navigate to QuestionAndAnswer pages
2. Test different font sizes (increase/decrease font size)
3. Verify arrow icons scale proportionally with text size
4. Confirm both QuestionHeader and QuestionsList components have consistent icon-to-text ratio

## Screenshots/Videos

| Before | After |
| ------ | ----- |
| <img width="1092" height="295" alt="image" src="https://github.com/user-attachments/assets/63603648-742f-4023-8bfe-cf2b26b55591" /> | <img width="1066" height="378" alt="image" src="https://github.com/user-attachments/assets/68fbfefe-6496-4828-9055-139ccbef1038" /> |



[QF-4641]: https://quranfoundation.atlassian.net/browse/QF-4641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ