### PR TITLE
[QF-4189] Auto-Scroll to answer on /:chapterId/answer/:answerId

### DIFF
--- a/src/components/QuestionAndAnswer/QuestionsList/index.tsx
+++ b/src/components/QuestionAndAnswer/QuestionsList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 
@@ -43,6 +43,14 @@ const QuestionsList: React.FC<Props> = ({
     onLoadMore,
   });
 
+  // Scroll to the initially opened question on mount
+  useEffect(() => {
+    if (initialOpenQuestionId) {
+      const element = document.getElementById(`question-${initialOpenQuestionId}`);
+      if (element) element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [initialOpenQuestionId]);
+
   const onQuestionCollapseOpenChange = (
     isOpen: boolean,
     questionId: string,
@@ -65,12 +73,13 @@ const QuestionsList: React.FC<Props> = ({
     <div className={styles.container}>
       {questions?.map((question) => (
         <Collapsible
+          key={question.id}
+          id={`question-${question.id}`}
           direction={CollapsibleDirection.Right}
           headerClassName={styles.headerClassName}
           title={
             <QuestionHeader body={question.body} theme={question.theme} type={question.type} />
           }
-          key={question.id}
           prefix={<ChevronDownIcon />}
           shouldRotatePrefixOnToggle
           isDefaultOpen={false}


### PR DESCRIPTION
## Summary

Added smooth scroll functionality to automatically scroll to the answer on the `/1:1/answer/1` page when navigating directly to a specific question ID. This ensures the answer content is immediately visible to users upon page load.

Part of: [QF-4189](https://quranfoundation.atlassian.net/browse/QF-4189)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Test Plan

**Testing steps:**

1. Navigate directly to a specific answer page (e.g., `/1:1/answer/1`)
2. Verify the page automatically scrolls to the answer content
3. Verify the scroll behavior is smooth
4. Test on different screen sizes (mobile, tablet, desktop)


[QF-4189]: https://quranfoundation.atlassian.net/browse/QF-4189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ