### PR TITLE
Fix footer spacing on Home Radio and Reciter pages

### DIFF
--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -2,6 +2,10 @@
 @use 'src/styles/utility';
 @use 'src/styles/constants';
 
+.footer {
+  background-color: var(--color-background-elevated-new);
+}
+
 .flowItem {
   @include utility.pageContainer();
   border-block-start: 1px solid var(--color-borders-hairline);

--- a/src/pages/radio.module.scss
+++ b/src/pages/radio.module.scss
@@ -16,6 +16,10 @@ $ribbon-text-color: #fff;
   margin-block-start: calc(3 * var(--spacing-mega));
 }
 
+.flow {
+  padding-block-end: var(--spacing-max);
+}
+
 .ribbon {
   position: absolute;
   inset-block-start: 0;

--- a/src/pages/radio.tsx
+++ b/src/pages/radio.tsx
@@ -33,7 +33,7 @@ const RadioPage = ({ reciters }: RadioPageProps) => {
       />
       <div className={pageStyle.pageContainer}>
         <div className={radioStyle.ribbon} />
-        <div className={pageStyle.flow}>
+        <div className={classNames(pageStyle.flow, radioStyle.flow)}>
           <div
             className={classNames(pageStyle.flowItem, radioStyle.title, radioStyle.titleOnRibbon)}
           >

--- a/src/pages/reciters/[reciterId]/[chapterId].tsx
+++ b/src/pages/reciters/[reciterId]/[chapterId].tsx
@@ -112,7 +112,7 @@ const RecitationPage = ({ selectedReciter, selectedChapter }: ShareRecitationPag
           getReciterChapterNavigationUrl(selectedReciter.id.toString(), selectedChapter.slug),
         )}
       />
-      <div className={classNames(layoutStyle.flow)}>
+      <div className={classNames(layoutStyle.flow, styles.flow)}>
         <div className={classNames(layoutStyle.flowItem, styles.container)}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img

--- a/src/pages/reciters/[reciterId]/chapterId.module.scss
+++ b/src/pages/reciters/[reciterId]/chapterId.module.scss
@@ -57,3 +57,7 @@
   font-size: var(--font-size-large);
   margin-block-end: var(--spacing-medium);
 }
+
+.flow {
+  padding-block-end: var(--spacing-max);
+}

--- a/src/pages/reciters/[reciterId]/index.tsx
+++ b/src/pages/reciters/[reciterId]/index.tsx
@@ -82,7 +82,7 @@ const ReciterPage = ({ selectedReciter, chaptersData }: ReciterPageProps) => {
           reciterName: selectedReciter?.translatedName?.name,
         })}
       />
-      <div className={classNames(layoutStyle.pageContainer)}>
+      <div className={classNames(layoutStyle.pageContainer, pageStyle.pageContainer)}>
         <div className={pageStyle.reciterInfoContainer}>
           <div className={classNames(layoutStyle.flowItem, pageStyle.headerContainer)}>
             <ReciterInfo selectedReciter={selectedReciter} />

--- a/src/pages/reciters/index.tsx
+++ b/src/pages/reciters/index.tsx
@@ -37,7 +37,7 @@ const RecitersListPage = ({ reciters }) => {
         canonical={getCanonicalUrl(lang, NAVIGATION_URL)}
         languageAlternates={getLanguageAlternates(NAVIGATION_URL)}
       />
-      <div className={layoutStyle.flow}>
+      <div className={classNames(layoutStyle.flow, pageStyle.flow)}>
         <QuranReciterListHero searchQuery={searchQuery} onSearchQueryChange={setSearchQuery} />
         <div className={classNames(layoutStyle.flowItem, pageStyle.recitersListContainer)}>
           <RecitersList reciters={filteredReciters} />

--- a/src/pages/reciters/reciterPage.module.scss
+++ b/src/pages/reciters/reciterPage.module.scss
@@ -43,3 +43,11 @@
   background-color: var(--color-success-medium);
   margin-block-end: var(--spacing-large);
 }
+
+.flow {
+  padding-block-end: var(--spacing-max);
+}
+
+.pageContainer {
+  padding-block-end: var(--spacing-max);
+}


### PR DESCRIPTION
Added bottom padding to Radio and Reciter pages to restore proper spacing between page content and the footer. This fixes visual issues where
  content was directly against the footer without any gap.

  ### Changes

  - Radio page (/radio): Added padding-block-end: var(--spacing-max) to flow container
  - Reciters list (/reciters): Added padding-block-end: var(--spacing-max) to flow container
  - Reciter detail (/reciters/[reciterId]): Added padding-block-end: var(--spacing-max) to page container
  - Reciter chapter (/reciters/[reciterId]/[chapterId]): Added padding-block-end: var(--spacing-max) to flow container

  ### Test Plan

  1. Visit /radio - verify gap between content and footer
  2. Visit /reciters - verify gap between content and footer
  3. Visit any reciter detail page (e.g., /reciters/1) - verify gap between content and footer
  4. Visit any reciter chapter page (e.g., /reciters/1/1) - verify gap between content and footer
  5. Test on mobile and desktop to ensure spacing is consistent

  All pages should now have consistent spacing matching the homepage pattern.