### PR TITLE
fix(QF-4613): enable page navigation in reading translation mode

### DIFF
--- a/src/components/QuranReader/ReadingView/TranslationPage.tsx
+++ b/src/components/QuranReader/ReadingView/TranslationPage.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import classNames from 'classnames';
+
+import { QURAN_READER_OBSERVER_ID } from '../observer';
 
 import TranslatedAyah from './TranslatedAyah';
 import styles from './TranslationPage.module.scss';
 
 import ChapterHeader from '@/components/chapters/ChapterHeader';
+import useIntersectionObserver from '@/hooks/useObserveElement';
 import { getLanguageDataById, toLocalizedNumber } from '@/utils/locale';
 import Translation from 'types/Translation';
 import Verse from 'types/Verse';
@@ -31,8 +34,15 @@ const TranslationPage: React.FC<TranslationPageProps> = ({
   lang,
   pageHeaderChapterId,
 }) => {
+  // Register with intersection observer for page tracking
+  const observerRef = useRef<HTMLDivElement>(null);
+  useIntersectionObserver(observerRef, QURAN_READER_OBSERVER_ID);
+
+  // Get first verse data for page tracking attributes
+  const firstVerse = verses?.[0];
+
   // Get language data from the first translation for RTL direction and number formatting
-  const firstTranslation: Translation | undefined = verses?.[0]?.translations?.[0];
+  const firstTranslation: Translation | undefined = firstVerse?.translations?.[0];
   const langData = firstTranslation?.languageId
     ? getLanguageDataById(firstTranslation.languageId)
     : null;
@@ -66,7 +76,14 @@ const TranslationPage: React.FC<TranslationPageProps> = ({
   };
 
   return (
-    <div className={classNames(styles.container, langData && styles[langData.direction])}>
+    <div
+      ref={observerRef}
+      className={classNames(styles.container, langData && styles[langData.direction])}
+      data-verse-key={firstVerse?.verseKey}
+      data-page={firstVerse?.pageNumber}
+      data-chapter-id={firstVerse?.chapterId}
+      data-hizb={firstVerse?.hizbNumber}
+    >
       <div className={styles.translationContent}>{getTranslationContent()}</div>
       <div className={styles.pageFooter}>
         <span className={styles.pageNumber}>

--- a/src/components/QuranReader/ReadingView/hooks/usePageNavigation.ts
+++ b/src/components/QuranReader/ReadingView/hooks/usePageNavigation.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { VirtuosoHandle } from 'react-virtuoso';
+
+import { READING_MODE_TOP_OFFSET } from '../../observer';
+import { getPageIndexByPageNumber } from '../../utils/page';
+
+import LookupRecord from 'types/LookupRecord';
+
+enum ScrollDirection {
+  Next = 'next',
+  Prev = 'prev',
+}
+
+type UsePageNavigationParams = {
+  pagesVersesRange: Record<number, LookupRecord>;
+  lastReadPageNumber: string;
+  pagesCount: number;
+  virtuosoRef: React.RefObject<VirtuosoHandle>;
+};
+
+/**
+ * Custom hook for handling page navigation in ReadingView.
+ * Tracks current page index in a ref to ensure navigation works
+ * even before the intersection observer updates.
+ *
+ * @returns {object} Navigation functions and current page index
+ */
+const usePageNavigation = ({
+  pagesVersesRange,
+  lastReadPageNumber,
+  pagesCount,
+  virtuosoRef,
+}: UsePageNavigationParams) => {
+  // Calculate page index from observer/Redux state
+  const currentPageIndexFromObserver = getPageIndexByPageNumber(
+    Number(lastReadPageNumber),
+    pagesVersesRange,
+  );
+
+  // Track current page index in a ref for navigation (avoids re-renders)
+  const currentPageIndexRef = useRef(currentPageIndexFromObserver);
+  useEffect(() => {
+    currentPageIndexRef.current = currentPageIndexFromObserver;
+  }, [currentPageIndexFromObserver]);
+
+  const scrollToPage = useCallback(
+    (direction: ScrollDirection) => {
+      const isPrev = direction === ScrollDirection.Prev;
+      const newIndex = currentPageIndexRef.current + (isPrev ? -1 : 1);
+      const isValidIndex = isPrev ? newIndex >= 0 : newIndex < pagesCount;
+
+      if (isValidIndex && virtuosoRef.current) {
+        currentPageIndexRef.current = newIndex;
+        virtuosoRef.current.scrollToIndex({
+          index: newIndex,
+          align: 'start',
+          offset: -READING_MODE_TOP_OFFSET,
+        });
+      }
+    },
+    [pagesCount, virtuosoRef],
+  );
+
+  const scrollToPreviousPage = useCallback(
+    () => scrollToPage(ScrollDirection.Prev),
+    [scrollToPage],
+  );
+  const scrollToNextPage = useCallback(() => scrollToPage(ScrollDirection.Next), [scrollToPage]);
+
+  return {
+    scrollToPreviousPage,
+    scrollToNextPage,
+    currentPageIndex: currentPageIndexFromObserver,
+  };
+};
+
+export default usePageNavigation;

--- a/src/components/QuranReader/ReadingView/index.tsx
+++ b/src/components/QuranReader/ReadingView/index.tsx
@@ -10,8 +10,7 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { shallowEqual, useSelector } from 'react-redux';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
-import { getPageIndexByPageNumber } from '../utils/page';
-
+import usePageNavigation from './hooks/usePageNavigation';
 import useScrollToVirtualizedVerse from './hooks/useScrollToVirtualizedVerse';
 import PageContainer from './PageContainer';
 import PageNavigationButtons from './PageNavigationButtons';
@@ -112,11 +111,15 @@ const ReadingView = ({
     quranReaderStyles,
     isUsingDefaultFont,
   );
-  const currentPageIndex = useMemo(
-    () => getPageIndexByPageNumber(Number(lastReadPageNumber), pagesVersesRange),
-    [lastReadPageNumber, pagesVersesRange],
-  );
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+
+  const { scrollToPreviousPage, scrollToNextPage } = usePageNavigation({
+    pagesVersesRange,
+    lastReadPageNumber,
+    pagesCount,
+    virtuosoRef,
+  });
+
   useScrollToVirtualizedVerse(
     quranReaderDataType,
     virtuosoRef,
@@ -129,22 +132,6 @@ const ReadingView = ({
     mushafLines,
     isLoading,
   );
-
-  const scrollToPreviousPage = useCallback(() => {
-    virtuosoRef.current.scrollToIndex({
-      index: currentPageIndex - 1,
-      align: 'start',
-      offset: -35,
-    });
-  }, [currentPageIndex]);
-
-  const scrollToNextPage = useCallback(() => {
-    virtuosoRef.current.scrollToIndex({
-      index: currentPageIndex + 1,
-      align: 'start',
-      offset: 25,
-    });
-  }, [currentPageIndex]);
 
   const onPrevPageClicked = useCallback(() => {
     logButtonClick('reading_view_prev_page_button');

--- a/src/components/QuranReader/observer.ts
+++ b/src/components/QuranReader/observer.ts
@@ -13,15 +13,17 @@ const OBSERVER_THRESHOLD = 0.1;
 export const QURAN_READER_OBSERVER_ID = 'quranReaderObserver';
 export const REFLECTIONS_OBSERVER_ID = 'reflectionsObserver';
 /**
- * the top -115.6px was calculated based on:
- *
- * 1. the height of emptySpacePlaceholder of navbar (3.6rem).
- * 2. the top padding of the QuranReader container (2rem).
- * 3. the top and bottom margin of the ReadingPreferenceSwitcher container (1.625rem).
- *
- * and the total is 7.225rem around 115.6 pixels.
+ * The top offset for page navigation scrolling in reading mode.
+ * This provides enough clearance for the navbar without excessive spacing.
  */
-const READING_MODE_ROOT_MARGIN = '-115.6px 0px -70% 0px';
+export const READING_MODE_TOP_OFFSET = 60;
+/**
+ * The top offset for the intersection observer in reading mode.
+ * Based on navbar height (3.6rem) + container padding (2rem) +
+ * ReadingPreferenceSwitcher margin (1.625rem) = 7.225rem ≈ 116px.
+ */
+const READING_MODE_OBSERVER_OFFSET = 116;
+const READING_MODE_ROOT_MARGIN = `-${READING_MODE_OBSERVER_OFFSET}px 0px -70% 0px`;
 
 /**
  * Get the observer options based on the reading preference.


### PR DESCRIPTION
## Summary

This PR fixes the PageNavigationButtons (up/down arrows in bottom right corner) not working in Reading Translation mode. The buttons were functional in Reading Arabic mode but completely non-functional in Reading Translation mode.

Closes: [QF-4613](https://quranfoundation.atlassian.net/browse/QF-4613)

---

## Problems & Root Causes

### 1. Missing Intersection Observer in TranslationPage

**Problem:** PageNavigationButtons did not respond to clicks in Reading Translation mode - users could not navigate between pages using the arrow buttons.

**Root Cause:** The `TranslationPage` component was missing intersection observer registration and data attributes (`data-verse-key`, `data-page`, `data-chapter-id`, `data-hizb`) that are required for page tracking. In Reading Arabic mode, `Line.tsx` has these attributes, but `TranslationPage.tsx` did not - so the system couldn't track which page the user was viewing.

### 2. Navigation Only Worked After Manual Scrolling

**Problem:** Even after fixing the observer, navigation only worked for the first 2 pages after a page refresh. Users had to manually scroll through the entire surah before navigation buttons would work correctly.

**Root Cause:** The `currentPageIndex` was derived from Redux state (`lastReadPageNumber`), which only updates when the intersection observer fires. On initial load, the observer hadn't fired yet, so `currentPageIndex` was stale/incorrect.

### 3. Navbar Covering Content on Navigation

**Problem:** When navigating to a page, the navbar would cover the first 1-2 lines of content.

**Root Cause:** The scroll offset values (`-35` and `25`) were inconsistent and insufficient to account for the navbar height.

---

## Solution Approach

### 1. Add Observer Registration to TranslationPage

Added intersection observer and required data attributes to `TranslationPage`:

```typescript
const observerRef = useRef<HTMLDivElement>(null);
useIntersectionObserver(observerRef, QURAN_READER_OBSERVER_ID);

<div
  ref={observerRef}
  data-verse-key={firstVerse?.verseKey}
  data-page={firstVerse?.pageNumber}
  data-chapter-id={firstVerse?.chapterId}
  data-hizb={firstVerse?.hizbNumber}
>
```

### 2. Ref-Based Page Index Tracking

Created `usePageNavigation` hook that uses a ref to track page index independently of Redux state. This allows immediate navigation without waiting for the intersection observer to update:

```typescript
const currentPageIndexRef = useRef(currentPageIndexFromObserver);
useEffect(() => {
  currentPageIndexRef.current = currentPageIndexFromObserver;
}, [currentPageIndexFromObserver]);
```

### 3. Consistent Scroll Offset

Exported `READING_MODE_TOP_OFFSET` (60px) as a shared constant for navigation scrolling, separate from the observer offset (116px).

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Reading Translation mode navigation:**
   - Go to any Surah in Reading Translation mode
   - Click the down arrow button (bottom right) - should navigate to next page
   - Click the up arrow button - should navigate to previous page
   - Verify content is visible and not covered by navbar

2. **Navigation after page refresh:**
   - Refresh the page on any Surah
   - Immediately click navigation buttons without scrolling first
   - Verify navigation works correctly from the start

3. **Reading Arabic mode (regression test):**
   - Switch to Reading Arabic mode
   - Verify navigation buttons still work correctly
   - Verify navbar doesn't cover content

4. **Keyboard navigation:**
   - Press Up/Down arrow keys
   - Verify page navigation works in both modes

### Edge Cases Verified

- [x] Empty state handled
- [x] Loading state handled
- [x] Error state handled
- [ ] RTL layout verified (if UI changes)
- [ ] Logged-in vs guest behavior (if auth-related)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [ ] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)

### Localization (if UI changes)

- [ ] All user-facing text uses `next-translate`
- [ ] RTL layout verified

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4613]: https://quranfoundation.atlassian.net/browse/QF-4613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ