### PR TITLE
Add surah-info namespace to all QuranReader pages

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -31,11 +31,11 @@
     "/learning-plans/[slug]/lessons/[lessonSlugOrId]": ["learn"],
     "/reading-goal/progress": ["reading-goal", "reading-progress"],
     "/[chapterId]": ["quran-reader", "reading-goal", "notes", "chapter", "surah-info"],
-    "/[chapterId]/reflections": ["quran-reader", "reading-goal", "notes"],
-    "/[chapterId]/lessons": ["quran-reader", "reading-goal", "notes"],
-    "/[chapterId]/tafsirs/[tafsirId]": ["quran-reader", "reading-goal", "notes"],
-    "/[chapterId]/[verseId]": ["quran-reader", "reading-goal", "notes"],
-    "/[chapterId]/[verseId]/tafsirs": ["quran-reader", "reading-goal", "notes"],
+    "/[chapterId]/reflections": ["quran-reader", "reading-goal", "notes", "surah-info"],
+    "/[chapterId]/lessons": ["quran-reader", "reading-goal", "notes", "surah-info"],
+    "/[chapterId]/tafsirs/[tafsirId]": ["quran-reader", "reading-goal", "notes", "surah-info"],
+    "/[chapterId]/[verseId]": ["quran-reader", "reading-goal", "notes", "surah-info"],
+    "/[chapterId]/[verseId]/tafsirs": ["quran-reader", "reading-goal", "notes", "surah-info"],
     "/page/[pageId]": ["quran-reader", "reading-goal", "notes", "surah-info"],
     "/juz/[juzId]": ["quran-reader", "reading-goal", "notes", "surah-info"],
     "/hizb/[hizbId]": ["quran-reader", "reading-goal", "notes", "surah-info"],
@@ -68,8 +68,14 @@
     "/calendar": ["quranic-calendar"],
     "/media": ["media"],
     "/take-notes": ["take-notes"],
-    "/[chapterId]/answers": ["quran-reader", "question", "reading-goal", "notes"],
-    "/[chapterId]/answers/[questionId]": ["quran-reader", "question", "reading-goal", "notes"],
+    "/[chapterId]/answers": ["quran-reader", "question", "reading-goal", "notes", "surah-info"],
+    "/[chapterId]/answers/[questionId]": [
+      "quran-reader",
+      "question",
+      "reading-goal",
+      "notes",
+      "surah-info"
+    ],
     "/my-quran": ["home", "profile", "collection", "quran-reader"]
   }
 }


### PR DESCRIPTION
## Summary

Add `surah-info` namespace to all pages that render `QuranReader` component with `ChapterHeader`. The `ChapterHeader` component includes a surah info button that opens a modal with chapter information, which requires translations from the `surah-info` namespace.

## Changes

- **i18n.json**: Added `surah-info` namespace to 7 pages that were missing it:
  - `/[chapterId]/[verseId]`
  - `/[chapterId]/[verseId]/tafsirs`
  - `/[chapterId]/reflections`
  - `/[chapterId]/lessons`
  - `/[chapterId]/tafsirs/[tafsirId]`
  - `/[chapterId]/answers`
  - `/[chapterId]/answers/[questionId]`

## Technical Details

The `ChapterHeader` component is rendered on all pages that use `QuranReader`:
- Via `Page.tsx` and `TranslationPage.tsx` in ReadingView
- Via `Line.tsx` for multi-chapter pages
- Via `TranslationPageVerse.tsx` in TranslationView

The component contains `SurahInfoButton` (with `infoIconButton` class) which opens a modal displaying chapter info that uses `surah-info` translations. Without this namespace loaded, the modal would show missing translation keys.

## Test Plan

- Visit any of the updated pages (e.g., `1/1`, `/en/2:255`, `/en/2/lessons`, `/en/2/reflections`)
- Click the info icon button next to the surah name
- Verify the surah info modal opens with all text properly translated
- No missing translation keys should appear in the modal
