### PR TITLE
fix(QF-4669): hide ReaderTopActions when ChapterHeader shows on verse 1

### DIFF
--- a/src/components/QuranReader/ReaderTopActions/index.tsx
+++ b/src/components/QuranReader/ReaderTopActions/index.tsx
@@ -20,8 +20,7 @@ interface ReaderTopActionsProps {
 /**
  * A persistent top actions bar that shows Arabic/Translation mode switching buttons.
  * This component renders when:
- * - Single verse view (QuranReaderDataType.Verse): Always shown
- * - Page/Juz/Hizb/Rub/Ranges: Only if not starting at verse 1
+ * - NOT starting at verse 1 (ChapterHeader handles verse 1 for all view types)
  * - Chapter view: Never shown (ChapterHeader handles this)
  * - Tafsir view: Never shown
  *
@@ -41,10 +40,10 @@ const ReaderTopActions: React.FC<ReaderTopActionsProps> = ({
   const firstVerse = initialData?.verses?.[0];
 
   // Determine if we should show this component based on the data type:
-  // - Chapter: Never show - ChapterHeader always appears at verse 1
-  // - Verse/Ranges: Show only if not starting at verse 1
-  // - Page/Juz/Hizb/Rub: Show only if first verse is not verse 1
+  // - Chapter: Never show - ChapterHeader always appears
   // - Tafsir: Never show
+  // - Verse 1: Never show - ChapterHeader handles verse 1 for all view types
+  // - All other cases: Show
   const shouldShow = (() => {
     if (!firstVerse) return false;
 
@@ -59,11 +58,11 @@ const ReaderTopActions: React.FC<ReaderTopActionsProps> = ({
       return false;
     }
 
-    // Always show for single verse view (QuranReaderDataType.Verse)
-    if (quranReaderDataType === QuranReaderDataType.Verse) return true;
+    // Never show for verse 1 - ChapterHeader handles this for all view types
+    if (firstVerse.verseNumber === 1) return false;
 
-    // For all other types, show only if not starting at verse 1
-    return firstVerse.verseNumber !== 1;
+    // For all other cases (Verse, Page, Juz, Hizb, Rub, Ranges not at verse 1), show
+    return true;
   })();
 
   if (!shouldShow) {

--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/TranslationPageVerse.tsx
@@ -50,7 +50,6 @@ const TranslationPageVerse: React.FC<TranslationPageVerse> = ({
   }, [isLastVerseInView, verse, verseKeysQueue]);
 
   // Only show chapter header for verse 1 of a chapter (for multi-chapter pages like page 604)
-  // Single verse pages are handled by ReaderTopActions which shows the translation button
   const shouldShowChapterHeader = verse.verseNumber === 1;
 
   // First cell has header above it when:


### PR DESCRIPTION
## Summary

Fixes duplicate header UI where both `ChapterHeader` and `ReaderTopActions` were displaying simultaneously for the first verse of each chapter.

Closes: [QF-4669](https://quranfoundation.atlassian.net/browse/QF-4669)

---

## Problems & Root Causes

### 1. Duplicate Headers on Verse 1

**Problem:** When viewing the first verse of any chapter (in Reading Mode Arabic, Reading Mode Translation, or single verse view), both the `ChapterHeader` component AND the `ReaderTopActions` component would render, creating a cluttered/duplicate UI.

**Root Cause:** The `ReaderTopActions` component had special-case logic that always showed for single verse views (`QuranReaderDataType.Verse`), regardless of the verse number:

```typescript
// Always show for single verse view (QuranReaderDataType.Verse)
if (quranReaderDataType === QuranReaderDataType.Verse) return true;
```

This bypassed the verse 1 check that existed for other view types, causing both components to render when viewing verse 1.

**Example scenario:**
1. User navigates to `/en/al-fatihah/1` (single verse view of verse 1)
2. `ChapterHeader` renders (correct - it shows for verse 1)
3. `ReaderTopActions` also renders (incorrect - should be hidden since ChapterHeader handles verse 1)

---

## Solution Approach

### 1. Unified Verse 1 Check

Changed `ReaderTopActions` to check for verse 1 **before** any view type-specific logic. Now for ALL view types (Verse, Page, Juz, Hizb, Rub, Ranges), the component returns early if the first verse is verse 1:

```typescript
// Never show for verse 1 - ChapterHeader handles this for all view types
if (firstVerse.verseNumber === 1) return false;

// For all other cases (Verse, Page, Juz, Hizb, Rub, Ranges not at verse 1), show
return true;
```

This ensures:
- **Verse 1 (any view type):** Only `ChapterHeader` shows
- **Not verse 1 (non-chapter views):** Only `ReaderTopActions` shows  
- **Chapter views:** Only `ChapterHeader` shows (unchanged)

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Reading Mode Arabic - Verse 1 test:**
   - Navigate to `/en/al-fatihah` (chapter view, starts at verse 1)
   - Verify only `ChapterHeader` shows (with Bismillah, chapter name, mode switcher)
   - Verify `ReaderTopActions` does NOT appear above

2. **Reading Mode Translation - Verse 1 test:**
   - Switch to Reading Mode Translation
   - Navigate to a chapter that starts at verse 1
   - Verify only `ChapterHeader` shows, not `ReaderTopActions`

3. **Single Verse View - Verse 1 test:**
   - Navigate to `/en/al-fatihah/1` (single verse of verse 1)
   - Verify only `ChapterHeader` shows
   - Verify `ReaderTopActions` does NOT appear

4. **Single Verse View - Non-Verse 1 test:**
   - Navigate to `/en/al-fatihah/5` (single verse, not verse 1)
   - Verify `ReaderTopActions` DOES show (since no ChapterHeader)
   - Verify `ChapterHeader` does NOT appear

5. **Page/Juz view - Verse 1 test:**
   - Navigate to `/page/1` (starts at verse 1 of Al-Fatihah)
   - Verify only `ChapterHeader` shows for the first verse

### Edge Cases Verified

- [x] Reading Mode Arabic starting at verse 1
- [x] Reading Mode Translation starting at verse 1
- [x] Single verse view of verse 1
- [x] Single verse view of non-verse 1 (should still show ReaderTopActions)
- [x] Page view starting at verse 1

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [ ] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4669]: https://quranfoundation.atlassian.net/browse/QF-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ