### PR TITLE
fix(QF-4597): skip scrolling when at verse 1 in chapter views

### DIFF
--- a/src/components/QuranReader/ReadingView/hooks/useScrollToVirtualizedVerse.ts
+++ b/src/components/QuranReader/ReadingView/hooks/useScrollToVirtualizedVerse.ts
@@ -130,8 +130,8 @@ const useScrollToVirtualizedReadingView = (
       // if startingVerse is present in the url
       if (quranReaderDataType === QuranReaderDataType.Chapter && startingVerse) {
         const startingVerseNumber = Number(startingVerse);
-        // if the startingVerse is a valid integer and is above 1
-        if (Number.isInteger(startingVerseNumber) && startingVerseNumber > 0) {
+        // if the startingVerse is a valid integer and is above 1 (skip verse 1 since it's already at the top)
+        if (Number.isInteger(startingVerseNumber) && startingVerseNumber > 1) {
           scrollToVerse(startingVerseNumber, true);
         }
       }

--- a/src/components/QuranReader/TranslationView/hooks/useScrollToVirtualizedVerse.ts
+++ b/src/components/QuranReader/TranslationView/hooks/useScrollToVirtualizedVerse.ts
@@ -66,7 +66,12 @@ const useScrollToVirtualizedTranslationView = (
   // it scrolls to the beginning of the verse cell and we set `shouldReadjustScroll` to true so that the other effect
   // adjusts the scroll to the correct position
   useEffect(() => {
-    if (quranReaderDataType === QuranReaderDataType.Chapter && isValidStartingVerse) {
+    // Skip scrolling for verse 1 since it's already at the top position
+    if (
+      quranReaderDataType === QuranReaderDataType.Chapter &&
+      isValidStartingVerse &&
+      startingVerseNumber > 1
+    ) {
       scrollToBeginningOfVerseCell(startingVerseNumber);
       setShouldReadjustScroll(true);
     }
@@ -83,6 +88,8 @@ const useScrollToVirtualizedTranslationView = (
     if (
       quranReaderDataType === QuranReaderDataType.Chapter &&
       isValidStartingVerse &&
+      // Skip scrolling for verse 1 since it's already at the top position
+      startingVerseNumber > 1 &&
       // we only want to run this effect when the user navigates to a new verse
       // and not when the user is scrolling through the verses while apiPageToVersesMap is being populated
       shouldReadjustScroll


### PR DESCRIPTION
## Summary

Fixes unnecessary scrolling and UI jumpiness when switching reading modes while at verse 1 in chapter views.

Closes: [QF-4597](https://quranfoundation.atlassian.net/browse/QF-4597)

---

## Problems & Root Causes

### 1. Unnecessary Scroll at Verse 1

**Problem:** When switching reading modes (Translation ↔ Reading Arabic ↔ Reading Translation) while at the top of a chapter view (e.g., `/1`), the UI would experience unnecessary scrolling/jumpiness even though the ChapterHeader was visible and the user was already at the correct position.

**Root Cause:** When switching modes, `useReadingPreferenceSwitcher` sets `startingVerse=1` in the URL params. The scroll hooks (`useScrollToVirtualizedVerse`) in both ReadingView and TranslationView would then trigger scrolling to verse 1 - even though:
- Verse 1 is at index 0, the natural starting position of Virtuoso
- Chapter views already render starting at verse 1 by default
- Scrolling to where you already are causes visual jumpiness

**Example scenario:**
1. User navigates to `/1` (Surah Al-Fatiha)
2. ChapterHeader and verse 1 are visible at the top
3. User switches from Translation mode to Reading Arabic mode
4. URL updates to include `?startingVerse=1`
5. Scroll hook fires, causing unnecessary scroll animation to verse 1

---

## Solution Approach

### Skip Scrolling for Verse 1

Added a condition to skip scrolling when `startingVerse=1` since verse 1 is already at the top position by default.

**ReadingView** - Changed condition from `> 0` to `> 1`:
```typescript
if (Number.isInteger(startingVerseNumber) && startingVerseNumber > 1) {
  scrollToVerse(startingVerseNumber, true);
}
```

**TranslationView** - Added `startingVerseNumber > 1` check to both scroll effects to prevent triggering scroll logic when already at verse 1.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Mode switching at verse 1 (ChapterHeader visible):**
   - Navigate to any surah (e.g., `/1`)
   - While at verse 1 with ChapterHeader visible, switch between Translation, Reading Arabic, and Reading Translation modes
   - ✅ Verify NO scrolling occurs - the page should stay exactly where it is

2. **Mode switching at other verses:**
   - Navigate to a surah (e.g., `/1`) and scroll down to verse 10+
   - Switch modes
   - ✅ Verify scrolling still works correctly to maintain position at that verse

3. **Other view types (should still work):**
   - `/page/604` - mode switching should work as before
   - `/juz/30` - mode switching should work as before
   - `/1:5` - specific verse view should work as before

4. **Direct URL navigation:**
   - Navigate to `/1?startingVerse=1` - ✅ Verify no scrolling
   - Navigate to `/1?startingVerse=5` - ✅ Verify scrolling to verse 5 works

### Edge Cases Verified

- [x] Empty state handled
- [x] Loading state handled
- [x] Error state handled
- [ ] RTL layout verified (if UI changes) - N/A (no UI changes)
- [ ] Logged-in vs guest behavior (if auth-related) - N/A

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)

### Localization (if UI changes)

- [ ] All user-facing text uses `next-translate` - N/A
- [ ] RTL layout verified - N/A

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4597]: https://quranfoundation.atlassian.net/browse/QF-4597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ