### PR TITLE
Add Hydration Safeguard to VerseDisplay

### DIFF
--- a/src/components/Collection/CollectionDetail/VerseDisplay.tsx
+++ b/src/components/Collection/CollectionDetail/VerseDisplay.tsx
@@ -13,6 +13,7 @@ import TranslationText from '@/components/QuranReader/TranslationView/Translatio
 import VerseText from '@/components/Verse/VerseText';
 import Spinner, { SpinnerSize } from '@/dls/Spinner/Spinner';
 import useQcfFont from '@/hooks/useQcfFont';
+import { selectIsPersistGateHydrationComplete } from '@/redux/slices/persistGateHydration';
 import { selectQuranReaderStyles } from '@/redux/slices/QuranReader/styles';
 import { selectSelectedTranslations } from '@/redux/slices/QuranReader/translations';
 import { getDefaultWordFields, getMushafId } from '@/utils/api';
@@ -38,18 +39,21 @@ const VerseDisplay: React.FC<VerseDisplayProps> = ({ chapterId, verseNumber }) =
   const { quranFont, mushafLines } = quranReaderStyles;
   const { mushaf } = getMushafId(quranFont, mushafLines);
   const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual);
+  const isPersistGateHydrationComplete = useSelector(selectIsPersistGateHydrationComplete);
 
   const verseKey = makeVerseKey(chapterId, verseNumber);
 
-  const queryKey = makeByVerseKeyUrl(verseKey, {
-    words: true,
-    translationFields: 'resource_name,language_id',
-    translations: selectedTranslations.join(','),
-    ...getDefaultWordFields(quranReaderStyles.quranFont),
-    ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
-    wordTranslationLanguage: 'en',
-    wordTransliteration: 'true',
-  });
+  const queryKey = isPersistGateHydrationComplete
+    ? makeByVerseKeyUrl(verseKey, {
+        words: true,
+        translationFields: 'resource_name,language_id',
+        translations: selectedTranslations.join(','),
+        ...getDefaultWordFields(quranReaderStyles.quranFont),
+        ...getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines),
+        wordTranslationLanguage: 'en',
+        wordTransliteration: 'true',
+      })
+    : null;
 
   const {
     data: verseData,
@@ -100,7 +104,7 @@ const VerseDisplay: React.FC<VerseDisplayProps> = ({ chapterId, verseNumber }) =
         <div className={styles.arabicVerseContainer}>
           <VerseText words={getVerseWords(verse)} shouldShowH1ForSEO={false} />
         </div>
-        <div className={styles.verseTranslationsContainer}>
+        <div>
           {verse.translations?.map((translation: Translation) => (
             <div key={translation.id} className={styles.verseTranslationContainer}>
               <TranslationText

--- a/src/components/MyQuran/CollectionDetailView/CollectionDetailView.module.scss
+++ b/src/components/MyQuran/CollectionDetailView/CollectionDetailView.module.scss
@@ -66,7 +66,7 @@
   background: var(--color-success-faded);
   border: var(--spacing-hairline-px) solid var(--color-borders-hairline);
   border-radius: var(--border-radius-pill);
-  color: var(--color-bookmark-icon);
+  color: var(--color-text-link-new);
   font-size: var(--font-size-xsmall-px);
   font-weight: var(--font-weight-semibold);
   // Fade in with delay

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -39,7 +39,11 @@ const ProfilePage: FC = () => {
         noindex
       />
       <HeaderNavigation title={t('my-profile')} />
-      <PageContainer isSheetsLike className={styles.pageContainer}>
+      <PageContainer
+        isSheetsLike
+        wrapperClassName={styles.wrapperSheets}
+        className={styles.pageContainer}
+      >
         <div className={styles.topDivider}>
           <Separator />
         </div>

--- a/src/pages/profile/profile.module.scss
+++ b/src/pages/profile/profile.module.scss
@@ -1,8 +1,10 @@
 @use 'src/styles/breakpoints';
 
-div.pageContainer {
-  margin-block-end: 0;
-  padding-block-end: calc(var(--spacing-mega) * 2) !important;
+.wrapperSheets {
+  .pageContainer {
+    margin-block-end: 0;
+    padding-block-end: calc(var(--spacing-mega) * 2);
+  }
 }
 
 .wrapper {


### PR DESCRIPTION
## Summary

Added a hydration safeguard to the `VerseDisplay` component to ensure stable SWR query keys during Redux rehydration. This prevents potential cache inconsistencies by waiting for persist gate hydration to complete before fetching verse data.

## Changes

- **VerseDisplay.tsx**: Added `isPersistGateHydrationComplete` check to conditionally generate `queryKey`
- **CollectionDetailView.module.scss**: Updated badge text color to use `--color-text-link-new` variable
- **Profile page**: Updated PageContainer wrapper structure

## Test Plan

- [x] Verify verses load correctly in collection detail view
- [x] Test with different persisted settings (different fonts, mushaf lines, translations)
