### PR TITLE
fix: persist tajweed bar state across reading mode switches

### DIFF
--- a/src/components/QuranReader/TajweedBar/TajweedBar.tsx
+++ b/src/components/QuranReader/TajweedBar/TajweedBar.tsx
@@ -2,14 +2,21 @@ import { useEffect, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
-import { shallowEqual, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import styles from './TajweedBar.module.scss';
 
 import useThemeDetector from '@/hooks/useThemeDetector';
 import ChevronDownIcon from '@/icons/chevron-down.svg';
-import { selectContextMenu } from '@/redux/slices/QuranReader/contextMenu';
+import {
+  selectContextMenu,
+  selectIsTajweedBarExpanded,
+  setIsTajweedBarExpanded,
+} from '@/redux/slices/QuranReader/contextMenu';
 import { logEvent } from '@/utils/eventLogger';
+
+// Ensures bar starts off-screen before measurement to prevent flash on mount
+const DEFAULT_COLLAPSED_HEIGHT = 100;
 
 const TAJWEED_RULES = [
   'edgham',
@@ -24,16 +31,17 @@ const TAJWEED_RULES = [
 
 const TajweedColors = () => {
   const { t } = useTranslation('quran-reader');
-  const ref = useRef(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const dispatch = useDispatch();
 
-  const [showTajweedBar, setShowTajweedBar] = useState(false);
-  const [height, setHeight] = useState(0);
+  const [height, setHeight] = useState(DEFAULT_COLLAPSED_HEIGHT);
+  const showTajweedBar = useSelector(selectIsTajweedBarExpanded);
   const { isExpanded } = useSelector(selectContextMenu, shallowEqual);
 
   const { themeVariant } = useThemeDetector();
 
   const toggle = () => {
-    setShowTajweedBar((prevShowTajweedBar) => !prevShowTajweedBar);
+    dispatch(setIsTajweedBarExpanded(!showTajweedBar));
     if (showTajweedBar) {
       logEvent('tajweed_bar_closed');
     } else {
@@ -42,10 +50,10 @@ const TajweedColors = () => {
   };
 
   useEffect(() => {
-    if (ref.current) {
+    if (ref.current && ref.current.clientHeight > 0) {
       setHeight(ref.current.clientHeight);
     }
-  }, [ref.current?.clientHeight]);
+  }, []);
 
   return (
     <div

--- a/src/redux/slices/QuranReader/contextMenu.ts
+++ b/src/redux/slices/QuranReader/contextMenu.ts
@@ -6,9 +6,14 @@ import SliceName from '@/redux/types/SliceName';
 export type ContextMenu = {
   isExpanded: boolean;
   showReadingPreferenceSwitcher: boolean;
+  isTajweedBarExpanded: boolean;
 };
 
-const initialState: ContextMenu = { isExpanded: true, showReadingPreferenceSwitcher: false };
+const initialState: ContextMenu = {
+  isExpanded: true,
+  showReadingPreferenceSwitcher: false,
+  isTajweedBarExpanded: false,
+};
 
 export const contextMenuSlice = createSlice({
   name: SliceName.CONTEXT_MENU,
@@ -22,12 +27,19 @@ export const contextMenuSlice = createSlice({
       ...state,
       showReadingPreferenceSwitcher: action.payload,
     }),
+    setIsTajweedBarExpanded: (state: ContextMenu, action: PayloadAction<boolean>) => ({
+      ...state,
+      isTajweedBarExpanded: action.payload,
+    }),
   },
 });
 
-export const { setIsExpanded, setShowReadingPreferenceSwitcher } = contextMenuSlice.actions;
+export const { setIsExpanded, setShowReadingPreferenceSwitcher, setIsTajweedBarExpanded } =
+  contextMenuSlice.actions;
 
 export const selectContextMenu = (state: RootState) => state.contextMenu;
 export const selectIsExpanded = (state: RootState) => state.contextMenu.isExpanded;
+export const selectIsTajweedBarExpanded = (state: RootState) =>
+  state.contextMenu.isTajweedBarExpanded;
 
 export default contextMenuSlice.reducer;


### PR DESCRIPTION
## Summary

Fix the Tajweed bar collapsing unexpectedly when switching between Reading Mode - Translation and Reading Mode - Arabic.

---

## Problems & Root Causes

### 1. Tajweed Bar State Reset on Mode Switch

**Problem:** When switching from "Reading Mode - Translation" to "Reading Mode - Arabic", the Tajweed color bar would briefly expand and then collapse, even if the user had it collapsed before.

**Root Cause:** The `TajweedColors` component is conditionally rendered based on `!isTranslationMode`. When in "Reading Mode - Translation", the component unmounts entirely. When switching back to "Reading Mode - Arabic", the component remounts with its local `useState(false)` reset, causing the collapsed state to be lost.

**Example scenario:**
1. User is in Reading Mode - Arabic with Tajweed mushaf
2. User collapses the Tajweed color bar
3. User switches to Reading Mode - Translation (component unmounts)
4. User switches back to Reading Mode - Arabic (component remounts with state reset)
5. Bar shows a flash of expanded state then collapses

### 2. Flash of Expanded State on Mount

**Problem:** When the `TajweedColors` component mounts, users would see a brief flash where the bar appears expanded before collapsing.

**Root Cause:** The initial `height` state was `0`, so on first render `translateY(-0px)` = `translateY(0)` made the bar appear in expanded position. Only after the `useEffect` measured the actual height would it collapse to `translateY(-height)`.

---

## Solution Approach

### 1. Move State to Redux

Moved `showTajweedBar` state from local `useState` to the `contextMenu` Redux slice as `isTajweedBarExpanded`. This preserves the expanded/collapsed state when the component unmounts and remounts.

```typescript
// Before: Local state lost on unmount
const [showTajweedBar, setShowTajweedBar] = useState(false);

// After: Redux state persists across unmounts
const showTajweedBar = useSelector(selectIsTajweedBarExpanded);
dispatch(setIsTajweedBarExpanded(!showTajweedBar));
```

### 2. Set Default Height

Changed initial `height` from `0` to `100` so the bar starts off-screen on first render, preventing the visual flash.

```typescript
// Before: height=0 means translateY(0) = visible
const [height, setHeight] = useState(0);

// After: height=100 means translateY(-100) = hidden
const [height, setHeight] = useState(100);
```

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Tajweed bar state persistence test:**
   - Navigate to a Surah with Tajweed V4 mushaf enabled
   - Switch to "Reading Mode - Arabic"
   - Expand the Tajweed color bar
   - Switch to "Reading Mode - Translation"
   - Switch back to "Reading Mode - Arabic"
   - ✅ Verify the bar remains expanded

2. **Collapsed state persistence test:**
   - With Tajweed bar collapsed, switch between reading modes
   - ✅ Verify the bar stays collapsed without any flash

### Edge Cases Verified

- [x] Bar state persists when switching Reading Mode - Arabic ↔ Reading Mode - Translation
- [x] No visual flash on component mount
- [x] Toggle button still works correctly

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [ ] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code