### PR TITLE
fix: add proper RTL support for what-is-ramadan and about-the-quran pages

### DIFF
--- a/src/pages/about-the-quran/AboutTheQuranArabic.module.scss
+++ b/src/pages/about-the-quran/AboutTheQuranArabic.module.scss
@@ -1,5 +1,5 @@
 .arabicContainer {
-  text-align: end;
+  text-align: start;
 
   ol {
     list-style: decimal;

--- a/src/pages/about-the-quran/index.tsx
+++ b/src/pages/about-the-quran/index.tsx
@@ -18,9 +18,10 @@ import Button, { ButtonVariant } from '@/dls/Button/Button';
 import Link, { LinkVariant } from '@/dls/Link/Link';
 import { getAboutTheQuranImageUrl } from '@/lib/og';
 import { logButtonClick } from '@/utils/eventLogger';
-import { getLanguageAlternates } from '@/utils/locale';
+import { getDir, getLanguageAlternates } from '@/utils/locale';
 import { getCanonicalUrl } from '@/utils/navigation';
 import verse3829 from 'src/data/verses/verse3829';
+import Language from 'types/Language';
 
 const PATH = '/about-quran';
 const AboutQuranPage: NextPage = (): JSX.Element => {
@@ -44,10 +45,10 @@ const AboutQuranPage: NextPage = (): JSX.Element => {
         imageHeight={630}
       />
       <PageContainer>
-        {lang === 'ar' ? (
+        {lang === Language.AR ? (
           <AboutTheQuranArabic />
         ) : (
-          <div className={styles.contentPage} dir="ltr">
+          <div className={styles.contentPage} dir={getDir(lang)}>
             <div className={styles.section}>
               <h1>What is the Quran?</h1>
               <div>

--- a/src/pages/what-is-ramadan/WhatIsRamadanArabic.module.scss
+++ b/src/pages/what-is-ramadan/WhatIsRamadanArabic.module.scss
@@ -1,5 +1,5 @@
 .arabicContainer {
-  text-align: end;
+  text-align: start;
 
   ol {
     list-style: decimal;

--- a/src/pages/what-is-ramadan/index.tsx
+++ b/src/pages/what-is-ramadan/index.tsx
@@ -13,8 +13,9 @@ import InlineLink from '@/components/RamadanActivity/InlineLink';
 import { getWhatIsRamadanOgImageUrl } from '@/lib/og';
 import styles from '@/pages/contentPage.module.scss';
 import pageStyles from '@/pages/ramadan/RamadanActivities.module.scss';
-import { getLanguageAlternates } from '@/utils/locale';
+import { getDir, getLanguageAlternates } from '@/utils/locale';
 import { getCanonicalUrl, getWhatIsRamadanNavigationUrl } from '@/utils/navigation';
+import Language from 'types/Language';
 
 const PATH = getWhatIsRamadanNavigationUrl();
 const WhatIsRamadanPage: NextPage = (): JSX.Element => {
@@ -32,10 +33,10 @@ const WhatIsRamadanPage: NextPage = (): JSX.Element => {
         })}
       />
       <PageContainer>
-        {lang === 'ar' ? (
+        {lang === Language.AR ? (
           <WhatIsRamadanArabic />
         ) : (
-          <div className={classNames(pageStyles.container, styles.contentPage)} dir="ltr">
+          <div className={classNames(pageStyles.container, styles.contentPage)} dir={getDir(lang)}>
             <h1>Ramadan: A Journey of Reflection, Renewal, and Revelation.</h1>
             <div className={styles.subSection}>
               <h2>What is Ramadan?</h2>


### PR DESCRIPTION
## Summary

Add proper RTL (Right-to-Left) support for the what-is-ramadan and about-the-quran pages. Previously, these pages had hardcoded `dir="ltr"` which broke RTL layout for Farsi and Urdu users.

Closes: [QF-4112](https://quranfoundation.atlassian.net/browse/QF-4112)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. Navigate to `/ar/what-is-ramadan` → Verify Arabic content with RTL layout
2. Navigate to `/fa/what-is-ramadan` → Verify English content with RTL layout (right-aligned)
3. Navigate to `/ur/what-is-ramadan` → Verify English content with RTL layout (right-aligned)
4. Navigate to `/en/what-is-ramadan` → Verify English content with LTR layout (left-aligned)
5. Repeat steps 1-4 for `/about-the-quran`

### Edge Cases Verified

- [x] ⏳ Loading state handled
- [x] ❌ Error state handled
- [x] 📭 Empty state handled
- [ ] 👤 Logged-in vs guest behavior (if applicable)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] Only English locale files modified (Lokalise handles others)
- [x] RTL layout verified

### Accessibility (if UI changes)

- [x] Semantic HTML elements used
- [x] Keyboard navigation works

## Changes Made

1. **`src/pages/what-is-ramadan/index.tsx`** & **`src/pages/about-the-quran/index.tsx`**:
   - Use `Language.AR` enum instead of hardcoded `'ar'` string for type safety
   - Use `getDir(lang)` for dynamic direction instead of hardcoded `dir="ltr"`
   - Arabic locale → Arabic content, other locales → English content with proper direction

2. **`src/pages/what-is-ramadan/WhatIsRamadanArabic.module.scss`** & **`src/pages/about-the-quran/AboutTheQuranArabic.module.scss`**:
   - Fixed `text-align: end` to `text-align: start` for proper right-alignment in RTL context
   - In RTL: `start` = right (correct), `end` = left (incorrect)

## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4112]: https://quranfoundation.atlassian.net/browse/QF-4112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ