### PR TITLE
Wrap Chapter Header

### DIFF
--- a/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
+++ b/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
@@ -2,7 +2,6 @@
 @use 'src/styles/constants';
 @use 'src/styles/utility';
 
-$chapterHeaderContainerMaxInlineSize: 450px;
 $changeTranslationButtonInlineSize: 310px;
 $changeTranslationButtonInlineSizeMobile: 257px;
 $bismillahSvgInlineSizeMobile: 148px;
@@ -31,7 +30,6 @@ $bismillahSvgInlineSizeMobile: 148px;
   align-content: start;
   margin-inline: auto;
   inline-size: 100%;
-  max-inline-size: $chapterHeaderContainerMaxInlineSize;
   margin-block-start: constants.$reading-view-container-top-margin;
   margin-block-end: var(--spacing-medium2-px);
 
@@ -128,6 +126,7 @@ $bismillahSvgInlineSizeMobile: 148px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  row-gap: var(--spacing-xxsmall-px);
 
   @include breakpoints.smallerThanTablet {
     p {
@@ -137,9 +136,15 @@ $bismillahSvgInlineSizeMobile: 148px;
 }
 
 .titleRow {
-  display: flex;
-  align-items: center;
-  gap: calc(var(--spacing-small-px) / 2);
+  &,
+  .titleName {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing-small-px) / 2);
+  }
+
+  flex-direction: row-reverse;
+  flex-wrap: wrap;
 }
 
 .chapterTitle {
@@ -173,6 +178,7 @@ $bismillahSvgInlineSizeMobile: 148px;
   font-size: var(--font-size-xlarge);
   font-weight: var(--font-weight-medium);
   color: var(--color-text-faded-new);
+  line-height: 1;
   text-align: end;
 }
 
@@ -317,10 +323,9 @@ div {
 }
 
 .chapterIconContainer {
-  // a hack to center the surah name, because the font width is not correct
-  // leave a lot of empty space on the left
+  // a hack to make it visually aligned with the surah name
   /* stylelint-disable-next-line csstools/use-logical */
-  margin-right: 0.5rem;
+  margin-left: calc(var(--spacing-medium-plus-px) * -1);
 }
 
 .chapterEventWrapper {

--- a/src/components/chapters/ChapterHeader/components/ChapterTitle.tsx
+++ b/src/components/chapters/ChapterHeader/components/ChapterTitle.tsx
@@ -42,9 +42,11 @@ const ChapterTitle: React.FC<ChapterTitleProps> = ({
         {showTranslatedName && (
           <div className={styles.titleTextContainer}>
             <div className={styles.titleRow}>
+              <div className={styles.titleName}>
+                <p className={styles.transliteratedName}>{transliteratedName}</p>
+                <p className={styles.chapterNumber}>.{chapterId}</p>
+              </div>
               <SurahInfoButton chapterId={chapterId} />
-              <p className={styles.transliteratedName}>{transliteratedName}</p>
-              <p className={styles.chapterNumber}>.{chapterId}</p>
             </div>
             <p className={styles.translatedName}>{translatedName}</p>
           </div>


### PR DESCRIPTION
## Summary

- Fix chapter header overflow issue by allowing info icon to wrap to next line when there's insufficient horizontal space
- Improve layout structure and spacing consistency for chapter title elements
- Better visual alignment between chapter icon and chapter name
- Remove unnecessary max-width constraint to allow full-width responsive layout

## Changes

### Components Modified
- `src/components/chapters/ChapterHeader/components/ChapterTitle.tsx`
- `src/components/chapters/ChapterHeader/ChapterHeader.module.scss`

### Technical Details

1. **Info Icon Wrapping**
   - Added `flex-wrap: wrap` to `.titleRow` to prevent overflow on smaller screens
   - Info button now wraps to next line when horizontal space is limited

2. **Improved Structure**
   - Created new `.titleName` wrapper around transliterated name and chapter number
   - Better separation of concerns for layout control

3. **Layout Enhancements**
   - Added `row-gap` to `.titleTextContainer` for consistent vertical spacing
   - Added `line-height: 1` to `.translatedName` for better vertical alignment
   - Adjusted `.chapterIconContainer` margin using `calc()` for precise alignment
   - Removed 450px `max-inline-size` constraint from `.containerWrapper`

4. **RTL Support**
   - Added `flex-direction: row-reverse` to `.titleRow` for proper right-to-left layout

## Test Plan

- [x] Test on mobile devices to verify info icon wraps correctly when chapter names are long
- [x] Test in both RTL (Arabic/Urdu) and LTR languages
- [x] Verify visual alignment of chapter icon with chapter name
- [x] Check spacing consistency across different screen sizes (mobile, tablet, desktop)
- [x] Ensure no horizontal overflow occurs with long chapter names
- [x] Verify chapter header displays correctly for all chapters (especially those with long transliterated names)

### Before / After

| Before | After |
|--------|-------|
| <img width="567" height="272" alt="image" src="https://github.com/user-attachments/assets/24bdaa17-b537-4d7b-b684-514f2a1b5d37" /> | <img width="648" height="286" alt="image" src="https://github.com/user-attachments/assets/7d28fc06-9221-4516-97a6-c30b27924578" /> |
