### PR TITLE
fix(QF-4683): prevent reader crash on bookmark modal close in empty translation state

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationViewVerse/hooks/useDedupedFetchVerse.ts
+++ b/src/components/QuranReader/TranslationView/TranslationViewVerse/hooks/useDedupedFetchVerse.ts
@@ -168,12 +168,6 @@ const useDedupedFetchVerse = ({
 
   const verse = effectiveVerses ? effectiveVerses[idxInPage] : null;
 
-  // This part handles an edge case where the user has no selected translations but the `initialData` sent from server-side rendering has a default translation.
-  // So, we need to remove the translations from the verse if the user has no selected translations.
-  if (verse && selectedTranslations.length === 0) {
-    verse.translations = [];
-  }
-
   return {
     verse,
     firstVerseInPage: effectiveVerses ? effectiveVerses[0] : null,


### PR DESCRIPTION
## Summary

Fixes a reader crash that occurs when closing the bookmark modal in Reading-Translation mode with no translations selected.

Closes: [QF-4683](https://quranfoundation.atlassian.net/browse/QF-4683)

---

## Problem & Root Cause

**Problem:** When in Reading-Translation mode with no translations selected, bookmarking a verse and then closing the modal (by clicking outside) would cause the entire reader to crash with an error boundary.

**Root Cause:** In `useDedupedFetchVerse.ts`, there was direct mutation of a cached/shared verse object:

```typescript
if (verse && selectedTranslations.length === 0) {
  verse.translations = [];  // Direct mutation of SWR cache object
}
```

The `verse` object comes from either SWR cache or `initialData.verses` - both are shared references. Mutating `verse.translations = []` corrupted the cached data. When the bookmark modal closed and components re-rendered, downstream components failed due to the corrupted state.

**Example scenario:**
1. User is in Reading-Translation mode with no translations selected
2. User clicks on a verse to open bookmark modal
3. User bookmarks/unbookmarks the verse
4. User clicks outside the modal to close it
5. Components re-render with corrupted cached data → crash

---

## Solution

Removed the code that directly mutated the verse object. This mutation was redundant because the `shouldUseInitialData` logic already handles this case correctly:

- When user deselects all translations, `selectedTranslations = []`
- `isUsingDefaultSettings` returns `false` (user's `[]` differs from locale default)
- Therefore `shouldUseInitialData = false`, so SSR data is not used
- A fresh API call is made with empty translations, returning verses without translations

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Test Plan

**Testing steps:**

1. Navigate to any chapter (e.g., `/1`)
2. Switch to Reading-Translation mode via settings
3. Remove all selected translations
4. Click on a verse to open the bookmark modal
5. Bookmark the verse
6. Unbookmark the verse
7. Click outside the modal to close it
8. **Expected:** No crash, empty state message remains visible

## Pre-Review Checklist

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4683]: https://quranfoundation.atlassian.net/browse/QF-4683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ