### PR TITLE
[QF-4055]  Add Note-Taking Functionality to Pinned Verses

### DIFF
--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesContent.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesContent.tsx
@@ -23,6 +23,7 @@ interface PinnedVersesContentProps {
   onSaveToCollection: () => void;
   onLoadFromCollection: () => void;
   onCopy: () => void;
+  onAddNote?: () => void;
 }
 
 const PinnedVersesContent: React.FC<PinnedVersesContentProps> = ({
@@ -37,6 +38,7 @@ const PinnedVersesContent: React.FC<PinnedVersesContentProps> = ({
   onSaveToCollection,
   onLoadFromCollection,
   onCopy,
+  onAddNote,
 }) => {
   const { t } = useTranslation('quran-reader');
 
@@ -68,6 +70,7 @@ const PinnedVersesContent: React.FC<PinnedVersesContentProps> = ({
               onSaveToCollection={onSaveToCollection}
               onLoadFromCollection={onLoadFromCollection}
               onCopy={onCopy}
+              onAddNote={onAddNote}
             />
           </div>
         </div>

--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.tsx
@@ -10,6 +10,7 @@ import PopoverMenu from '@/dls/PopoverMenu/PopoverMenu';
 import CopyIcon from '@/icons/copy.svg';
 import FolderIcon from '@/icons/folder.svg';
 import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
+import NotesIcon from '@/icons/notes-with-pencil.svg';
 import TrashIcon from '@/icons/trash.svg';
 import BookmarkIcon from '@/icons/unbookmarked.svg';
 import { logButtonClick } from '@/utils/eventLogger';
@@ -19,6 +20,7 @@ interface PinnedVersesMenuProps {
   onSaveToCollection?: () => void;
   onLoadFromCollection?: () => void;
   onCopy?: () => void;
+  onAddNote?: () => void;
 }
 
 const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
@@ -26,6 +28,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
   onSaveToCollection,
   onLoadFromCollection,
   onCopy,
+  onAddNote,
 }) => {
   const { t } = useTranslation('quran-reader');
 
@@ -42,6 +45,11 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
   const handleCopy = () => {
     logButtonClick('pinned_menu_copy');
     onCopy?.();
+  };
+
+  const handleAddNote = () => {
+    logButtonClick('pinned_menu_add_note');
+    onAddNote?.();
   };
 
   const handleClear = () => {
@@ -81,6 +89,15 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
         className={menuStyles.menuItem}
       >
         <span className={menuStyles.menuItemText}>{t('load-from-collection')}</span>
+      </PopoverMenu.Item>
+
+      <PopoverMenu.Item
+        icon={<NotesIcon className={menuStyles.menuItemIcon} />}
+        onClick={handleAddNote}
+        shouldCloseMenuAfterClick
+        className={menuStyles.menuItem}
+      >
+        <span className={menuStyles.menuItemText}>{t('take-a-note')}</span>
       </PopoverMenu.Item>
 
       <PopoverMenu.Item

--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.tsx
@@ -13,7 +13,6 @@ import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 import NotesIcon from '@/icons/notes-with-pencil.svg';
 import TrashIcon from '@/icons/trash.svg';
 import BookmarkIcon from '@/icons/unbookmarked.svg';
-import { logButtonClick } from '@/utils/eventLogger';
 
 interface PinnedVersesMenuProps {
   onClear: () => void;
@@ -31,31 +30,6 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
   onAddNote,
 }) => {
   const { t } = useTranslation('quran-reader');
-
-  const handleSaveToCollection = () => {
-    logButtonClick('pinned_menu_save_to_collection');
-    onSaveToCollection?.();
-  };
-
-  const handleLoadFromCollection = () => {
-    logButtonClick('pinned_menu_load_from_collection');
-    onLoadFromCollection?.();
-  };
-
-  const handleCopy = () => {
-    logButtonClick('pinned_menu_copy');
-    onCopy?.();
-  };
-
-  const handleAddNote = () => {
-    logButtonClick('pinned_menu_add_note');
-    onAddNote?.();
-  };
-
-  const handleClear = () => {
-    logButtonClick('pinned_menu_clear_all');
-    onClear();
-  };
 
   return (
     <PopoverMenu
@@ -75,7 +49,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
     >
       <PopoverMenu.Item
         icon={<BookmarkIcon className={menuStyles.menuItemIcon} />}
-        onClick={handleSaveToCollection}
+        onClick={onSaveToCollection}
         shouldCloseMenuAfterClick
         className={menuStyles.menuItem}
       >
@@ -84,7 +58,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
 
       <PopoverMenu.Item
         icon={<FolderIcon className={menuStyles.menuItemIcon} />}
-        onClick={handleLoadFromCollection}
+        onClick={onLoadFromCollection}
         shouldCloseMenuAfterClick
         className={menuStyles.menuItem}
       >
@@ -93,7 +67,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
 
       <PopoverMenu.Item
         icon={<NotesIcon className={menuStyles.menuItemIcon} />}
-        onClick={handleAddNote}
+        onClick={onAddNote}
         shouldCloseMenuAfterClick
         className={menuStyles.menuItem}
       >
@@ -102,7 +76,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
 
       <PopoverMenu.Item
         icon={<CopyIcon className={menuStyles.menuItemIcon} />}
-        onClick={handleCopy}
+        onClick={onCopy}
         shouldCloseMenuAfterClick
         className={menuStyles.menuItem}
       >
@@ -111,7 +85,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
 
       <PopoverMenu.Item
         icon={<TrashIcon className={menuStyles.menuItemIcon} />}
-        onClick={handleClear}
+        onClick={onClear}
         shouldCloseMenuAfterClick
         className={menuStyles.menuItem}
       >

--- a/src/components/QuranReader/PinnedVersesBar/index.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/index.tsx
@@ -110,9 +110,10 @@ const PinnedVersesBar: React.FC = () => {
     logButtonClick('pinned_menu_add_note');
     if (!isLoggedIn()) {
       router.push(getLoginNavigationUrl(router.asPath));
-    } else {
-      setIsNoteModalOpen(true);
+      return;
     }
+
+    setIsNoteModalOpen(true);
   }, [router]);
 
   if (pinnedVerses.length === 0) return null;

--- a/src/components/QuranReader/PinnedVersesBar/index.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/index.tsx
@@ -135,14 +135,6 @@ const PinnedVersesBar: React.FC = () => {
         />
       </div>
 
-      <AddNoteModal
-        showRanges
-        isModalOpen={isNoteModalOpen}
-        onModalClose={() => setIsNoteModalOpen(false)}
-        onMyNotes={() => setIsNoteModalOpen(false)}
-        verseKeys={pinnedVerseKeys}
-      />
-
       {isLoggedIn() && (
         <>
           <SavePinnedToCollectionModal
@@ -152,6 +144,13 @@ const PinnedVersesBar: React.FC = () => {
           <LoadFromCollectionModal
             isOpen={isLoadModalOpen}
             onClose={() => setIsLoadModalOpen(false)}
+          />
+          <AddNoteModal
+            showRanges
+            isModalOpen={isNoteModalOpen}
+            onModalClose={() => setIsNoteModalOpen(false)}
+            onMyNotes={() => setIsNoteModalOpen(false)}
+            verseKeys={pinnedVerseKeys}
           />
         </>
       )}

--- a/src/components/QuranReader/PinnedVersesBar/index.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/index.tsx
@@ -11,6 +11,7 @@ import copyPinnedVerses from '../PinnedVerses/utils/copyPinnedVerses';
 import styles from './PinnedVersesBar.module.scss';
 import PinnedVersesContent from './PinnedVersesContent';
 
+import AddNoteModal from '@/components/Notes/modal/AddNoteModal';
 import DataContext from '@/contexts/DataContext';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
 import usePinnedVerseSync from '@/hooks/usePinnedVerseSync';
@@ -36,16 +37,12 @@ const PinnedVersesBar: React.FC = () => {
   const { unpinVerseWithSync, clearPinnedWithSync } = usePinnedVerseSync();
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
+  const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
 
   const handleCompareClick = useCallback(() => {
     logButtonClick('pinned_bar_compare');
     if (pinnedVerseKeys.length > 0) {
-      dispatch(
-        openStudyMode({
-          verseKey: pinnedVerseKeys[0],
-          showPinnedSection: true,
-        }),
-      );
+      dispatch(openStudyMode({ verseKey: pinnedVerseKeys[0], showPinnedSection: true }));
     }
   }, [dispatch, pinnedVerseKeys]);
 
@@ -61,12 +58,7 @@ const PinnedVersesBar: React.FC = () => {
   const handleCopy = useCallback(async () => {
     logButtonClick('pinned_menu_copy');
     try {
-      await copyPinnedVerses({
-        pinnedVerses,
-        lang,
-        chaptersData,
-        selectedTranslations,
-      });
+      await copyPinnedVerses({ pinnedVerses, lang, chaptersData, selectedTranslations });
       toast(t('common:copied'), { status: ToastStatus.Success });
     } catch {
       toast(t('common:error.general'), { status: ToastStatus.Error });
@@ -114,6 +106,15 @@ const PinnedVersesBar: React.FC = () => {
     setIsSaveModalOpen(true);
   }, [router]);
 
+  const handleAddNote = useCallback(() => {
+    logButtonClick('pinned_menu_add_note');
+    if (!isLoggedIn()) {
+      router.push(getLoginNavigationUrl(router.asPath));
+    } else {
+      setIsNoteModalOpen(true);
+    }
+  }, [router]);
+
   if (pinnedVerses.length === 0) return null;
 
   return (
@@ -130,19 +131,29 @@ const PinnedVersesBar: React.FC = () => {
           onSaveToCollection={handleSaveToCollection}
           onLoadFromCollection={handleLoadFromCollection}
           onCopy={handleCopy}
+          onAddNote={handleAddNote}
         />
       </div>
+
+      <AddNoteModal
+        showRanges
+        isModalOpen={isNoteModalOpen}
+        onModalClose={() => setIsNoteModalOpen(false)}
+        onMyNotes={() => setIsNoteModalOpen(false)}
+        verseKeys={pinnedVerseKeys}
+      />
+
       {isLoggedIn() && (
-        <SavePinnedToCollectionModal
-          isOpen={isSaveModalOpen}
-          onClose={() => setIsSaveModalOpen(false)}
-        />
-      )}
-      {isLoggedIn() && (
-        <LoadFromCollectionModal
-          isOpen={isLoadModalOpen}
-          onClose={() => setIsLoadModalOpen(false)}
-        />
+        <>
+          <SavePinnedToCollectionModal
+            isOpen={isSaveModalOpen}
+            onClose={() => setIsSaveModalOpen(false)}
+          />
+          <LoadFromCollectionModal
+            isOpen={isLoadModalOpen}
+            onClose={() => setIsLoadModalOpen(false)}
+          />
+        </>
       )}
     </>
   );

--- a/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/index.tsx
@@ -7,6 +7,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import styles from './PinnedVersesSection.module.scss';
 import usePinnedVerseHandlers from './usePinnedVerseHandlers';
 
+import AddNoteModal from '@/components/Notes/modal/AddNoteModal';
 import LoadFromCollectionModal from '@/components/QuranReader/PinnedVerses/LoadFromCollectionModal';
 import SavePinnedToCollectionModal from '@/components/QuranReader/PinnedVerses/SavePinnedToCollectionModal';
 import PinnedVersesContent from '@/components/QuranReader/PinnedVersesBar/PinnedVersesContent';
@@ -36,6 +37,7 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
 
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
+  const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
   const { unpinVerseWithSync, clearPinnedWithSync } = usePinnedVerseSync();
 
   const {
@@ -44,6 +46,7 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
     handleClear,
     handleSaveToCollection,
     handleLoadFromCollection,
+    handleAddNote,
     handleCopy,
   } = usePinnedVerseHandlers({
     pinnedVerses,
@@ -55,6 +58,7 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
     selectedTranslations,
     setIsSaveModalOpen,
     setIsLoadModalOpen,
+    setIsNoteModalOpen,
     unpinVerseWithSync,
     clearPinnedWithSync,
     onGoToVerse,
@@ -63,6 +67,12 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
   if (pinnedVerses.length === 0) {
     return null;
   }
+
+  const pinnedVerseKeys = pinnedVerses.map((v) => v.verseKey);
+
+  const handleNoteModalClose = () => {
+    setIsNoteModalOpen(false);
+  };
 
   return (
     <>
@@ -78,6 +88,7 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
           onSaveToCollection={handleSaveToCollection}
           onLoadFromCollection={handleLoadFromCollection}
           onCopy={handleCopy}
+          onAddNote={handleAddNote}
         />
       </div>
 
@@ -90,6 +101,13 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
           <LoadFromCollectionModal
             isOpen={isLoadModalOpen}
             onClose={() => setIsLoadModalOpen(false)}
+          />
+          <AddNoteModal
+            showRanges
+            isModalOpen={isNoteModalOpen}
+            onModalClose={handleNoteModalClose}
+            onMyNotes={handleNoteModalClose}
+            verseKeys={pinnedVerseKeys}
           />
         </>
       )}

--- a/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/usePinnedVerseHandlers.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/usePinnedVerseHandlers.ts
@@ -21,6 +21,7 @@ interface UsePinnedVerseHandlersProps {
   selectedTranslations: number[];
   setIsSaveModalOpen: (isOpen: boolean) => void;
   setIsLoadModalOpen: (isOpen: boolean) => void;
+  setIsNoteModalOpen: (isOpen: boolean) => void;
   unpinVerseWithSync: (verseKey: string) => Promise<void>;
   clearPinnedWithSync: () => Promise<void>;
   onGoToVerse: (chapterId: string, verseNumber: string) => void;
@@ -36,6 +37,7 @@ const usePinnedVerseHandlers = ({
   selectedTranslations,
   setIsSaveModalOpen,
   setIsLoadModalOpen,
+  setIsNoteModalOpen,
   unpinVerseWithSync,
   clearPinnedWithSync,
   onGoToVerse,
@@ -89,6 +91,15 @@ const usePinnedVerseHandlers = ({
     setIsLoadModalOpen(true);
   }, [router, setIsLoadModalOpen]);
 
+  const handleAddNote = useCallback(() => {
+    logButtonClick('study_mode_add_note');
+    if (!isLoggedIn()) {
+      router.push(getLoginNavigationUrl(router.asPath));
+      return;
+    }
+    setIsNoteModalOpen(true);
+  }, [router, setIsNoteModalOpen]);
+
   const handleCopy = useCallback(async () => {
     logButtonClick('study_mode_copy_pinned');
     try {
@@ -110,6 +121,7 @@ const usePinnedVerseHandlers = ({
     handleClear,
     handleSaveToCollection,
     handleLoadFromCollection,
+    handleAddNote,
     handleCopy,
   };
 };


### PR DESCRIPTION
## Summary

This PR adds the ability for users to create notes for their pinned verses. Users can now access the note-taking feature directly from the pinned verses bar menu and from the Study Mode pinned verses section.


Closes: [QF-4055](https://quranfoundation.atlassian.net/browse/QF-4055)

## Changes Made

### Core Functionality
- **Added "Take a note" menu item** to `PinnedVersesMenu` with a NotesIcon
- **Integrated AddNoteModal** in both `PinnedVersesBar` and `PinnedVersesSection` components
- **Added authentication checks** - redirects to login if user is not authenticated
- **Created handler functions** for opening the note modal with proper event logging

### Component Updates
1. **PinnedVersesContent.tsx**
   - Added `onAddNote` prop interface
   - Passed `onAddNote` through to `PinnedVersesMenu`

2. **PinnedVersesMenu.tsx**
   - Imported `NotesIcon` from `@/icons/notes-with-pencil.svg`
   - Added new menu item for "Take a note" action
   - Implemented `handleAddNote` with event logging

3. **PinnedVersesBar/index.tsx**
   - Added `isNoteModalOpen` state
   - Implemented `handleAddNote` with authentication check and navigation
   - Integrated `AddNoteModal` component with `verseKeys` prop
   - Refactored conditional rendering to group modals together

4. **PinnedVersesSection/index.tsx**
   - Added `isNoteModalOpen` state
   - Extracted `pinnedVerseKeys` for passing to modal
   - Integrated `AddNoteModal` component
   - Updated `usePinnedVerseHandlers` hook call with new parameters

5. **usePinnedVerseHandlers.ts**
   - Added `setIsNoteModalOpen` to hook parameters
   - Implemented `handleAddNote` function with authentication check
   - Added event logging for 'study_mode_add_note'

### Key Features
- Users can add notes to all pinned verses at once
- Proper authentication flow redirects unauthenticated users
- Event tracking for analytics (`pinned_menu_add_note`, `study_mode_add_note`)
- Modal uses `showRanges` prop to support multiple verse keys
- Consistent UX between PinnedVersesBar and Study Mode

## Test Plan
- [ ] Verify "Take a note" menu item appears in pinned verses menu
- [ ] Test authentication flow - unauthenticated users should be redirected to login
- [ ] Verify note modal opens when authenticated user clicks "Take a note"
- [ ] Test that all pinned verse keys are correctly passed to the modal
- [ ] Verify modal works from both PinnedVersesBar and Study Mode
- [ ] Check event logging for button clicks
- [ ] Test modal close functionality
- [ ] Verify notes are saved correctly for all pinned verses

## Technical Notes
- Reuses existing `AddNoteModal` component from `@/components/Notes/modal/AddNoteModal`
- Uses `showRanges` prop to handle multiple verse keys
- Follows existing patterns for modal state management (similar to Save/Load collection modals)
- Maintains consistency with existing menu item structure and styling


[QF-4055]: https://quranfoundation.atlassian.net/browse/QF-4055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ