### PR TITLE
Improve Pin Popover Menu Alignment and Accessibility

### DIFF
--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.module.scss
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.module.scss
@@ -1,18 +1,10 @@
 @use 'src/styles/breakpoints';
 
 .menuContent {
-  padding-inline: var(--spacing-medium-px);
-  padding-block-start: var(--spacing-medium-px);
-  padding-block-end: 0;
+  padding-block: var(--spacing-small-px);
   border-radius: var(--spacing-xxsmall-px);
-  box-shadow: var(--shadow-surah-search);
   min-inline-size: auto;
-  margin-inline-end: calc(1.2 * var(--spacing-mega));
   z-index: var(--z-index-modal);
-
-  @include breakpoints.smallerThanTablet {
-    margin-inline-end: var(--spacing-medium-px);
-  }
 }
 
 .menuItem {
@@ -21,13 +13,6 @@
   border: none;
   background: transparent;
   cursor: pointer;
-  padding: 0;
-  padding-block-end: var(--spacing-medium-px);
-
-  &:hover,
-  &:focus {
-    background: transparent;
-  }
 }
 
 .menuItemText {

--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.tsx
@@ -6,7 +6,7 @@ import styles from './PinnedVersesBar.module.scss';
 import menuStyles from './PinnedVersesMenu.module.scss';
 
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from '@/dls/Button/Button';
-import PopoverMenu from '@/dls/PopoverMenu/PopoverMenu';
+import PopoverMenu, { PopoverMenuAlign } from '@/dls/PopoverMenu/PopoverMenu';
 import CopyIcon from '@/icons/copy.svg';
 import FolderIcon from '@/icons/folder.svg';
 import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
@@ -34,6 +34,7 @@ const PinnedVersesMenu: React.FC<PinnedVersesMenuProps> = ({
   return (
     <PopoverMenu
       contentClassName={menuStyles.menuContent}
+      align={PopoverMenuAlign.END}
       trigger={
         <Button
           size={ButtonSize.Small}


### PR DESCRIPTION
## Summary

- Use `PopoverMenuAlign.END` prop to properly align the popover menu to the trigger button, removing the CSS margin hacks
- Restore hover and focus states on menu items to improve visual feedback and keyboard navigation
- Fix PopoverMenu Alignment on the study mode

## Changes

- Set `align={PopoverMenuAlign.END}` on PopoverMenu component for proper alignment
- Remove manual margin offsets that were used as alignment hacks
- Restore menu item hover/focus backgrounds for better UX
- Simplify padding and shadow styles to use PopoverMenu's defaults

## Test Plan

- Open pinned verses menu from the pinned verses bar
- Verify menu aligns properly to the end of the trigger button
- Test hover states show visual feedback on menu items
- Test keyboard navigation through menu items and verify focus indicators are visible
- Test on mobile and desktop viewport sizes

| Before | After |
|--------|-------|
| <img width="515" height="340" alt="image" src="https://github.com/user-attachments/assets/2c0b1cd8-502a-4e2b-8f90-9a16cabf9fa0" /> | <img width="472" height="339" alt="image" src="https://github.com/user-attachments/assets/990541d9-f4ba-4d6f-932b-1b44a6290e31" /> |
| <img width="394" height="356" alt="image" src="https://github.com/user-attachments/assets/57ffe8ab-074b-4e03-8e5e-fb4c537279e1" /> | <img width="500" height="403" alt="image" src="https://github.com/user-attachments/assets/95d5ca50-323a-463a-a87d-8a2124ee2975" /> |

