### PR TITLE
Fix: Header Text Overflow

### DIFF
--- a/src/components/Collection/CollectionDetailContainer/CollectionDetailContainer.module.scss
+++ b/src/components/Collection/CollectionDetailContainer/CollectionDetailContainer.module.scss
@@ -44,10 +44,15 @@ $max-inline-size: 670px;
 .wrapper {
   .backButton {
     font-size: var(--font-size-large2);
-    inline-size: max-content;
+    max-inline-size: 100%;
+    inline-size: auto;
     justify-content: flex-start;
     block-size: auto;
     margin: 0;
+    white-space: normal;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    text-align: start;
 
     @include breakpoints.tablet {
       font-size: var(--font-size-xlarge);


### PR DESCRIPTION
| Before | After |
|--------|-------|
| <img width="590" height="345" alt="image" src="https://github.com/user-attachments/assets/ebb7ce2c-ef20-48e5-a6ba-fe89270f9e07" /> | <img width="534" height="356" alt="image" src="https://github.com/user-attachments/assets/e4be282d-7ec9-4258-bbd2-2b5958b61112" /> |