### PR TITLE
fix(QF-4426): fix homepage hero background visible on overscroll

### DIFF
--- a/src/components/HomePage/HomePageHero.module.scss
+++ b/src/components/HomePage/HomePageHero.module.scss
@@ -3,6 +3,7 @@
 
 .outerContainer {
   position: relative;
+  overflow: hidden;
 }
 
 .backgroundImage {


### PR DESCRIPTION
## Summary

Fix homepage hero background SVG showing without its background color when overscrolling (pulling down) the page on macOS/iOS.

Closes: [QF-4426](https://quranfoundation.atlassian.net/browse/QF-4426)

---

## Problem & Root Cause

**Problem:** When a user pulls down (overscrolls) the homepage, the decorative Arabic calligraphy SVG becomes visible without its background color, creating a visual glitch.

**Root Cause:** The background SVG in `.backgroundImage` uses `transform: translateY(-40%)` to position it above the container for decorative effect. However, since the `.outerContainer` didn't have `overflow: hidden`, the translated SVG portion extending above the container bounds was visible during overscroll, but without the background color that normally sits behind it.

---

## Solution

Add `overflow: hidden` to `.outerContainer` to clip the background SVG at the container boundaries. This prevents the SVG from appearing in the overscroll area where it would be displayed without its background color.

```scss
.outerContainer {
  position: relative;
  overflow: hidden; // Added to clip SVG overflow
}
```

This approach was chosen over alternatives like:
- Extending the background upward (would require adjusting multiple elements)
- Changing overscroll-behavior (already set in global.scss, doesn't fully prevent visual bounce)
- Modifying body background (would affect other pages)

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Overscroll test:**
   - Navigate to the homepage (quran.com)
   - On macOS: Pull down the page (overscroll at the top)
   - On iOS: Pull down the page to trigger the bounce effect
   - **Expected:** Only the body background color is visible during overscroll, no floating calligraphy SVG

2. **Visual regression test:**
   - Verify the homepage hero looks the same as before during normal scrolling
   - Verify the decorative calligraphy pattern is still visible within the hero section

### Edge Cases Verified

- [x] Light theme verified
- [x] Dark theme verified (SVG is intentionally very subtle/hidden in dark mode)
- [x] Sepia theme verified

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code
- [x] My code follows the project style guidelines
- [x] No unused code or imports included

### Localization

- [x] N/A - No user-facing text changes

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4426]: https://quranfoundation.atlassian.net/browse/QF-4426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ