### PR TITLE
fix: check source exists before clearing destination in v4-fonts-update

### DIFF
--- a/scripts/v4-fonts-update.js
+++ b/scripts/v4-fonts-update.js
@@ -141,7 +141,13 @@ function main() {
       const sourcePath = path.join(sourceDirPath, format.sourceDir);
       const destPath = path.join(PROJECT_ROOT, mapping.destination, format.destDir);
 
-      // Clear existing files
+      // Check if source exists before clearing destination
+      if (!fs.existsSync(sourcePath)) {
+        console.log(`  ${format.destDir}: source not found - skipping (existing files preserved)`);
+        return;
+      }
+
+      // Clear existing files only after confirming source exists
       const removed = clearDirectory(destPath);
       totalRemoved += removed;
 
@@ -149,11 +155,7 @@ function main() {
       const result = copyFontFiles(sourcePath, destPath);
       totalCopied += result.copied;
 
-      if (result.notFound) {
-        console.log(`  ${format.destDir}: source not found`);
-      } else {
-        console.log(`  ${format.destDir}: removed ${removed}, copied ${result.copied}`);
-      }
+      console.log(`  ${format.destDir}: removed ${removed}, copied ${result.copied}`);
     });
   });
 


### PR DESCRIPTION
## Summary

Fix a potential issue in the v4-fonts-update script where destination font files could be wiped if a source format directory is missing.

Follow-up to: #2981

---

## Problem & Root Cause

**Problem:** If a source format subdirectory (e.g., `WOFF2`) is missing or incomplete when running the script, the existing destination fonts would be deleted and left empty.

**Root Cause:** The script called `clearDirectory(destPath)` before verifying that `sourcePath` exists. When the source was missing, the script would:
1. Delete all existing files in the destination
2. Attempt to copy from source
3. Log "source not found" — but the destination is now empty

This could silently wipe production font assets when the input set is partial.

---

## Solution

Move the source existence check **before** clearing the destination directory:

```javascript
// Check if source exists before clearing destination
if (!fs.existsSync(sourcePath)) {
  console.log(`  ${format.destDir}: source not found - skipping (existing files preserved)`);
  return;
}

// Clear existing files only after confirming source exists
const removed = clearDirectory(destPath);
```

Now if a source format is missing, the script:
1. Logs that the source was not found
2. Preserves existing destination files
3. Continues to the next format

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. Run script with complete source directory - all formats should update normally
2. Run script with missing format (e.g., remove WOFF2 folder) - existing WOFF2 files should be preserved, other formats update

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code
- [x] My code follows the project style guidelines
- [x] No unused code or imports included

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code