### PR TITLE
QF-4205 - Made translation and arabic search result text not justified anymore

### DIFF
--- a/src/components/Search/SearchResults/SearchResultItem/SearchResultText.module.scss
+++ b/src/components/Search/SearchResults/SearchResultItem/SearchResultText.module.scss
@@ -44,7 +44,7 @@
 }
 
 .translationColumn {
-  text-align: justify;
+  text-align: start;
   text-align-last: start;
   box-sizing: border-box;
   padding-inline-end: 0;
@@ -52,7 +52,7 @@
 }
 
 .arabicColumn {
-  text-align: justify;
+  text-align: start;
   block-size: 100%;
   box-sizing: border-box;
   padding-inline-end: 0;


### PR DESCRIPTION
 Made translation and arabic search result text not justified anymore :  
<img width="862" height="653" alt="image" src="https://github.com/user-attachments/assets/a5c8ca45-5623-483e-9561-3f008b453d1d" />
<img width="867" height="462" alt="image" src="https://github.com/user-attachments/assets/d65a8cd1-482b-4565-a78d-c6c89074c1f2" />
