### PR TITLE
fix(QF-4426): fix homepage hero background visible on overscroll

### DIFF
--- a/src/components/HomePage/HomePageHero.module.scss
+++ b/src/components/HomePage/HomePageHero.module.scss
@@ -9,6 +9,7 @@
   position: absolute;
   z-index: -1;
   inset: 0;
+  overflow: hidden;
   background-color: var(--color-search-background);
 
   svg {


### PR DESCRIPTION
## Summary

Fix homepage hero background SVG showing without its background color when overscrolling (pulling down) the page on macOS/iOS.

Closes: [QF-4426](https://quranfoundation.atlassian.net/browse/QF-4426)

---

## Problem & Root Cause

**Problem:** When a user pulls down (overscrolls) the homepage, the decorative Arabic calligraphy SVG becomes visible without its background color, creating a visual glitch.

**Root Cause:** The background SVG in `.backgroundImage` uses `transform: translateY(-40%)` to position it above the container for decorative effect. The translated SVG portion extending above the container bounds was visible during overscroll, but without the background color that normally sits behind it.

---

## Solution

Add `overflow: hidden` to `.backgroundImage` (not `.outerContainer`) to clip the background SVG at the container boundaries.

```scss
.backgroundImage {
  position: absolute;
  z-index: -1;
  inset: 0;
  overflow: hidden; // Added - clips SVG without affecting search popup
  background-color: var(--color-search-background);
  // ...
}
```

This approach was chosen because:
- Clips only the background element, not the entire container
- Search popup (in sibling `.innerContainer`) is unaffected
- Minimal change with no side effects

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **Overscroll test:**
   - Navigate to the homepage (quran.com)
   - On macOS: Pull down the page (overscroll at the top)
   - On iOS: Pull down the page to trigger the bounce effect
   - **Expected:** Only the body background color is visible during overscroll, no floating calligraphy SVG

2. **Search popup regression test:**
   - Click on the search input
   - Type a search query
   - **Expected:** Search dropdown appears and is fully visible (not clipped)

3. **Visual regression test:**
   - Verify the homepage hero looks the same as before during normal scrolling
   - Verify the decorative calligraphy pattern is still visible within the hero section

### Edge Cases Verified

- [x] Light theme verified
- [x] Dark theme verified
- [x] Search popup not clipped

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code
- [x] My code follows the project style guidelines
- [x] No unused code or imports included

### Localization

- [x] N/A - No user-facing text changes

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4426]: https://quranfoundation.atlassian.net/browse/QF-4426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ