### PR TITLE
[QF-4664] fix: WBW tooltip and highlight not triggering when hovering on translation/transliteration text 

### DIFF
--- a/src/components/dls/InlineWordByWord/InlineWordByWord.module.scss
+++ b/src/components/dls/InlineWordByWord/InlineWordByWord.module.scss
@@ -1,6 +1,8 @@
 @use 'src/styles/breakpoints';
 
 .word {
+  // display as block so it appears on its own line below the word
+  display: block;
   /**
         This is needed for when the translation/transliteration content
         is too big to be fit into one line on mobile

--- a/src/components/dls/InlineWordByWord/index.tsx
+++ b/src/components/dls/InlineWordByWord/index.tsx
@@ -25,12 +25,12 @@ const InlineWordByWord: React.FC<Props> = ({ text, className }) => {
   const wordByWordFontScale = useSelector(selectWordByWordFontScale, shallowEqual);
 
   return (
-    <p
+    <span
       className={classNames(styles.word, className, FONT_SIZE_CLASS_MAP[wordByWordFontScale])}
       dir="auto"
     >
       {text}
-    </p>
+    </span>
   );
 };
 

--- a/src/components/dls/QuranWord/QuranWord.module.scss
+++ b/src/components/dls/QuranWord/QuranWord.module.scss
@@ -18,6 +18,11 @@
 
 .wbwContainer {
   text-align: center;
+}
+
+.wbwContent {
+  display: inline-block;
+  vertical-align: top;
   padding-block-start: var(--spacing-micro);
   padding-block-end: var(--spacing-micro);
   padding-inline-start: var(--spacing-micro);

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -369,7 +369,7 @@ const QuranWord = ({
           return <>{children}</>;
         }}
       >
-        <>
+        <span className={styles.wbwContent}>
           {wordText}
           {isWordByWordAllowed && (
             <>
@@ -379,7 +379,7 @@ const QuranWord = ({
               {showWordByWordTranslation && <InlineWordByWord text={word.translation?.text} />}
             </>
           )}
-        </>
+        </span>
       </Wrapper>
     </div>
   );


### PR DESCRIPTION
## Summary                  

  Fix Word-by-Word (WBW) hover behavior when both "on hover" and "below word" options are enabled. Previously, hovering on the translation/transliteration text below the word would not highlight the word or show the tooltip.
                                                                                                                                        
  Closes: [QF-4664](https://quranfoundation.atlassian.net/browse/QF-4664)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
        expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations
  - [ ] Rollback requires special steps (describe below):

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Open any surah
  2. Go to Settings > Word by Word section
  3. Enable "Translation" or "Transliteration" under "On Hover" section
  4. Enable "Translation" or "Transliteration" under "Below Word" section
  5. Hover on the translation/transliteration text displayed below any word
  6. Verify the word is highlighted and the tooltip appears
  7. Disable the "On Hover" options and verify hovering on translation/transliteration text still highlights the word

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled
  - [x] ❌ Error state handled
  - [x] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [x] Inline comments added for complex logic

  ### Localization (if UI changes)

  - [x] All user-facing text uses `next-translate`
  - [x] Only English locale files modified (Lokalise handles others)
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] ARIA attributes added where needed
  - [x] Keyboard navigation works

  ## Related PRs

  N/A

  ## Reviewer Notes

  The fix moves the `InlineWordByWord` components inside the `Wrapper` component so they become part of the tooltip trigger area. This
  ensures that hovering on the translation/transliteration text triggers both the highlight and tooltip, matching the behavior when
  hovering on the Arabic word itself.

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4664]: https://quranfoundation.atlassian.net/browse/QF-4664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ