### PR TITLE
 fix: handle null values in repeat settings from backend

### DIFF
--- a/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.helpers.test.ts
+++ b/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.helpers.test.ts
@@ -16,6 +16,10 @@ describe('RepeatAudioModal.helpers', () => {
       expect(fromPersistedValue(undefined, 5)).toBe(5);
     });
 
+    it('should return fallback when value is null (from backend when Infinity was stored)', () => {
+      expect(fromPersistedValue(null, 5)).toBe(5);
+    });
+
     it('should convert REPEAT_INFINITY (-1) to Infinity', () => {
       expect(fromPersistedValue(REPEAT_INFINITY, 2)).toBe(Infinity);
     });

--- a/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.helpers.ts
+++ b/src/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal.helpers.ts
@@ -5,12 +5,12 @@ import { getChapterNumberFromKey, getVerseNumberFromKey } from '@/utils/verse';
  * Convert a persisted value (where -1 = Infinity) to the runtime value.
  * Used when reading from Redux/backend.
  *
- * @param {number | undefined} value - The persisted value (may be -1 for Infinity).
- * @param {number} fallback - The fallback value if value is undefined.
+ * @param {number | undefined | null} value - The persisted value (may be -1 for Infinity, null from backend when Infinity was stored).
+ * @param {number} fallback - The fallback value if value is null or undefined.
  * @returns {number} The runtime numeric value (with Infinity restored if needed).
  */
-export const fromPersistedValue = (value: number | undefined, fallback: number): number => {
-  if (value === undefined) return fallback;
+export const fromPersistedValue = (value: number | undefined | null, fallback: number): number => {
+  if (value === null || value === undefined) return fallback;
   if (value === REPEAT_INFINITY) return Infinity;
   return value;
 };


### PR DESCRIPTION
  ## Summary                                                

  Fix `fromPersistedValue` to handle `null` values returned from the backend API. When users set repeat settings to
  infinity (∞) before 2 days ago, the backend stored these as `null` (since JSON cannot represent `Infinity`). The
  current implementation crashes when loading these `null` values.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Log in as a user who previously set repeat settings to ∞ (infinity) before 2 days
  2. Navigate to any Surah (e.g., `/1`)
  3. Open the repeat audio modal
  4. Verify the modal opens without crashing and displays default values instead of `null`

  **Reproduction steps (before fix):**
  1. Backend returns `{"repeatRange": null, "repeatEachVerse": null}` for users with old infinity settings
  2. `fromPersistedValue(null, 2)` returns `null` instead of the fallback
  3. Modal crashes when trying to use `null` as a number

  ### Edge Cases Verified

  - [ ] ⏳ Loading state handled
  - [x] ❌ Error state handled
  - [ ] 📭 Empty state handled
  - [x] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [x] All tests pass locally (`yarn test`)
  - [x] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [x] Inline comments added for complex logic

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
