### PR TITLE
Localize the "Read on Quran.com" text

### DIFF
--- a/docs/embed-widget.md
+++ b/docs/embed-widget.md
@@ -195,8 +195,8 @@ Notes:
 ## Localization
 
 Widget labels are localized via `next-translate` in the embed page. The builder locale list is
-derived from `i18n.json`. The header now uses a `quran` label from `quran-reader` (`q-and-a.quran`).
-Action labels include separate `reflections` and `lessons` keys.
+derived from `i18n.json`. The header link text ("Read on Quran.com") uses
+`embed:widget.readOnQuran`. Action labels include separate `reflections` and `lessons` keys.
 
 If you add new labels:
 

--- a/locales/en/embed.json
+++ b/locales/en/embed.json
@@ -78,5 +78,8 @@
   "translations": {
     "chipRemoveLabel": "Remove translation",
     "otherLanguage": "Other"
+  },
+  "widget": {
+    "readOnQuran": "Read on Quran.com"
   }
 }

--- a/src/components/AyahWidget/WidgetHeader.tsx
+++ b/src/components/AyahWidget/WidgetHeader.tsx
@@ -83,7 +83,7 @@ const WidgetHeader = ({ verse, options, colors }: Props): JSX.Element => {
   const verseCaptionUrl = options.rangeEnd
     ? `${verse.chapterId}:${verse.verseNumber}-${options.rangeEnd}`
     : verseCaption;
-  const siteLinkLabel = 'Read on Quran.com';
+  const siteLinkLabel = options.labels?.readOnQuran || 'Read on Quran.com';
 
   // Labels with defaults
   const surahLabel = options.labels?.surah || 'Surah';

--- a/src/components/AyahWidget/getAyahWidgetData.ts
+++ b/src/components/AyahWidget/getAyahWidgetData.ts
@@ -484,9 +484,11 @@ const resolveAnswersMeta = async (
 const loadWidgetLabels = async (locale: string): Promise<WidgetLabels> => {
   const tCommon = await getT(locale, 'common');
   const tQuranReader = await getT(locale, 'quran-reader');
+  const tEmbed = await getT(locale, 'embed');
 
   return {
     quran: tQuranReader('q-and-a.quran'),
+    readOnQuran: tEmbed('widget.readOnQuran'),
     surah: tCommon('surah'),
     verse: tCommon('verse'),
     tafsirs: tQuranReader('tafsirs'),

--- a/types/Embed.ts
+++ b/types/Embed.ts
@@ -132,6 +132,7 @@ export type WidgetColors = {
 
 export type WidgetLabels = {
   quran: string;
+  readOnQuran: string;
   surah: string;
   verse: string;
   tafsirs: string;


### PR DESCRIPTION
Localize the "Read on Quran.com" label on the widget

<img width="832" height="427" alt="image" src="https://github.com/user-attachments/assets/faa24484-2e40-4658-9031-15969a399654" />
<img width="830" height="426" alt="image" src="https://github.com/user-attachments/assets/bcfbd92e-b9d0-431c-8d2d-85f789ded854" />
