### PR TITLE
fix(QF-4737): squash PinnedVersesBar and TajweedBar with sidebar navigation on desktop

### DIFF
--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesBar.module.scss
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesBar.module.scss
@@ -6,6 +6,14 @@
   inline-size: 100%;
   background: var(--color-background-elevated);
   border: var(--spacing-micro-px) solid var(--color-separators-new);
+  transition: margin-inline-start var(--transition-regular), inline-size var(--transition-regular);
+}
+
+.withSidebarNavigation {
+  @include breakpoints.tablet {
+    margin-inline-start: calc(10 * var(--spacing-mega));
+    inline-size: calc(100% - calc(10 * var(--spacing-mega)));
+  }
 }
 
 .barContent {

--- a/src/components/QuranReader/PinnedVersesBar/index.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 
+import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
@@ -16,6 +17,7 @@ import DataContext from '@/contexts/DataContext';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
 import usePinnedVerseSync from '@/hooks/usePinnedVerseSync';
 import { selectPinnedVerses, selectPinnedVerseKeys } from '@/redux/slices/QuranReader/pinnedVerses';
+import { selectIsSidebarNavigationVisible } from '@/redux/slices/QuranReader/sidebarNavigation';
 import { openStudyMode } from '@/redux/slices/QuranReader/studyMode';
 import { selectSelectedTranslations } from '@/redux/slices/QuranReader/translations';
 import ChaptersData from '@/types/ChaptersData';
@@ -33,6 +35,7 @@ const PinnedVersesBar: React.FC = () => {
   const pinnedVerses = useSelector(selectPinnedVerses, shallowEqual);
   const pinnedVerseKeys = useSelector(selectPinnedVerseKeys, shallowEqual);
   const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual) as number[];
+  const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
 
   const { unpinVerseWithSync, clearPinnedWithSync } = usePinnedVerseSync();
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
@@ -121,7 +124,11 @@ const PinnedVersesBar: React.FC = () => {
 
   return (
     <>
-      <div className={styles.container}>
+      <div
+        className={classNames(styles.container, {
+          [styles.withSidebarNavigation]: isSidebarNavigationVisible,
+        })}
+      >
         <PinnedVersesContent
           pinnedVerses={pinnedVerses}
           selectedVerseKey={null}

--- a/src/components/QuranReader/TajweedBar/TajweedBar.module.scss
+++ b/src/components/QuranReader/TajweedBar/TajweedBar.module.scss
@@ -19,6 +19,13 @@ $pixel: 1px;
   z-index: var(--z-index-min);
 }
 
+.withSidebarNavigation {
+  @include breakpoints.tablet {
+    margin-inline-start: calc(10 * var(--spacing-mega));
+    inline-size: calc(100% - calc(10 * var(--spacing-mega)));
+  }
+}
+
 .hiddenContainer {
   transform: translateY(calc(-100% + var(--tajweed-trigger-height)));
 }

--- a/src/components/QuranReader/TajweedBar/TajweedBar.tsx
+++ b/src/components/QuranReader/TajweedBar/TajweedBar.tsx
@@ -12,6 +12,7 @@ import {
   selectIsTajweedBarExpanded,
   setIsTajweedBarExpanded,
 } from '@/redux/slices/QuranReader/contextMenu';
+import { selectIsSidebarNavigationVisible } from '@/redux/slices/QuranReader/sidebarNavigation';
 import { logEvent } from '@/utils/eventLogger';
 
 // Ensures bar starts off-screen before measurement to prevent flash on mount
@@ -32,6 +33,7 @@ const TajweedColors = () => {
   const dispatch = useDispatch();
 
   const showTajweedBar = useSelector(selectIsTajweedBarExpanded);
+  const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
 
   const { themeVariant } = useThemeDetector();
 
@@ -48,6 +50,7 @@ const TajweedColors = () => {
     <div
       className={classNames(styles.container, {
         [styles.hiddenContainer]: !showTajweedBar,
+        [styles.withSidebarNavigation]: isSidebarNavigationVisible,
       })}
     >
       <div


### PR DESCRIPTION
## Summary

Fixes PinnedVersesBar and TajweedBar to properly squash when the sidebar navigation drawer opens on desktop, matching the behavior of the QuranReader content container.

Closes: [QF-4737](https://quranfoundation.atlassian.net/browse/QF-4737)

---

## Problems & Root Causes

### 1. PinnedVersesBar and TajweedBar don't squash when sidebar opens

**Problem:** When the surah side drawer opens on desktop, the QuranReader content squashes to make room via `margin-inline-start`, but the PinnedVersesBar and TajweedBar (rendered inside the ContextMenu) stay at full viewport width, creating a visual inconsistency.

**Root Cause:** The QuranReader container applies `.withSidebarNavigationOpenOrAuto` class which adds `margin-inline-start: calc(10 * var(--spacing-mega))` on tablet+. However, neither PinnedVersesBar nor TajweedBar had any equivalent offset — they remained at `inline-size: 100%` regardless of sidebar state.

---

## Solution Approach

### 1. Add sidebar-aware CSS class to both components

Added a `.withSidebarNavigation` class to both PinnedVersesBar and TajweedBar SCSS modules that applies the same sidebar offset on tablet+ breakpoint:

```scss
.withSidebarNavigation {
  @include breakpoints.tablet {
    margin-inline-start: calc(10 * var(--spacing-mega));
    inline-size: calc(100% - calc(10 * var(--spacing-mega)));
  }
}
```

### 2. Connect components to sidebar Redux state

Both components now read `selectIsSidebarNavigationVisible` from Redux and conditionally apply the `.withSidebarNavigation` class. PinnedVersesBar also adds a transition for `margin-inline-start` and `inline-size` for smooth animation. TajweedBar already had `transition: var(--transition-regular)` on its container.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [x] Manual testing performed

**Testing steps:**

1. **PinnedVersesBar test:**
   - Open a surah page on desktop (e.g. `/al-fatihah`)
   - Pin a verse to make the PinnedVersesBar visible
   - Toggle the sidebar navigation open → verify the bar squashes with the reader content
   - Close the sidebar → verify smooth transition back to full width

2. **TajweedBar test:**
   - Switch to Tajweed mushaf in settings
   - Verify the TajweedBar squashes when sidebar opens
   - Toggle the tajweed color bar expanded/collapsed with sidebar open

3. **RTL test:**
   - Switch to Arabic locale, verify `margin-inline-start` works correctly in RTL direction

### Edge Cases Verified

- [x] RTL layout verified

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used
- [x] No unused code, imports, or dead code included

### Localization (if UI changes)

- [x] RTL layout verified

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4737]: https://quranfoundation.atlassian.net/browse/QF-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ