### PR TITLE
fix(study-mode): prevent stale answers data when switching verses in SSR modal    

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeSsrContainer.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeSsrContainer.tsx
@@ -102,6 +102,10 @@ const StudyModeSsrContainer: React.FC<StudyModeSsrContainerProps> = ({
       StudyModeTabId.RELATED_VERSES,
     ].includes(activeContentTab);
 
+  const isInitialVerse =
+    verseNav.selectedChapterId === initialChapterId &&
+    verseNav.selectedVerseNumber === initialVerseNumber;
+
   if (!chaptersData || !initialChapterId || !initialVerseNumber) return null;
 
   return (
@@ -132,8 +136,8 @@ const StudyModeSsrContainer: React.FC<StudyModeSsrContainerProps> = ({
       canNavigateWordNext={wordNav.canNavigateWordNext}
       activeContentTab={activeContentTab}
       onTabChange={events.handleTabChange}
-      questionId={questionId}
-      questionsInitialData={questionsInitialData}
+      questionId={isInitialVerse ? questionId : undefined}
+      questionsInitialData={isInitialVerse ? questionsInitialData : undefined}
       isContentTabActive={isContentTabActive}
       tafsirIdOrSlug={tafsirIdOrSlug}
     />


### PR DESCRIPTION
## Summary                                                                                                                  
                                                                
  Fix SSR study modal answers tab showing stale data from the initial verse when navigating to a different verse. When loading
   a direct URL like `/2:4/answers` and switching to another verse, the answers from verse 2:4 persisted instead of fetching  
  the new verse's answers.

  Root cause: `StudyModeSsrContainer` unconditionally passed `questionsInitialData` (from SSR props) to the answers tab
  regardless of the currently selected verse. This stale data was used as `fallbackData` in SWR, preventing fresh fetches.

  Fix: Only pass `questionsInitialData` and `questionId` when the selected verse matches the initial SSR verse. This follows
  the same pattern already used by `useStudyModeVerseData` for verse data.

  Closes: [QF-4736](https://quranfoundation.atlassian.net/browse/QF-4736)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
        expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations
  - [ ] Rollback requires special steps (describe below):

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Navigate directly to `/2:4/answers` — answers for 2:4 should load instantly from SSR
  2. Switch to a different verse (e.g., 2:5) that has answers — should fetch and display 2:5's answers, not 2:4's
  3. Switch back to verse 2:4 — should show 2:4's answers (from SWR cache or re-fetch)
  4. Navigate directly to `/2:4/answers/[questionId]` — the specific question should auto-expand on initial load, but not
  after switching verses
  5. Open the normal (client-side) study modal and switch between verses with answers — should continue working as before

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled
  - [x] ❌ Error state handled
  - [x] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming

  ## Reviewer Notes

  The fix is a 3-line addition to `StudyModeSsrContainer.tsx`. It adds an `isInitialVerse` check (comparing current selected
  verse to the SSR initial verse) and conditionally passes `questionsInitialData`/`questionId` only when they match. This
  mirrors the existing pattern in `useStudyModeVerseData` which already does the same check for SSR verse data.

  The normal (client-side) modal is unaffected — it never passes `questionsInitialData` at all.

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4736]: https://quranfoundation.atlassian.net/browse/QF-4736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ