### PR TITLE
Fix Chapter Header Spacing

### DIFF
--- a/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
+++ b/src/components/chapters/ChapterHeader/ChapterHeader.module.scss
@@ -159,7 +159,7 @@ $bismillahSvgInlineSizeMobile: 148px;
 
 .chapterTitleWithTranslationName {
   justify-content: center;
-  column-gap: var(--spacing-small-px);
+  column-gap: var(--spacing-medium2-px);
 }
 
 .chapterNumber {
@@ -216,7 +216,7 @@ $bismillahSvgInlineSizeMobile: 148px;
 
 .infoIconButtonWithSurahName {
   align-self: center;
-  margin-inline-end: var(--spacing-xxsmall-px);
+  margin-inline-end: var(--spacing-medium-px);
 }
 
 .arabicSurahNameContainer {
@@ -341,6 +341,10 @@ div {
   // a hack to make it visually aligned with the surah name
   /* stylelint-disable-next-line csstools/use-logical */
   margin-left: calc(var(--spacing-medium-plus-px) * -1);
+
+  // add extra space to right to fix overlap, (calligraphy is off sometime)
+  /* stylelint-disable-next-line csstools/use-logical */
+  margin-right: var(--spacing-xxsmall-px);
 }
 
 .chapterEventWrapper {


### PR DESCRIPTION
## Summary
- Updated spacing in ChapterHeader component for improved layout consistency
- Increased gap between chapter title and translation name from `--spacing-small-px` to `--spacing-medium2-px`
- Increased margin for info icon button from `--spacing-xxsmall-px` to `--spacing-medium-px`
- Added extra spacing to surah name container for better visual alignment

## Changes
- `src/components/chapters/ChapterHeader/ChapterHeader.module.scss`
  - `.chapterTitleWithTranslationName`: increased column-gap
  - `.infoIconButtonWithSurahName`: increased margin-inline-end
  - `.arabicSurahNameContainer`: added extra left margin for alignment

## Test plan
- [x] Verify chapter header displays correctly on desktop
- [x] Verify chapter header displays correctly on mobile
- [x] Check alignment of surah name with info icon button
- [x] Verify spacing between chapter title and translation name looks balanced



| Before | After |
|-----------|----------|
| <img width="456" height="288" alt="image" src="https://github.com/user-attachments/assets/96330468-1780-4ede-856d-2bf35c496d9d" /> | <img width="501" height="285" alt="image" src="https://github.com/user-attachments/assets/e1c4e6cf-fdef-47bb-aec6-1e014f2b51cf" /> |


## Note
Actually, Calligraphy it self need fix it's off


<img width="520" height="417" alt="image" src="https://github.com/user-attachments/assets/f0fcea12-cc22-4c86-85bc-ff01235dee01" />
