### PR TITLE
fix(LPs): use course thumbnail for OG image

### DIFF
--- a/src/pages/learning-plans/[slug]/index.tsx
+++ b/src/pages/learning-plans/[slug]/index.tsx
@@ -49,6 +49,9 @@ const LearningPlanPage: NextPage<Props> = ({ course }) => {
         canonical={getCanonicalUrl(lang, url)}
         description={course?.metaDescription || t('learning-plan-meta-desc')}
         languageAlternates={getLanguageAlternates(url)}
+        image={course.thumbnail}
+        imageWidth={1200}
+        imageHeight={630}
       />
       <div className={layoutStyles.pageContainer}>
         <div className={styles.container}>


### PR DESCRIPTION
## Summary

Use the course thumbnail as the Open Graph image for Learning Plan pages.

Rebased cleanly from #3044

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Test Plan

- [x] Verify LP pages show the course thumbnail in OG meta tags