### PR TITLE
fix: update learning plans OG image dimensions

### DIFF
--- a/src/pages/learning-plans/[slug]/index.tsx
+++ b/src/pages/learning-plans/[slug]/index.tsx
@@ -51,7 +51,7 @@ const LearningPlanPage: NextPage<Props> = ({ course }) => {
         languageAlternates={getLanguageAlternates(url)}
         image={course.thumbnail}
         imageWidth={1200}
-        imageHeight={630}
+        imageHeight={1000}
       />
       <div className={layoutStyles.pageContainer}>
         <div className={styles.container}>


### PR DESCRIPTION
Updates OG image dimensions from 1200x630 to 1200x1000 to match actual thumbnail aspect ratio (1.2:1) and prevent stretching on Discord and other social platforms