### PR TITLE
Update CollectionVerseCell.tsx

### DIFF
--- a/src/components/Collection/CollectionDetail/CollectionVerseCell.tsx
+++ b/src/components/Collection/CollectionDetail/CollectionVerseCell.tsx
@@ -105,7 +105,9 @@ const CollectionVerseCell: React.FC<CollectionVerseCellProps> = ({
               >
                 {bookmarkName}
               </Link>
-              {formattedDate && <div className={styles.bookmarkDate}>{formattedDate}</div>}
+              {isOwner && formattedDate && (
+                <div className={styles.bookmarkDate}>{formattedDate}</div>
+              )}
             </div>
             <div className={styles.headerRight}>
               {isSelectMode ? (


### PR DESCRIPTION
only show the date if the user is the owner of the collection

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

## Test Plan

**Testing steps:**

1. Step one

Visit https://quran.com/collections/the-authority-and-importance-of-the-sunnah-clem7p7lf15921610rsdk4xzulfj
and you should not see any dates 
<img width="599" height="425" alt="image" src="https://github.com/user-attachments/assets/0fa375db-629a-45c7-8bbb-2401d00b2c6b" />


2. Step two
Create a new collection, add a verse and still able to see dates. 

### Edge Cases Verified

- [ ] 👤 Logged-in vs guest behavior (if applicable)