### PR TITLE
fix(LPs): use course thumbnail for OG image (1200x1000)

### DIFF
--- a/src/pages/learning-plans/[slug]/index.tsx
+++ b/src/pages/learning-plans/[slug]/index.tsx
@@ -49,6 +49,9 @@ const LearningPlanPage: NextPage<Props> = ({ course }) => {
         canonical={getCanonicalUrl(lang, url)}
         description={course?.metaDescription || t('learning-plan-meta-desc')}
         languageAlternates={getLanguageAlternates(url)}
+        image={course.thumbnail}
+        imageWidth={1200}
+        imageHeight={1000}
       />
       <div className={layoutStyles.pageContainer}>
         <div className={styles.container}>


### PR DESCRIPTION
## Summary

Use the course thumbnail as the Open Graph image for Learning Plan pages with 1200x1000 dimensions to match actual thumbnail aspect ratio and prevent stretching on Discord and other social platforms.

Previously merged to testing via #3053 and #3054.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)