### PR TITLE
 style(Pin and compare): adjust pinned verse tag spacing and icon size  

### DIFF
--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.module.scss
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesMenu.module.scss
@@ -5,10 +5,6 @@
   border-radius: var(--spacing-xxsmall-px);
   min-inline-size: auto;
   z-index: var(--z-index-modal);
-
-  [data-theme='dark'] & {
-    box-shadow: var(--shadow-pinned-item);
-  }
 }
 
 .menuItem {

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -75,7 +75,6 @@
   --shadow-language-selector: 0px 2px 4px 0px rgba(0, 0, 0, 0.3);
   --shadow-chapter-header-actions: 0px 0px 4px rgba(0, 0, 0, 0.7);
   --shadow-tajweed-trigger: 0px 2px 4px rgba(0, 0, 0, 0.7);
-  --shadow-pinned-item: 0px 4px 25px 0px rgba(0, 0, 0, 0.8);
   font-palette: --Dark;
 
   // scrollbar styles


### PR DESCRIPTION
 ## Summary                                                                                                                 

  Refine the VerseTag component styling used in both the PinnedVersesBar and Study Mode modal:
  - Adjust gap between verse key text and close icon from 6px to 12px (`--spacing-small2-px`).
  - Update inline padding from 15px to 12px (`--spacing-small2-px`).

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
        expected)
  - [ ] 📝 Documentation update
  - [x] ♻️  Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Pin one or more verses and check the VerseTag pills in the PinnedVersesBar — verify the close icon size, gap, and
  padding look correct.
  2. Open the Study Mode modal and verify the same VerseTag styling is consistent.
  3. Test in RTL locale to confirm padding-inline and layout remain correct.

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [x] All tests pass locally (`yarn test`)
  - [x] Linting passes (`yarn lint`)
  - [x] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming

  ### Localization (if UI changes)

  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] Keyboard navigation works

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
