### PR TITLE
fix(StudyMode): stabilize mobile modal height when content tab is active 

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeModal.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeModal.module.scss
@@ -249,6 +249,10 @@ div.bottomSheetOverlay {
 
 // Bottom sheet content - full height from bottom (double div for higher specificity)
 div div.bottomSheetContent {
+  @include breakpoints.smallerThanTablet {
+    block-size: 95dvh;
+    max-block-size: 95dvh;
+  }
   @include breakpoints.tablet {
     border-radius: var(--border-radius-rounded) var(--border-radius-rounded) 0 0;
     block-size: 95vh;
@@ -263,6 +267,12 @@ div div.bottomSheetContent {
 
 // Inner content scrollable for bottom sheet mode
 div.bottomSheetInnerContent {
+  @include breakpoints.smallerThanTablet {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    min-block-size: 0;
+  }
   @include breakpoints.tablet {
     flex: 1;
     overflow-y: auto;


### PR DESCRIPTION
## Summary                                                                                                                 
                                                                                                                           
  Fixes the study mode modal content jumping on mobile when navigating between ayahs with a content tab (Tafsir, Reflections,etc.) open.
On mobile, the modal height was `auto`, causing it to shrink when the skeleton loaded and grow when content arrived  producing two visible layout shifts. Desktop/tablet already had a fixed `95vh` height for this state but mobile was missing it.

  Closes: [QF-4746](https://quranfoundation.atlassian.net/browse/QF-4746)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
        expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️  Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Open study mode for any ayah on a mobile viewport (< 768px)
  2. Open any content tab (e.g., Tafsir)
  3. Navigate to another ayah using the arrow buttons or the verse dropdown
  4. Verify the modal height stays stable — no jumping or collapsing
  5. Close the content tab and navigate between ayahs — modal should use natural auto height as before
  6. Repeat on tablet (768px+) and desktop — verify behavior is unchanged

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled
  - [ ] ❌ Error state handled
  - [ ] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Localization (if UI changes)

  - [x] All user-facing text uses `next-translate`
  - [x] Only English locale files modified (Lokalise handles others)
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] ARIA attributes added where needed
  - [x] Keyboard navigation works

  ## Reviewer Notes

  CSS-only change. Adds `smallerThanTablet` rules to `bottomSheetContent` (sets `block-size: 95dvh` on mobile when a tab is
  active) and `bottomSheetInnerContent` (matching flex/overflow for the inner scroll container). This mirrors the existing
  tablet behavior at `95vh`. The `bottomSheetContent` class is only applied when `isContentTabActive` is true, so the default
   auto-height modal for no-tab state is unaffected.

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4746]: https://quranfoundation.atlassian.net/browse/QF-4746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ