### PR TITLE
remove RLM character from hadith text

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/HadithList/HadithContent.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/HadithList/HadithContent.module.scss
@@ -28,51 +28,6 @@ $hadith-font-line-height: 1.6;
   color: var(--color-text-default-new);
   @include utility.kitabFontLang;
 
-  /*
-   * ========================================================================
-   * ARABIC TEXT SELECTION FIX
-   * ========================================================================
-   *
-   * Issue: Arabic text selection fails when using the Kitab font in hadith tab (e.g., quran.com/33:66/hadith).
-   *
-   * Root Cause: The main issue occurs when the Right-to-Left Mark (RLM) character
-   * (U+200F, HTML entity &rlm;) is present in the hadith text. When selecting Arabic
-   * text rendered with the Kitab font that contains RLM characters, the browser's bidi
-   * (bidirectional text) algorithm conflicts with the font's complex ligature
-   * rendering, causing text selection to fail or behave erratically.
-   *
-   * The RLM character is an invisible control character used to properly directionally
-   * isolate text in mixed LTR/RTL contexts. However, when combined with the Kitab
-   * font's sophisticated ligature system, it creates bidirectional formatting
-   * conflicts that break the browser's text selection mechanism.
-   *
-   * Solution: Apply unicode-bidi: isolate to:
-   * 1. Create a separate directional context for the hadith text container
-   * 2. Prevent the bidi algorithm from interfering with text selection
-   * 3. Isolate the Kitab font rendering from parent/adjacent elements
-   * 4. Properly handle RLM characters without breaking text selection
-   *
-   * Why this works:
-   * - 'isolate' creates a new bidi formatting context that treats the element
-   *   as if it were surrounded by bidi-neutral characters (like parentheses)
-   * - This prevents the browser's bidi resolution from merging adjacent text
-   *   runs, which was causing the selection issue with RLM characters
-   * - The nested selector (&, & *) ensures all child elements also maintain
-   *   this isolation, preserving the fix throughout the hadith text hierarchy
-   * - The RLM character can still perform its intended function (directional
-   *   isolation) but without breaking text selection
-   *
-   * Trade-offs:
-   * - No removal of Kitab font or special characters (including RLM) needed
-   * - Text selection remains fully functional
-   * - No visual or behavioral regressions
-   * - Minimal performance impact (CSS isolation is lightweight)
-   *
-   * References:
-   * - CSS Writing Modes Level 3: https://www.w3.org/TR/css-writing-modes-3/#unicode-bidi
-   * - MDN unicode-bidi documentation: https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi
-   * - Similar fixes used in other RTL (right-to-left) text applications
-   */
   unicode-bidi: isolate;
 
   &,

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/utility.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/utility.ts
@@ -19,7 +19,8 @@ export const replaceBreaksWithSpans = (html: string): string => {
   const singlePattern = /<br\s*\/?>/gi;
   const finalResult = result.replace(singlePattern, '<span class="single"></span>');
 
-  return finalResult;
+  // Remove &rlm; char from content
+  return finalResult.replaceAll('\u200f', '');
 };
 
 export interface ParsedHadithNumber {


### PR DESCRIPTION
  PR Summary:
  ## Summary
  - Remove RLM (U+200F) character from hadith text content to fix Arabic text selection issues
  - Remove related CSS unicode-bidi workaround that's no longer needed

  ## Changes
  - Updated `replaceBreaksWithSpans()` utility to strip RLM characters from HTML content
  - Removed extensive unicode-bidi CSS fix comments from HadithContent.module.scss (the unicode-bidi property remains but the detailed
  documentation about the RLM workaround is no longer applicable)

  This resolves text selection failures when selecting Arabic text rendered with the Kitab font in the hadith tab (e.g., quran.com/33:66/hadith).