### PR TITLE
Fix Hadith tab Navigation Fake Url

### DIFF
--- a/src/hooks/studyMode/useStudyModeTabNavigation.ts
+++ b/src/hooks/studyMode/useStudyModeTabNavigation.ts
@@ -14,6 +14,7 @@ import {
   getVerseAnswersNavigationUrl,
   getVerseQiraatNavigationUrl,
   getVerseLayersNavigationUrl,
+  getVerseHadithsNavigationUrl,
 } from '@/utils/navigation';
 
 interface UseStudyModeTabNavigationProps {
@@ -65,6 +66,9 @@ const useStudyModeTabNavigation = ({
       }
       if (tab === StudyModeTabId.QIRAAT) {
         return getVerseQiraatNavigationUrl(vk);
+      }
+      if (tab === StudyModeTabId.HADITH) {
+        return getVerseHadithsNavigationUrl(vk);
       }
       return null;
     },


### PR DESCRIPTION
  ## Summary
  - Fix missing Hadith tab navigation in study mode
  - Add navigation logic for Hadith tab to properly update URL when changing verses
  - Previously, navigating between verses in study mode while on the Hadith tab would not update the URL correctly

  ## Changes
  - Added import for `getVerseHadithsNavigationUrl` utility
  - Added navigation logic for `StudyModeTabId.HADITH` to return verse-specific hadith URLs

  This fixes a bug where the Hadith tab in study mode wasn't properly handling verse navigation - the URL wouldn't update correctly when users
  changed verses while viewing hadith content.