### PR TITLE
Scale List Styling in Surah Info

### DIFF
--- a/src/components/chapters/Info/SurahInfoModal.module.scss
+++ b/src/components/chapters/Info/SurahInfoModal.module.scss
@@ -92,11 +92,20 @@ $line-height-relaxed: 1.6;
     font-style: italic;
   }
 
+  ul,
   ol {
     display: block;
-    list-style-type: decimal;
     margin-block-end: var(--spacing-medium);
-    padding-inline-start: calc(2 * var(--spacing-large));
+    // hard coded em to make it small and big relative to font size
+    padding-inline-start: 1.5em;
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  ul {
+    list-style-type: disc;
   }
 
   li {


### PR DESCRIPTION
  ## Summary
  - Update list item indentation to use em-based spacing (1.5em) for proper font scaling
  - Add `list-style-type: disc` for unordered lists (`ul`)
  - Reorganize list styles to share common properties between ordered and unordered lists

  ## Details
  Previously, only ordered lists (`ol`) had explicit styling. This change:
  - Moves shared properties (`display`, `margin-block-end`, `padding-inline-start`) to a shared `ul, ol` selector
  - Adds explicit styling for unordered lists with `list-style-type: disc`
  - Changes padding from fixed spacing units to em-based units to scale properly with font size changes

  This ensures both ordered and unordered lists in the Surah info modal display consistently and respond appropriately to font size adjustments.
  
| Before | After |
|--------|-------|
| <img width="923" height="477" alt="image" src="https://github.com/user-attachments/assets/6f961922-1a20-4523-9d5e-a0884df5c211" /> | <img width="936" height="357" alt="image" src="https://github.com/user-attachments/assets/89d2d3fa-5316-47fd-85f7-5c385e1e974f" />|