### PR TITLE
fix: auto-close popover menu when verse action is triggered

### DIFF
--- a/src/components/Verse/OverflowVerseActionsMenu.test.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenu.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Track PopoverMenu props to assert isOpen state changes
+const popoverMenuProps = vi.hoisted(() => ({ current: {} as any }));
+
+vi.mock('next-translate/useTranslation', () => ({
+  default: () => ({ t: (key: string) => key, lang: 'en' }),
+}));
+
+vi.mock('../QuranReader/TranslationView/TranslationViewCell.module.scss', () => ({
+  default: {},
+}));
+
+vi.mock('./OverflowVerseActionsMenuBody.module.scss', () => ({
+  default: {},
+}));
+
+vi.mock('@/dls/Button/Button', () => ({
+  default: ({ children, ...props }: any) => (
+    <button data-testid={props['data-testid'] || 'button'} {...props}>
+      {children}
+    </button>
+  ),
+  ButtonShape: { Circle: 'circle' },
+  ButtonSize: { Small: 'small' },
+  ButtonVariant: { Ghost: 'ghost' },
+}));
+
+vi.mock('@/dls/IconContainer/IconContainer', () => ({
+  default: ({ children }: any) => <div data-testid="icon-container">{children}</div>,
+  IconColor: { tertiary: 'tertiary' },
+  IconSize: { Custom: 'Custom' },
+}));
+
+vi.mock('@/dls/PopoverMenu/PopoverMenu', () => ({
+  default: ({ children, trigger, isOpen, onOpenChange, ...rest }: any) => {
+    // Store props so tests can inspect them
+    popoverMenuProps.current = { isOpen, onOpenChange, ...rest };
+    return (
+      <div data-testid="popover-menu" data-is-open={isOpen}>
+        <div
+          data-testid="popover-trigger"
+          onClick={() => onOpenChange?.(!isOpen)}
+          onKeyDown={() => {}}
+          role="button"
+          tabIndex={0}
+        >
+          {trigger}
+        </div>
+        {isOpen && <div data-testid="popover-content">{children}</div>}
+      </div>
+    );
+  },
+}));
+
+vi.mock('@/dls/Spinner/Spinner', () => ({
+  default: () => <div data-testid="spinner" />,
+}));
+
+vi.mock('@/icons/menu_more_horiz.svg', () => ({
+  default: () => <div data-testid="menu-icon" />,
+}));
+
+vi.mock('@/utils/eventLogger', () => ({
+  logEvent: vi.fn(),
+}));
+
+// Mock the dynamically imported OverflowVerseActionsMenuBody
+vi.mock('./OverflowVerseActionsMenuBody', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <div data-testid="menu-body">
+      <button data-testid="action-button" onClick={() => onActionTriggered?.()}>
+        Action
+      </button>
+    </div>
+  ),
+}));
+
+// Mock next/dynamic to render the mocked component synchronously
+vi.mock('next/dynamic', () => ({
+  default: (importFn: () => Promise<any>, _options?: any) => {
+    let Comp: React.ComponentType<any> | null = null;
+    importFn().then((mod) => {
+      Comp = mod.default;
+    });
+    // eslint-disable-next-line react/display-name
+    return (props: any) => {
+      if (!Comp) return <div data-testid="spinner" />;
+      return <Comp {...props} />;
+    };
+  },
+}));
+
+const mockVerse = {
+  verseKey: '1:1',
+  verseNumber: 1,
+  hizbNumber: 1,
+  rubElHizbNumber: 1,
+  juzNumber: 1,
+  pageNumber: 1,
+  chapterId: 1,
+  verseIndex: 0,
+  words: [],
+  textUthmani: '',
+  textImlaeiSimple: '',
+} as any;
+
+describe('OverflowVerseActionsMenu', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    popoverMenuProps.current = {};
+  });
+
+  it('renders the popover menu trigger button', async () => {
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} />);
+    expect(screen.getByTestId('verse-actions-more')).toBeDefined();
+  });
+
+  it('initializes with popover closed (isOpen=false)', async () => {
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} />);
+    expect(screen.getByTestId('popover-menu').getAttribute('data-is-open')).toBe('false');
+  });
+
+  it('opens popover when trigger is clicked', async () => {
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} />);
+
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(screen.getByTestId('popover-menu').getAttribute('data-is-open')).toBe('true');
+  });
+
+  it('closes popover when an action is triggered', async () => {
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} />);
+
+    // Open the popover first
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(screen.getByTestId('popover-menu').getAttribute('data-is-open')).toBe('true');
+
+    // Wait for the dynamically loaded menu body to render
+    await waitFor(() => {
+      expect(screen.getByTestId('action-button')).toBeDefined();
+    });
+
+    // Click an action inside the menu body
+    fireEvent.click(screen.getByTestId('action-button'));
+
+    // Popover should now be closed
+    expect(screen.getByTestId('popover-menu').getAttribute('data-is-open')).toBe('false');
+  });
+
+  it('calls external onActionTriggered callback when action is triggered', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(
+      <OverflowVerseActionsMenu verse={mockVerse} onActionTriggered={onActionTriggered} />,
+    );
+
+    // Open the popover
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+
+    // Wait for the dynamically loaded menu body to render
+    await waitFor(() => {
+      expect(screen.getByTestId('action-button')).toBeDefined();
+    });
+
+    // Click an action
+    fireEvent.click(screen.getByTestId('action-button'));
+
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes popover even without external onActionTriggered', async () => {
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} />);
+
+    // Open, then trigger action without external callback
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(screen.getByTestId('popover-menu').getAttribute('data-is-open')).toBe('true');
+
+    // Wait for the dynamically loaded menu body to render
+    await waitFor(() => {
+      expect(screen.getByTestId('action-button')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByTestId('action-button'));
+    expect(screen.getByTestId('popover-menu').getAttribute('data-is-open')).toBe('false');
+  });
+
+  it('logs open/close events via onOpenChange', async () => {
+    const { logEvent } = await import('@/utils/eventLogger');
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} isTranslationView />);
+
+    // Open
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(logEvent).toHaveBeenCalledWith('translation_view_verse_actions_menu_open');
+
+    // Close via trigger
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(logEvent).toHaveBeenCalledWith('translation_view_verse_actions_menu_close');
+  });
+
+  it('logs close event when popover closes via action trigger', async () => {
+    const { logEvent } = await import('@/utils/eventLogger');
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} isTranslationView />);
+
+    // Open the popover
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(logEvent).toHaveBeenCalledWith('translation_view_verse_actions_menu_open');
+
+    // Wait for the dynamically loaded menu body to render
+    await waitFor(() => {
+      expect(screen.getByTestId('action-button')).toBeDefined();
+    });
+
+    // Close via action (not via trigger)
+    fireEvent.click(screen.getByTestId('action-button'));
+    expect(logEvent).toHaveBeenCalledWith('translation_view_verse_actions_menu_close');
+  });
+
+  it('logs reading_view events when isTranslationView is false', async () => {
+    const { logEvent } = await import('@/utils/eventLogger');
+    const { default: OverflowVerseActionsMenu } = await import('./OverflowVerseActionsMenu');
+    render(<OverflowVerseActionsMenu verse={mockVerse} isTranslationView={false} />);
+
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    expect(logEvent).toHaveBeenCalledWith('reading_view_verse_actions_menu_open');
+  });
+});

--- a/src/components/Verse/OverflowVerseActionsMenu.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenu.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
@@ -38,18 +38,29 @@ const OverflowVerseActionsMenu: React.FC<Props> = ({
   isInsideStudyMode = false,
 }) => {
   const { t } = useTranslation('common');
+  const [isOpen, setIsOpen] = useState(false);
 
-  const onOpenModalChange = (open: boolean) => {
-    logEvent(
-      `${isTranslationView ? 'translation_view' : 'reading_view'}_verse_actions_menu_${
-        open ? 'open' : 'close'
-      }`,
-    );
-  };
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      logEvent(
+        `${isTranslationView ? 'translation_view' : 'reading_view'}_verse_actions_menu_${
+          open ? 'open' : 'close'
+        }`,
+      );
+      setIsOpen(open);
+    },
+    [isTranslationView],
+  );
+
+  const handleActionTriggered = useCallback(() => {
+    onOpenChange(false);
+    onActionTriggered?.();
+  }, [onOpenChange, onActionTriggered]);
 
   return (
     <div className={styles.container}>
       <PopoverMenu
+        isOpen={isOpen}
         contentClassName={classNames(cellStyles.menuOffset, cellStyles.overlayModal)}
         trigger={
           <Button
@@ -80,12 +91,12 @@ const OverflowVerseActionsMenu: React.FC<Props> = ({
         isModal
         isPortalled
         shouldUseModalZIndex={shouldUseModalZIndex}
-        onOpenChange={onOpenModalChange}
+        onOpenChange={onOpenChange}
       >
         <OverflowVerseActionsMenuBody
           verse={verse}
           isTranslationView={isTranslationView}
-          onActionTriggered={onActionTriggered}
+          onActionTriggered={handleActionTriggered}
           isInsideStudyMode={isInsideStudyMode}
         />
       </PopoverMenu>

--- a/src/components/Verse/OverflowVerseActionsMenuBody/OverflowVerseActionsMenuBody.test.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenuBody/OverflowVerseActionsMenuBody.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-redux', () => ({
+  useSelector: () => false, // selectStudyModeIsOpen returns false
+}));
+
+vi.mock('../PinVerseAction', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="pin-verse-action" onClick={() => onActionTriggered?.()}>
+      Pin
+    </button>
+  ),
+}));
+
+vi.mock('../TranslationFeedback/TranslationFeedbackAction', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="translation-feedback-action" onClick={() => onActionTriggered?.()}>
+      Feedback
+    </button>
+  ),
+}));
+
+vi.mock('../VerseActionAdvancedCopy', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="advanced-copy-action" onClick={() => onActionTriggered?.()}>
+      Copy
+    </button>
+  ),
+}));
+
+vi.mock('../VerseActionEmbedWidget', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="embed-widget-action" onClick={() => onActionTriggered?.()}>
+      Embed
+    </button>
+  ),
+}));
+
+vi.mock('../VerseActionRepeatAudio', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="repeat-audio-action" onClick={() => onActionTriggered?.()}>
+      Repeat
+    </button>
+  ),
+}));
+
+vi.mock('./ShareVerseActionsMenu', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="share-actions-menu" onClick={() => onActionTriggered?.()}>
+      Share
+    </button>
+  ),
+}));
+
+vi.mock('@/components/QuranReader/ReadingView/WordActionsMenu/types', () => ({
+  default: { Main: 'main', Share: 'share' },
+}));
+
+vi.mock('@/components/QuranReader/ReadingView/WordByWordVerseAction', () => ({
+  default: ({ onActionTriggered }: any) => (
+    <button data-testid="word-by-word-action" onClick={() => onActionTriggered?.()}>
+      Word by Word
+    </button>
+  ),
+}));
+
+vi.mock('@/redux/slices/QuranReader/studyMode', () => ({
+  selectStudyModeIsOpen: () => false,
+}));
+
+const mockVerse = {
+  verseKey: '1:1',
+  verseNumber: 1,
+  hizbNumber: 1,
+  rubElHizbNumber: 1,
+  juzNumber: 1,
+  pageNumber: 1,
+  chapterId: 1,
+  verseIndex: 0,
+  words: [],
+  textUthmani: '',
+  textImlaeiSimple: '',
+} as any;
+
+describe('OverflowVerseActionsMenuBody', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders all action components', async () => {
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody verse={mockVerse} isTranslationView />,
+    );
+
+    expect(screen.getByTestId('pin-verse-action')).toBeDefined();
+    expect(screen.getByTestId('advanced-copy-action')).toBeDefined();
+    expect(screen.getByTestId('word-by-word-action')).toBeDefined();
+    expect(screen.getByTestId('repeat-audio-action')).toBeDefined();
+    expect(screen.getByTestId('translation-feedback-action')).toBeDefined();
+    expect(screen.getByTestId('embed-widget-action')).toBeDefined();
+  });
+
+  it('passes onActionTriggered to PinVerseAction', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody
+        verse={mockVerse}
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('pin-verse-action'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes onActionTriggered to VerseActionAdvancedCopy', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody
+        verse={mockVerse}
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('advanced-copy-action'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes onActionTriggered to WordByWordVerseAction', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody
+        verse={mockVerse}
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('word-by-word-action'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes onActionTriggered to VerseActionRepeatAudio', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody
+        verse={mockVerse}
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('repeat-audio-action'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes onActionTriggered to TranslationFeedbackAction', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody
+        verse={mockVerse}
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('translation-feedback-action'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes onActionTriggered to VerseActionEmbedWidget', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: OverflowVerseActionsMenuBody } = await import('./index');
+    render(
+      <OverflowVerseActionsMenuBody
+        verse={mockVerse}
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('embed-widget-action'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Verse/OverflowVerseActionsMenuBody/index.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenuBody/index.tsx
@@ -48,7 +48,11 @@ const OverflowVerseActionsMenuBody: React.FC<Props> = ({
         <WordByWordVerseAction verse={verse} onActionTriggered={onActionTriggered} />
       )}
       {!isStudyModeOpen && (
-        <VerseActionRepeatAudio isTranslationView={isTranslationView} verseKey={verse.verseKey} />
+        <VerseActionRepeatAudio
+          isTranslationView={isTranslationView}
+          verseKey={verse.verseKey}
+          onActionTriggered={onActionTriggered}
+        />
       )}
       <TranslationFeedbackAction
         verse={verse}

--- a/src/components/Verse/VerseActionRepeatAudio.test.tsx
+++ b/src/components/Verse/VerseActionRepeatAudio.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-translate/useTranslation', () => ({
+  default: () => ({ t: (key: string) => key, lang: 'en' }),
+}));
+
+vi.mock('../AudioPlayer/RepeatAudioModal/SelectRepetitionMode', () => ({
+  RepetitionMode: { Single: 'single' },
+}));
+
+vi.mock('@/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal', () => ({
+  default: ({ isOpen, onClose }: any) =>
+    isOpen ? (
+      <div data-testid="repeat-audio-modal">
+        <button data-testid="close-modal" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/dls/IconContainer/IconContainer', () => ({
+  default: () => <div data-testid="icon-container" />,
+  IconColor: { tertiary: 'tertiary' },
+  IconSize: { Custom: 'Custom' },
+}));
+
+vi.mock('@/dls/PopoverMenu/PopoverMenu', () => {
+  const Item = ({ children, onClick, icon }: any) => (
+    <button data-testid="popover-menu-item" onClick={onClick}>
+      {icon}
+      {children}
+    </button>
+  );
+
+  const PopoverMenu = ({ children }: any) => <div>{children}</div>;
+  PopoverMenu.Item = Item;
+  PopoverMenu.Divider = () => <hr />;
+  return { default: PopoverMenu };
+});
+
+vi.mock('@/icons/repeat-new.svg', () => ({
+  default: () => <div data-testid="repeat-icon" />,
+}));
+
+vi.mock('@/utils/eventLogger', () => ({
+  logButtonClick: vi.fn(),
+}));
+
+vi.mock('@/utils/verse', () => ({
+  getChapterNumberFromKey: (key: string) => Number(key.split(':')[0]),
+}));
+
+describe('VerseActionRepeatAudio', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the repeat audio menu item', async () => {
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(<VerseActionRepeatAudio verseKey="1:1" isTranslationView />);
+    expect(screen.getByTestId('popover-menu-item')).toBeDefined();
+    expect(screen.getByText('audio.player.repeat-1-verse')).toBeDefined();
+  });
+
+  it('opens the repeat audio modal when clicked', async () => {
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(<VerseActionRepeatAudio verseKey="1:1" isTranslationView />);
+
+    expect(screen.queryByTestId('repeat-audio-modal')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('popover-menu-item'));
+
+    expect(screen.getByTestId('repeat-audio-modal')).toBeDefined();
+  });
+
+  it('calls onActionTriggered when clicked', async () => {
+    const onActionTriggered = vi.fn();
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(
+      <VerseActionRepeatAudio
+        verseKey="1:1"
+        isTranslationView
+        onActionTriggered={onActionTriggered}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('popover-menu-item'));
+    expect(onActionTriggered).toHaveBeenCalledTimes(1);
+  });
+
+  it('works without onActionTriggered (optional prop)', async () => {
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(<VerseActionRepeatAudio verseKey="1:1" isTranslationView />);
+
+    // Should not throw when clicking without onActionTriggered
+    fireEvent.click(screen.getByTestId('popover-menu-item'));
+    expect(screen.getByTestId('repeat-audio-modal')).toBeDefined();
+  });
+
+  it('logs translation_view event when isTranslationView is true', async () => {
+    const { logButtonClick } = await import('@/utils/eventLogger');
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(<VerseActionRepeatAudio verseKey="1:1" isTranslationView />);
+
+    fireEvent.click(screen.getByTestId('popover-menu-item'));
+    expect(logButtonClick).toHaveBeenCalledWith('translation_view_verse_actions_menu_repeat');
+  });
+
+  it('logs reading_view event when isTranslationView is false', async () => {
+    const { logButtonClick } = await import('@/utils/eventLogger');
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(<VerseActionRepeatAudio verseKey="2:255" isTranslationView={false} />);
+
+    fireEvent.click(screen.getByTestId('popover-menu-item'));
+    expect(logButtonClick).toHaveBeenCalledWith('reading_view_verse_actions_menu_repeat');
+  });
+
+  it('closes the modal when onClose is called', async () => {
+    const { default: VerseActionRepeatAudio } = await import('./VerseActionRepeatAudio');
+    render(<VerseActionRepeatAudio verseKey="1:1" isTranslationView />);
+
+    // Open modal
+    fireEvent.click(screen.getByTestId('popover-menu-item'));
+    expect(screen.getByTestId('repeat-audio-modal')).toBeDefined();
+
+    // Close modal
+    fireEvent.click(screen.getByTestId('close-modal'));
+    expect(screen.queryByTestId('repeat-audio-modal')).toBeNull();
+  });
+});

--- a/src/components/Verse/VerseActionRepeatAudio.tsx
+++ b/src/components/Verse/VerseActionRepeatAudio.tsx
@@ -14,8 +14,13 @@ import { getChapterNumberFromKey } from '@/utils/verse';
 type VerseActionRepeatAudioProps = {
   verseKey: string;
   isTranslationView: boolean;
+  onActionTriggered?: () => void;
 };
-const VerseActionRepeatAudio = ({ verseKey, isTranslationView }: VerseActionRepeatAudioProps) => {
+const VerseActionRepeatAudio = ({
+  verseKey,
+  isTranslationView,
+  onActionTriggered,
+}: VerseActionRepeatAudioProps) => {
   const { t } = useTranslation('common');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const chapterId = getChapterNumberFromKey(verseKey);
@@ -27,6 +32,7 @@ const VerseActionRepeatAudio = ({ verseKey, isTranslationView }: VerseActionRepe
       logButtonClick('reading_view_verse_actions_menu_repeat');
     }
     setIsModalOpen(true);
+    onActionTriggered?.();
   };
 
   return (


### PR DESCRIPTION
## Summary

Closes #1826

The ayah actions popover menu was not closing automatically after a user triggered an action. This PR fixes the issue by:

- **Lifting `isOpen` state** to `OverflowVerseActionsMenu` so the popover can be closed programmatically
- **Adding `handleActionTriggered`** callback that closes the popover and chains to the optional external `onActionTriggered` callback
- **Wiring `onActionTriggered` to `VerseActionRepeatAudio`** — this was the only action component missing the prop

### Files changed

| File | Change |
|------|--------|
| `OverflowVerseActionsMenu.tsx` | Added controlled `isOpen` state, `useCallback`-wrapped handlers |
| `OverflowVerseActionsMenuBody/index.tsx` | Passed `onActionTriggered` to `VerseActionRepeatAudio` |
| `VerseActionRepeatAudio.tsx` | Added `onActionTriggered` optional prop |

### Notes

- All existing action components (`PinVerseAction`, `VerseActionAdvancedCopy`, `WordByWordVerseAction`, `TranslationFeedbackAction`, `VerseActionEmbedWidget`) already had `onActionTriggered` wired — only `VerseActionRepeatAudio` was missing it
- The `onOpenChange` callback is routed through for both trigger-based and action-based close paths, ensuring analytics events fire consistently

## Test plan

- [x] 23 unit/component tests added across 3 test files (all passing)
- [ ] Manual QA: Open the verse actions popover (⋯ button), click any action — verify the popover closes
- [ ] Manual QA: Verify "Repeat 1 Verse" closes the popover and opens the repeat modal
- [ ] Manual QA: Verify closing via clicking outside or clicking the trigger again still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)