### PR TITLE
Layer Make Content Markup Support More Flexible

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeLayersTab/StudyModeLayersTab.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeLayersTab/StudyModeLayersTab.module.scss
@@ -41,6 +41,23 @@ $layers-scales: (
   }
 }
 
+.markdown {
+  & p {
+    display: inline;
+  }
+
+  & strong,
+  & b {
+    font-weight: var(--font-weight-medium);
+  }
+
+  & em,
+  & i {
+    font-size: inherit;
+    font-style: italic;
+  }
+}
+
 // ------------------------------------------------------------
 // Font Size Scale Factors
 // These values represent proportional multipliers (ratios)
@@ -121,13 +138,7 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   font-weight: var(--font-weight-light);
   line-height: 1.8;
 
-  & b {
-    font-weight: var(--font-weight-medium);
-  }
-
-  & i {
-    font-style: italic;
-  }
+  @extend .markdown;
 }
 
 .groupToken {
@@ -241,13 +252,7 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   line-height: 1;
   cursor: pointer;
 
-  & b {
-    font-weight: var(--font-weight-medium);
-  }
-
-  & i {
-    font-style: italic;
-  }
+  @extend .markdown;
 }
 
 .optionText {
@@ -316,13 +321,7 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   font-weight: var(--font-weight-light);
   line-height: 1.5;
 
-  & i {
-    font-style: italic;
-  }
-
-  & b {
-    font-weight: var(--font-weight-medium);
-  }
+  @extend .markdown;
 }
 
 .translationText :global(sup[foot_note]),
@@ -345,8 +344,5 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   --font-size-xsmall: calc(var(--layers-base-font-size) * #{$font-scale-10}); // base 3 => 10px
   font-size: var(--font-size-normal);
 
-  i {
-    font-size: inherit;
-    font-style: italic;
-  }
+  @extend .markdown;
 }


### PR DESCRIPTION
  ## Summary
  - Extract common markdown text formatting (paragraphs, bold, italic) into a reusable `.markdown` class
  - Replace duplicated inline styles in `.translationText`, `.groupToken` and `.optionButton` with `@extend .markdown`
  - Reduces SCSS duplication and centralizes markdown styling rules

  ## Changes
  - Added `.markdown` class with `p`, `strong`, `b`, `em`, and `i` element styling
  - Refactored 4 components to use the new base class via `@extend`