### PR TITLE
fix: treat blockquote as flashcard section boundary

### DIFF
--- a/src/utils/flashcardParser.test.ts
+++ b/src/utils/flashcardParser.test.ts
@@ -72,6 +72,14 @@ describe('flashcardParser', () => {
       expect(result?.afterHtml).toBe('<p>Practice this line slowly.</p>');
     });
 
+    it('splits before trailing blockquote sections', () => {
+      const html = `${makeSection()}<blockquote><a href="https://quran.com/2/1">2:1</a><p>Verse widget</p></blockquote>`;
+      const result = parseFlashcardsFromHtml(html);
+      expect(result?.afterHtml).toBe(
+        '<blockquote><a href="https://quran.com/2/1">2:1</a><p>Verse widget</p></blockquote>',
+      );
+    });
+
     it('parses arabic, transliteration and translation', () => {
       const result = parseFlashcardsFromHtml(makeSection());
       const card = result?.flashcards[0];

--- a/src/utils/flashcardParser.ts
+++ b/src/utils/flashcardParser.ts
@@ -25,7 +25,7 @@ export default function parseFlashcardsFromHtml(html: string): {
 
   const afterHeadingContent = html.slice(headingEndIndex);
   const nextSectionMatch = afterHeadingContent.match(
-    /<h[1-6][^>]*>|<hr\b[^>]*\/?>|<p(?![^>]*\bdir=["'](?:rtl|ltr)["'])[^>]*>/i,
+    /<h[1-6][^>]*>|<hr\b[^>]*\/?>|<blockquote\b[^>]*>|<p(?![^>]*\bdir=["'](?:rtl|ltr)["'])[^>]*>/i,
   );
   const splitAt = nextSectionMatch?.index ?? afterHeadingContent.length;
   const wordByWordHtml = afterHeadingContent.slice(0, splitAt);


### PR DESCRIPTION
Fixes flashcard section splitting when content after the flashcards starts with a `<blockquote>`.
This preserves complete trailing `blockquote` HTML so verse widgets still parse/render correctly.