### PR TITLE
Sync Font Size in Footnotes

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeLayersTab/StudyModeLayersTab.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeLayersTab/StudyModeLayersTab.module.scss
@@ -324,12 +324,16 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   @extend .markdown;
 }
 
+:is(.translationText, .groupPanel) span:has(sup[foot_note]) {
+  font-size: inherit !important;
+}
+
 .translationText :global(sup[foot_note]),
 .groupPanel :global(sup[foot_note]) {
   vertical-align: super;
   color: var(--color-text-link);
   font-weight: var(--font-weight-medium);
-  font-size: 0.75em;
+  font-size: calc(var(--layers-base-font-size) * 0.75);
   padding-inline: var(--spacing-micro2-px);
   cursor: pointer;
 


### PR DESCRIPTION
# PR Summary

## Changes
- Updated footnote styling to use relative font sizing based on `--layers-base-font-size` instead of fixed `0.75em`
- Added CSS rule to ensure footnote text within `<span>` elements inherits font size properly

## Technical Details
- Changed `font-size: 0.75em` to `font-size: calc(var(--layers-base-font-size) * 0.75)` for better scalability
- Added `:is(.translationText, .groupPanel) span:has(sup[foot_note])` selector with `font-size: inherit !important` to prevent font size conflicts

## Impact
- Footnotes will now scale appropriately with the base layer font size
- Ensures consistent footnote styling across different text containers
- Improves readability and visual hierarchy in Study Mode layers