### PR TITLE
fix: use lesson h3 text for flashcard header

### DIFF
--- a/src/components/Course/LessonHtmlContent/index.tsx
+++ b/src/components/Course/LessonHtmlContent/index.tsx
@@ -23,7 +23,6 @@ const VARIANT_CONFIG = {
     subtitle: 'Swipe right if you know it, left to review',
   },
 };
-const FLASHCARD_TITLE = 'Word-by-word breakdown';
 
 type Props = {
   content: string;
@@ -60,7 +59,7 @@ const LessonHtmlContent: React.FC<Props> = ({ content, language }) => {
         {flashcardData.beforeHtml && renderHtml(flashcardData.beforeHtml, 'before-')}
         <div className={styles.flashcardSection}>
           <div className={styles.flashcardHeader}>
-            <h4 className={styles.flashcardTitle}>{FLASHCARD_TITLE}</h4>
+            <h4 className={styles.flashcardTitle}>{flashcardData.headingText}</h4>
             <span className={styles.flashcardSubtitle}>{subtitle}</span>
           </div>
           <FlashCardComponent key={content} cards={flashcardData.flashcards} />

--- a/src/utils/flashcardParser.test.ts
+++ b/src/utils/flashcardParser.test.ts
@@ -27,6 +27,7 @@ describe('flashcardParser', () => {
     it('defaults to list variant when no class on h3', () => {
       const result = parseFlashcardsFromHtml(makeSection());
       expect(result?.variant).toBe(FlashCardVariant.List);
+      expect(result?.headingText).toBe('Word-by-word breakdown');
       expect(result?.flashcards).toHaveLength(1);
     });
 

--- a/src/utils/flashcardParser.ts
+++ b/src/utils/flashcardParser.ts
@@ -12,6 +12,7 @@ export default function parseFlashcardsFromHtml(html: string): {
   flashcards: FlashCardData[];
   afterHtml: string;
   variant: FlashCardVariant;
+  headingText: string;
 } | null {
   const headingRegex =
     /<h3[^>]*>(?:(?!<\/h3>)[\s\S])*?Word-by-word\s+breakdown(?:(?!<\/h3>)[\s\S])*?<\/h3>/i;
@@ -20,6 +21,7 @@ export default function parseFlashcardsFromHtml(html: string): {
   if (!headingMatch || headingMatch.index === undefined) return null;
 
   const variant = extractVariant(headingMatch[0]);
+  const headingText = stripHtmlTags(headingMatch[0]).trim();
   const headingEndIndex = headingMatch.index + headingMatch[0].length;
   const beforeHtml = html.slice(0, headingMatch.index);
 
@@ -34,7 +36,7 @@ export default function parseFlashcardsFromHtml(html: string): {
   const flashcards = extractFlashcardsFromSection(wordByWordHtml);
   if (flashcards.length === 0) return null;
 
-  return { beforeHtml, flashcards, afterHtml, variant };
+  return { beforeHtml, flashcards, afterHtml, variant, headingText };
 }
 
 function extractFlashcardsFromSection(html: string): FlashCardData[] {


### PR DESCRIPTION
Use the lesson’s matched `<h3>` body as the flashcard header title instead of a hardcoded string.