### PR TITLE
fix: refine LP lesson horizontal rule styling in MarkdownEditor

### DIFF
--- a/src/components/MarkdownEditor/MarkdownEditor.module.scss
+++ b/src/components/MarkdownEditor/MarkdownEditor.module.scss
@@ -35,9 +35,9 @@
   }
 
   hr {
-    margin: var(--spacing-medium) 0;
+    margin: var(--spacing-xlarge) 0;
     border: none;
-    border-block-start: 2px solid var(--color-background-inverse);
+    border-block-start: 1px solid var(--color-borders-hairline);
   }
   blockquote {
     background-color: var(--color-success-faint);


### PR DESCRIPTION
### Summary
Improves horizontal rule styling in LP lesson markdown content to better match spacing and border token usage.

before: 
<img width="714" height="204" alt="Screenshot 2026-02-14 at 6 45 40 PM" src="https://github.com/user-attachments/assets/bd6c65d3-70f1-46e8-92a9-045cd9449351" />

after:
<img width="675" height="195" alt="Screenshot 2026-02-14 at 6 46 04 PM" src="https://github.com/user-attachments/assets/33270f2d-5795-42a4-9e8b-bfbd085e22e8" />
