### PR TITLE
fix: set learning plan lesson metadata and reuse LP OG image

### DIFF
--- a/src/components/Course/LessonContent/index.tsx
+++ b/src/components/Course/LessonContent/index.tsx
@@ -15,11 +15,17 @@ interface Props {
 
 const LessonContent: React.FC<Props> = ({ lesson, lessonSlugOrId, courseSlug }) => {
   const { lang } = useTranslation('learn');
+  const description = `Lesson ${lesson.day} of "${lesson.course.title}"`;
+
   return (
     <>
       <NextSeoWrapper
         title={lesson.title}
+        description={description}
         url={getCanonicalUrl(lang, getLessonNavigationUrl(courseSlug, lessonSlugOrId))}
+        image={lesson.course.thumbnail}
+        imageWidth={1200}
+        imageHeight={1000}
       />
       <LessonView lesson={lesson} lessonSlugOrId={lessonSlugOrId} courseSlug={courseSlug} />
     </>


### PR DESCRIPTION
## Summary

- Adds lesson detail page meta description as: Lesson N of "Course title".
- Keeps lesson page title from lesson data.
- Uses learning plan thumbnail (course.thumbnail) as lesson og:image.