### PR TITLE
fix: use date number instead of week number

### DIFF
--- a/src/components/HomePage/QuranGrowthJourneySection/CollapsibleSection/QuranReadingGoals/CurrentWeekProgress.tsx
+++ b/src/components/HomePage/QuranGrowthJourneySection/CollapsibleSection/QuranReadingGoals/CurrentWeekProgress.tsx
@@ -7,7 +7,7 @@ import styles from './ReadingStreak.module.scss';
 import { ContentSide } from '@/dls/Popover';
 import HoverablePopover from '@/dls/Popover/HoverablePopover';
 import useGetStreakWithMetadata from '@/hooks/auth/useGetStreakWithMetadata';
-import { compareDateWithToday, dateToReadableFormat } from '@/utils/datetime';
+import { dateToReadableFormat } from '@/utils/datetime';
 import { convertFractionToPercent } from '@/utils/number';
 
 interface Props {
@@ -19,9 +19,7 @@ const CurrentWeekProgress: React.FC<Props> = ({ weekData, goal }) => {
   const { lang, t } = useTranslation();
   const { days, readingDaysMap } = weekData;
 
-  const getDayState = (day: (typeof days)[number]): [DayState, boolean] => {
-    const { today, normalizedDate, isToday } = compareDateWithToday(day.date);
-
+  const getDayState = (day: (typeof days)[number]): DayState => {
     const readingDay = readingDaysMap[day.dateString];
     const hasRead = readingDay?.hasRead;
 
@@ -29,11 +27,11 @@ const CurrentWeekProgress: React.FC<Props> = ({ weekData, goal }) => {
     // otherwise, we want to show a checked circle if the user has read at all for the day
     const isGoalDone = goal ? convertFractionToPercent(readingDay?.progress || 0) >= 100 : hasRead;
 
-    if (isGoalDone) return [DayState.Checked, isToday];
+    if (isGoalDone) return DayState.Checked;
 
-    if (normalizedDate > today) return [DayState.Future, isToday];
+    if (day.date > new Date()) return DayState.Future;
 
-    return [DayState.None, isToday];
+    return DayState.None;
   };
 
   return (
@@ -41,7 +39,7 @@ const CurrentWeekProgress: React.FC<Props> = ({ weekData, goal }) => {
       <p className={styles.weekProgressLabel}>{t('reading-goal:week-progress')}:</p>
       <div className={styles.week}>
         {days.map((day) => {
-          const [dayState, isToday] = getDayState(day);
+          const dayState = getDayState(day);
 
           return (
             <div key={day.info.localizedNumber} className={styles.day}>
@@ -54,7 +52,7 @@ const CurrentWeekProgress: React.FC<Props> = ({ weekData, goal }) => {
               >
                 <span
                   className={classNames(styles.shortName, {
-                    [styles.textBold]: isToday,
+                    [styles.textBold]: day.current,
                   })}
                 >
                   {dayState === DayState.Future ? day.info.localizedNumber : day.info.shortName}

--- a/src/hooks/auth/useGetStreakWithMetadata.ts
+++ b/src/hooks/auth/useGetStreakWithMetadata.ts
@@ -76,7 +76,7 @@ const useGetWeekDayNames = (week: Day[], streak: number, showWeekdayName = false
       let dayName: { localizedNumber: string; title: string; shortName: string };
       if (showWeekdayName) {
         dayName = {
-          localizedNumber: toLocalizedNumber(i + 1, lang),
+          localizedNumber: toLocalizedNumber(week[i].date.getDate(), lang),
           title: getFullDayName(week[i].date, lang),
           shortName: getShortDayName(week[i].date, lang),
         };

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -1,13 +1,8 @@
 /* eslint-disable max-lines */
 /* eslint-disable react-func/max-lines-per-function */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-import {
-  compareDateWithToday,
-  formatDateRelatively,
-  getEarliestDate,
-  getShortDayName,
-} from './datetime';
+import { formatDateRelatively, getEarliestDate, getShortDayName } from './datetime';
 
 it('getEarliestDate returns earliest date', () => {
   const result = getEarliestDate([
@@ -96,73 +91,5 @@ describe('getShortDayName', () => {
       // The function uses 'narrow' format which is the shortest available, not guaranteed to be 1 char
       expect(result.length).toBeLessThanOrEqual(2);
     });
-  });
-});
-
-describe('compareDateWithToday', () => {
-  const mockToday = new Date('2024-01-15T12:30:45.000Z');
-
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(mockToday);
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('returns isToday as true when date is today', () => {
-    const result = compareDateWithToday('2024-01-15');
-    expect(result.isToday).toBe(true);
-    expect(result.normalizedDate.getTime()).toBe(result.today.getTime());
-  });
-
-  it('returns isToday as false for past and future dates', () => {
-    const pastResult = compareDateWithToday('2024-01-14');
-    const futureResult = compareDateWithToday('2024-01-16');
-
-    expect(pastResult.isToday).toBe(false);
-    expect(pastResult.normalizedDate.getTime()).toBeLessThan(pastResult.today.getTime());
-    expect(futureResult.isToday).toBe(false);
-    expect(futureResult.normalizedDate.getTime()).toBeGreaterThan(futureResult.today.getTime());
-  });
-
-  it('normalizes both dates to midnight', () => {
-    const result = compareDateWithToday('2024-01-15T18:20:10.500Z');
-
-    expect(result.today.getHours()).toBe(0);
-    expect(result.today.getMinutes()).toBe(0);
-    expect(result.today.getSeconds()).toBe(0);
-    expect(result.today.getMilliseconds()).toBe(0);
-    expect(result.normalizedDate.getHours()).toBe(0);
-    expect(result.normalizedDate.getMinutes()).toBe(0);
-    expect(result.normalizedDate.getSeconds()).toBe(0);
-    expect(result.normalizedDate.getMilliseconds()).toBe(0);
-  });
-
-  it('works with Date object input for today, past, and future', () => {
-    const todayDate = new Date(2024, 0, 15, 18, 20, 10);
-    const pastDate = new Date(2024, 0, 14, 18, 20, 10);
-    const futureDate = new Date(2024, 0, 16, 18, 20, 10);
-
-    const todayResult = compareDateWithToday(todayDate);
-    const pastResult = compareDateWithToday(pastDate);
-    const futureResult = compareDateWithToday(futureDate);
-
-    expect(todayResult.isToday).toBe(true);
-    expect(todayResult.normalizedDate.getHours()).toBe(0);
-    expect(pastResult.isToday).toBe(false);
-    expect(futureResult.isToday).toBe(false);
-  });
-
-  it('returns correct structure with all required properties', () => {
-    const result = compareDateWithToday('2024-01-15');
-
-    expect(result).toHaveProperty('today');
-    expect(result).toHaveProperty('normalizedDate');
-    expect(result).toHaveProperty('isToday');
-    expect(result.today).toBeInstanceOf(Date);
-    expect(result.normalizedDate).toBeInstanceOf(Date);
-    expect(typeof result.isToday).toBe('boolean');
   });
 });

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -362,37 +362,6 @@ export const getMonthsInYear = (year: number, locale: string): Month[] => {
 };
 
 /**
- * Normalizes a date to midnight and compares it with today's date.
- *
- * @param {string | Date} date - The date to compare (can be a string or Date object)
- * @returns {{ today: Date, normalizedDate: Date, isToday: boolean }} An object containing:
- *   - today: Today's date normalized to midnight (00:00:00.000)
- *   - normalizedDate: The provided date normalized to midnight (00:00:00.000)
- *   - isToday: Boolean indicating if the provided date is today
- *
- * @example
- * const { today, normalizedDate, isToday } = compareDateWithToday('2024-01-15');
- * // today: Date object for current date at 00:00:00.000
- * // normalizedDate: Date object for 2024-01-15 at 00:00:00.000
- * // isToday: true if today is January 15, 2024, false otherwise
- */
-export const compareDateWithToday = (
-  date: string | Date,
-): {
-  today: Date;
-  normalizedDate: Date;
-  isToday: boolean;
-} => {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const normalizedDate = new Date(date);
-  normalizedDate.setHours(0, 0, 0, 0);
-  const isToday = normalizedDate.getTime() === today.getTime();
-
-  return { today, normalizedDate, isToday };
-};
-
-/**
  * Convert a date to a safe ISO string.
  *
  * @param {string | Date} date


### PR DESCRIPTION
## Summary

This PR updates the streak metadata logic to display the actual day of the month (e.g., 15) in the reading progress widget instead of the day index within the week (e.g., 1-7). This ensures users verify their progress against specific dates. Additionally, it removes unused date utility functions (`compareDateWithToday`) and their associated tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [x] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs

## Environment Variables

<!-- List any new environment variables introduced. Delete section if not applicable. -->

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

## Test Plan

<!-- Describe how this PR has been tested -->

- [x] Unit tests added/updated (Removed obsolete tests)
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. Navigate to the Quran Growth Journey section on the home page.
2. Observe the "Current Week Progress" / streak widget.
3. Verify that the circles display the actual date of the month (e.g., 15, 16) rather than the week index (1, 2...).
4. Confirm that the current day is correctly highlighted.

### Edge Cases Verified

- [x] ⏳ Loading state handled
- [ ] ❌ Error state handled
- [ ] 📭 Empty state handled
- [x] 👤 Logged-in vs guest behavior (if applicable)

## Pre-Review Checklist

<!-- Complete ALL items before requesting review. Ready for review = Ready to release! -->

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [ ] README updated (if adding features or setup changes)
- [ ] Inline comments added for complex logic

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] Only English locale files modified (Lokalise handles others)
- [x] RTL layout verified

### Accessibility (if UI changes)

- [x] Semantic HTML elements used
- [x] ARIA attributes added where needed
- [x] Keyboard navigation works

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Delete section if not applicable. -->

| Before | After |
| ------ | ----- |
| *(Shows 1, 2, 3...)* | *(Shows e.g. 15, 16, 17...)* |

## Related PRs

<!-- Link any related PRs here. Delete section if not applicable. -->

## Reviewer Notes

<!-- Optional: Anything specific you want reviewed? Concerns or trade-offs? -->
Removed `compareDateWithToday` and related tests in [src/utils/datetime.ts](cci:7://file:///home/afifvdin/Desktop/quran.com-frontend-next/src/utils/datetime.ts:0:0-0:0) as they were no longer used.

## AI Assistance Disclosure

<!-- If AI tools were used, confirm you have reviewed and understand all generated code -->

- [x] AI tools were NOT used for this PR
- [ ] AI tools were used, and I have **thoroughly reviewed and validated** all generated code