### PR TITLE
Show Arabic text in learning plan lesson widgets

### DIFF
--- a/src/pages/api/ayah-widget.ts
+++ b/src/pages/api/ayah-widget.ts
@@ -42,7 +42,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       theme: parseTheme(theme),
       locale: 'en',
       lp: true,
-      showArabic: false,
       mergeVerses: true,
       showTafsirs: false,
       showReflections: false,


### PR DESCRIPTION
Remove `showArabic: false` from ayah-widget API to display Arabic ayah in learning plan lessons