### PR TITLE
fix: apply Kitab font correctly in learning plan flashcards

### DIFF
--- a/src/components/Course/FlashCards/FlashCardList/FlashCardList.module.scss
+++ b/src/components/Course/FlashCards/FlashCardList/FlashCardList.module.scss
@@ -65,7 +65,7 @@
 }
 
 .arabicText {
-  font-family: 'Kitab', var(--font-quran);
+  font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
   font-size: 1.25rem;
   line-height: 1.4;
   color: var(--color-text-default);

--- a/src/components/Course/FlashCards/_shared.scss
+++ b/src/components/Course/FlashCards/_shared.scss
@@ -51,7 +51,7 @@
   }
 
   .arabicText {
-    font-family: 'Kitab', var(--font-quran);
+    font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
     font-size: $arabicFont;
     line-height: 1.6;
     text-align: center;
@@ -64,7 +64,7 @@
   }
 
   .arabicTextSmall {
-    font-family: 'Kitab', var(--font-quran);
+    font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
     font-size: $smallArabicFont;
     line-height: 1.4;
     text-align: center;


### PR DESCRIPTION
## Summary
Fix Arabic flashcard text not using Kitab on production.

## Changes
- Replaced `font-family: 'Kitab', var(--font-quran);`
- With `font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;`
- Updated in:
  - `src/components/Course/FlashCards/FlashCardList/FlashCardList.module.scss`
  - `src/components/Course/FlashCards/_shared.scss`

## Why
`--font-quran` is empty on this page, so the original `font-family` declaration becomes invalid and falls back to Figtree.

## Result
Flashcard Arabic text can use Kitab correctly in list/carousel/deck.
