### PR TITLE
refactor: use shared Kitab font stack token in flashcards

### DIFF
--- a/src/components/Course/FlashCards/FlashCardList/FlashCardList.module.scss
+++ b/src/components/Course/FlashCards/FlashCardList/FlashCardList.module.scss
@@ -65,7 +65,7 @@
 }
 
 .arabicText {
-  font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
+  font-family: var(--font-family-kitab);
   font-size: 1.25rem;
   line-height: 1.4;
   color: var(--color-text-default);

--- a/src/components/Course/FlashCards/_shared.scss
+++ b/src/components/Course/FlashCards/_shared.scss
@@ -51,7 +51,7 @@
   }
 
   .arabicText {
-    font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
+    font-family: var(--font-family-kitab);
     font-size: $arabicFont;
     line-height: 1.6;
     text-align: center;
@@ -64,7 +64,7 @@
   }
 
   .arabicTextSmall {
-    font-family: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
+    font-family: var(--font-family-kitab);
     font-size: $smallArabicFont;
     line-height: 1.4;
     text-align: center;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -74,6 +74,7 @@
   --font-weight-extra-bold: 800;
 
   --font-family-figtree: 'Figtree', sans-serif;
+  --font-family-kitab: 'Kitab', 'UthmanicHafs', 'Figtree', sans-serif;
 
   --border-radius-sharp: 0;
   --border-radius-pill: 20rem;


### PR DESCRIPTION
## Summary
Centralize the flashcard Arabic font stack into a shared theme token to avoid hardcoding in component styles.

## Changes
- Add `--font-family-kitab` in `src/styles/theme.scss`
- Replace hardcoded Kitab font stacks with `var(--font-family-kitab)` in:
  - `src/components/Course/FlashCards/FlashCardList/FlashCardList.module.scss`
  - `src/components/Course/FlashCards/_shared.scss`

## Result
Flashcard Arabic text keeps the same rendering behavior, with a single reusable font-stack source.
