### PR TITLE
[QF-4779] Update colors in StudyModeQiraatTab

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/JunctureTabs.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/JunctureTabs.module.scss
@@ -32,7 +32,7 @@
   block-size: calc(var(--spacing-small-plus-px) * 4);
   padding-inline: var(--spacing-medium-px);
   border-radius: var(--border-radius-pill);
-  background-color: var(--color-background-alternative-medium);
+  background-color: var(--color-background-alternative-faint);
   color: var(--color-text-default-new);
   line-height: 1;
   font-weight: var(--font-weight-medium);
@@ -40,8 +40,8 @@
   transition: background-color var(--transition-fast), transform var(--transition-fast);
 
   &:where(:hover, :focus-visible, [aria-selected='true']):not(:disabled) {
-    background-color: var(--color-blue-buttons-and-icons);
-    color: var(--color-text-white);
+    background-color: var(--color-success-medium);
+    color: var(--color-text-inverse);
   }
 
   &:active:not(:disabled) {


### PR DESCRIPTION
# Summary

- Update Qiraat juncture tabs default state background color from `--color-background-alternative-medium` to `--color-background-alternative-faint`
- Update Qiraat juncture tabs active/hover state background color from `--color-blue-buttons-and-icons` to `--color-success-medium`
- Update Qiraat juncture tabs active/hover state text color from `--color-text-white` to `--color-text-inverse`

Closes: [QF-4779](https://quranfoundation.atlassian.net/browse/QF-4779)


[QF-4779]: https://quranfoundation.atlassian.net/browse/QF-4779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ