### PR TITLE
 [QF-4753] feat: add 3-dots word hover actions in Arabic reading mode

### DIFF
--- a/locales/en/quran-reader.json
+++ b/locales/en/quran-reader.json
@@ -157,6 +157,7 @@
   "pin-verses-to-compare": "Pin verses to compare them",
   "pinned-saved-successfully": "Pinned verses saved successfully",
   "pinned-verses": "Pinned verses",
+  "play-from-word": "Play from Word",
   "posted-in": "Posted in",
   "prev-ayah": "Previous Ayah",
   "prev-hizb": "Previous Hizb",

--- a/locales/en/quran-reader.json
+++ b/locales/en/quran-reader.json
@@ -217,6 +217,7 @@
   "save-pinned-to-collection": "Save to Collection",
   "save-to": "Save to...",
   "save-verse": "Save verse {{verseKey}}",
+  "save-verse-short": "Save verse",
   "saved-to": "Saved to {{collectionName}}",
   "see-less": "See less",
   "see-more": "See more",

--- a/src/components/Notes/modal/ReadingViewNoteAction.tsx
+++ b/src/components/Notes/modal/ReadingViewNoteAction.tsx
@@ -11,6 +11,7 @@ import NotesWithPencilIcon from '@/icons/notes-with-pencil.svg';
 interface ReadingViewNoteActionProps {
   verseKey: string;
   onActionTriggered?: () => void;
+  onActionClick?: () => void;
   shouldCloseMenuAfterClick?: boolean;
   label?: string;
 }
@@ -18,6 +19,7 @@ interface ReadingViewNoteActionProps {
 const ReadingViewNoteAction: React.FC<ReadingViewNoteActionProps> = ({
   verseKey,
   onActionTriggered,
+  onActionClick,
   shouldCloseMenuAfterClick = false,
   label,
 }) => {
@@ -32,7 +34,10 @@ const ReadingViewNoteAction: React.FC<ReadingViewNoteActionProps> = ({
     >
       {({ onClick, hasNote }) => (
         <PopoverMenu.Item
-          onClick={onClick}
+          onClick={() => {
+            onActionClick?.();
+            onClick();
+          }}
           dataTestId="notes-menu-item"
           shouldCloseMenuAfterClick={shouldCloseMenuAfterClick}
           icon={

--- a/src/components/Notes/modal/ReadingViewNoteAction.tsx
+++ b/src/components/Notes/modal/ReadingViewNoteAction.tsx
@@ -11,13 +11,18 @@ import NotesWithPencilIcon from '@/icons/notes-with-pencil.svg';
 interface ReadingViewNoteActionProps {
   verseKey: string;
   onActionTriggered?: () => void;
+  shouldCloseMenuAfterClick?: boolean;
+  label?: string;
 }
 
 const ReadingViewNoteAction: React.FC<ReadingViewNoteActionProps> = ({
   verseKey,
   onActionTriggered,
+  shouldCloseMenuAfterClick = false,
+  label,
 }) => {
   const { t } = useTranslation('common');
+  const noteLabel = label || t('notes.label');
 
   return (
     <NoteActionController
@@ -29,6 +34,7 @@ const ReadingViewNoteAction: React.FC<ReadingViewNoteActionProps> = ({
         <PopoverMenu.Item
           onClick={onClick}
           dataTestId="notes-menu-item"
+          shouldCloseMenuAfterClick={shouldCloseMenuAfterClick}
           icon={
             <IconContainer
               shouldForceSetColors={false}
@@ -38,7 +44,7 @@ const ReadingViewNoteAction: React.FC<ReadingViewNoteActionProps> = ({
             />
           }
         >
-          {t('notes.label')}
+          {noteLabel}
         </PopoverMenu.Item>
       )}
     </NoteActionController>

--- a/src/components/Verse/BookmarkAction.tsx
+++ b/src/components/Verse/BookmarkAction.tsx
@@ -27,6 +27,7 @@ interface Props {
   verse: Verse;
   isTranslationView: boolean;
   onActionTriggered?: () => void;
+  onActionClick?: () => void;
   isInsideStudyMode?: boolean;
   forceMenuItem?: boolean;
   shouldCloseMenuAfterClick?: boolean;
@@ -45,6 +46,7 @@ const BookmarkAction: React.FC<Props> = ({
   verse,
   isTranslationView,
   onActionTriggered,
+  onActionClick,
   isInsideStudyMode = false,
   forceMenuItem = false,
   shouldCloseMenuAfterClick = false,
@@ -73,6 +75,7 @@ const BookmarkAction: React.FC<Props> = ({
         e.preventDefault();
         e.stopPropagation();
       }
+      onActionClick?.();
 
       logButtonClick(
         `${
@@ -101,9 +104,7 @@ const BookmarkAction: React.FC<Props> = ({
         }),
       );
 
-      if (onActionTriggered) {
-        onActionTriggered();
-      }
+      onActionTriggered?.();
     },
     [
       verse,
@@ -115,6 +116,7 @@ const BookmarkAction: React.FC<Props> = ({
       studyModeActiveTab,
       studyModeHighlightedWordLocation,
       dispatch,
+      onActionClick,
       onActionTriggered,
     ],
   );

--- a/src/components/Verse/BookmarkAction.tsx
+++ b/src/components/Verse/BookmarkAction.tsx
@@ -28,6 +28,9 @@ interface Props {
   isTranslationView: boolean;
   onActionTriggered?: () => void;
   isInsideStudyMode?: boolean;
+  forceMenuItem?: boolean;
+  shouldCloseMenuAfterClick?: boolean;
+  unbookmarkedLabel?: string;
 }
 
 /**
@@ -43,6 +46,9 @@ const BookmarkAction: React.FC<Props> = ({
   isTranslationView,
   onActionTriggered,
   isInsideStudyMode = false,
+  forceMenuItem = false,
+  shouldCloseMenuAfterClick = false,
+  unbookmarkedLabel,
 }): JSX.Element => {
   const dispatch = useDispatch();
   const {
@@ -123,10 +129,13 @@ const BookmarkAction: React.FC<Props> = ({
   );
 
   const isBookmarked = isVerseBookmarked || isVerseMultipleBookmarked || isVerseReadingBookmark;
-  const bookmarkLabel = isBookmarked ? t('bookmarked') : t('bookmark');
+  const bookmarkLabel = isBookmarked ? t('bookmarked') : unbookmarkedLabel || t('bookmark');
+
+  const shouldRenderAsButton =
+    !forceMenuItem && (isTranslationView || (!isTranslationView && isMobile));
 
   // For use in the TopActions component (standalone button)
-  if (isTranslationView || (!isTranslationView && isMobile)) {
+  if (shouldRenderAsButton) {
     return (
       <Button
         size={ButtonSize.Small}
@@ -151,6 +160,7 @@ const BookmarkAction: React.FC<Props> = ({
       onClick={onBookmarkClicked}
       icon={bookmarkIcon}
       isDisabled={isVerseBookmarkedLoading}
+      shouldCloseMenuAfterClick={shouldCloseMenuAfterClick}
     >
       {bookmarkLabel}
     </PopoverMenu.Item>

--- a/src/components/dls/Popover/Popover.module.scss
+++ b/src/components/dls/Popover/Popover.module.scss
@@ -47,7 +47,7 @@
   gap: var(--spacing-micro2-px);
 
   @include breakpoints.smallerThanTablet {
-    margin-inline: var(--spacing-small);
+    margin-inline-end: var(--spacing-small);
   }
 
   & > span {
@@ -83,11 +83,30 @@
   flex-shrink: 0;
   margin-inline-start: auto;
   cursor: pointer;
+
+  [dir='rtl'] & svg {
+    transform: scaleX(1);
+  }
+}
+
+.contentWithPrefix {
+  display: flex;
+  direction: ltr;
+  align-items: center;
+  gap: var(--spacing-xxsmall2-px);
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
+
+  & > span {
+    fill: var(--color-success-medium);
+  }
 }
 
 .clickableContent {
   cursor: pointer;
   display: flex;
+  direction: ltr;
   align-items: center;
   gap: var(--spacing-micro2-px);
 

--- a/src/components/dls/Popover/index.tsx
+++ b/src/components/dls/Popover/index.tsx
@@ -44,6 +44,7 @@ interface Props {
   onIconClick?: () => void;
   iconAriaLabel?: string;
   shouldContentBeClickable?: boolean;
+  suffixContent?: ReactNode;
 }
 
 const Popover: React.FC<Props> = ({
@@ -69,19 +70,24 @@ const Popover: React.FC<Props> = ({
   onIconClick,
   iconAriaLabel,
   shouldContentBeClickable = false,
+  suffixContent,
 }) => {
+  const hasSuffixContent = !!suffixContent;
+
+  const contentClassNames = classNames(styles.content, {
+    [styles.tooltipContent]: useTooltipStyles,
+    [styles.info]: tooltipType === TooltipType.INFO,
+    [styles.success]: tooltipType === TooltipType.SUCCESS,
+    [contentStyles]: contentStyles,
+  });
+
   const content = (
     <RadixPopover.Content
       sideOffset={contentSideOffset}
       side={contentSide}
       align={contentAlign}
       avoidCollisions={avoidCollisions}
-      className={classNames(styles.content, {
-        [styles.tooltipContent]: useTooltipStyles,
-        [styles.info]: tooltipType === TooltipType.INFO,
-        [styles.success]: tooltipType === TooltipType.SUCCESS,
-        [contentStyles]: contentStyles,
-      })}
+      className={hasSuffixContent ? styles.contentWithPrefix : contentClassNames}
       {...(stopPropagation && {
         onClick: (e) => e.stopPropagation(),
         onKeyDown: (e) => {
@@ -89,14 +95,32 @@ const Popover: React.FC<Props> = ({
         },
       })}
     >
-      <PopoverContentBody
-        icon={icon}
-        onIconClick={onIconClick}
-        iconAriaLabel={iconAriaLabel}
-        shouldContentBeClickable={shouldContentBeClickable}
-      >
-        {children}
-      </PopoverContentBody>
+      {hasSuffixContent ? (
+        <>
+          {suffixContent}
+          {children && (
+            <div className={contentClassNames}>
+              <PopoverContentBody
+                icon={icon}
+                onIconClick={onIconClick}
+                iconAriaLabel={iconAriaLabel}
+                shouldContentBeClickable={shouldContentBeClickable}
+              >
+                {children}
+              </PopoverContentBody>
+            </div>
+          )}
+        </>
+      ) : (
+        <PopoverContentBody
+          icon={icon}
+          onIconClick={onIconClick}
+          iconAriaLabel={iconAriaLabel}
+          shouldContentBeClickable={shouldContentBeClickable}
+        >
+          {children}
+        </PopoverContentBody>
+      )}
       {tip && <RadixPopover.Arrow />}
     </RadixPopover.Content>
   );

--- a/src/components/dls/PopoverMenu/PopoverMenu.tsx
+++ b/src/components/dls/PopoverMenu/PopoverMenu.tsx
@@ -36,6 +36,7 @@ type PopoverMenuProps = {
   contentClassName?: string;
   shouldClose?: boolean;
   shouldUseModalZIndex?: boolean;
+  dir?: Direction;
 };
 
 const PopoverMenu = ({
@@ -51,9 +52,11 @@ const PopoverMenu = ({
   align = PopoverMenuAlign.CENTER,
   sideOffset = 0,
   contentClassName,
+  dir,
 }: PopoverMenuProps) => {
   const [open, setOpen] = useState(isOpen);
-  const direction = useDirection();
+  const pageDirection = useDirection();
+  const direction = dir || pageDirection;
   const content = (
     <PrimitiveDropdownMenu.Content
       className={classNames(styles.content, contentClassName, {
@@ -68,14 +71,8 @@ const PopoverMenu = ({
   );
 
   const handleOpenChange = (newOpen: boolean) => {
-    if (!shouldClose) {
-      return;
-    }
-
-    if (onOpenChange) {
-      onOpenChange(newOpen);
-    }
-
+    if (!shouldClose) return;
+    onOpenChange?.(newOpen);
     setOpen(newOpen);
   };
 
@@ -136,8 +133,7 @@ PopoverMenu.Item = ({
       onClick={(e) => {
         if (shouldStopPropagation) e.stopPropagation();
         if (!shouldCloseMenuAfterClick) {
-          // PopoverMenu automatically close itself when one of item is clicked
-          // this code prevent that, so it only close when user click outside of the PopoverMenu
+          // Prevent auto-close so menu only closes on outside click
           e.preventDefault();
         }
         if (onClick) onClick();

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -41,10 +41,11 @@ import { areArraysEqual } from '@/utils/array';
 import { milliSecondsToSeconds } from '@/utils/datetime';
 import { logButtonClick } from '@/utils/eventLogger';
 import { isQCFFont } from '@/utils/fontFaceHelper';
-import { getChapterNumberFromKey, makeWordLocation } from '@/utils/verse';
+import { getChapterNumberFromKey, getVerseNumberFromKey, makeWordLocation } from '@/utils/verse';
 import { getWordTimeSegment } from 'src/xstate/actors/audioPlayer/audioPlayerMachineHelper';
 import { selectIsAudioPlayerVisible } from 'src/xstate/actors/audioPlayer/selectors';
 import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
+import Verse from 'types/Verse';
 import Word, { CharType } from 'types/Word';
 
 export const DATA_ATTRIBUTE_WORD_LOCATION = 'data-word-location';
@@ -189,6 +190,19 @@ const QuranWord = ({
     () => (isWordByWordAllowed ? getTooltipText(showTooltipFor, word) : null),
     [isWordByWordAllowed, showTooltipFor, word],
   );
+
+  const verseForWordActions = useMemo(() => {
+    const fallbackChapterId = Number(getChapterNumberFromKey(word.verseKey));
+    const fallbackVerseNumber = Number(getVerseNumberFromKey(word.verseKey));
+    const baseVerse = word.verse || {};
+
+    return {
+      ...baseVerse,
+      chapterId: baseVerse.chapterId ?? fallbackChapterId,
+      verseNumber: baseVerse.verseNumber ?? fallbackVerseNumber,
+      verseKey: baseVerse.verseKey ?? word.verseKey,
+    } as Verse;
+  }, [word.verse, word.verseKey]);
 
   const getReadingModeSuffix = useCallback(() => {
     if (readingPreference === ReadingPreference.Translation) {
@@ -388,6 +402,7 @@ const QuranWord = ({
                 isTooltipVisible={showTooltip}
                 tooltipContent={translationViewTooltipContent}
                 tooltipDelay={TOOLTIP_HOVER_DELAY_MS}
+                verse={verseForWordActions}
                 onOpenStudyMode={handleOpenStudyModeFromOverlay}
                 onPlayFromWord={handlePlayFromWord}
                 verseKey={word.verseKey}

--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -14,6 +14,7 @@ import GlyphWord from './GlyphWord';
 import playFromWord from './playFromWord';
 import playWordAudio from './playWordAudio';
 import styles from './QuranWord.module.scss';
+import type { ReadingWordHoverActionSource } from './ReadingModeWordHoverActions';
 import ReadingModeWordHoverActions from './ReadingModeWordHoverActions';
 import TextWord from './TextWord';
 
@@ -194,7 +195,7 @@ const QuranWord = ({
   const verseForWordActions = useMemo(() => {
     const fallbackChapterId = Number(getChapterNumberFromKey(word.verseKey));
     const fallbackVerseNumber = Number(getVerseNumberFromKey(word.verseKey));
-    const baseVerse = word.verse || {};
+    const baseVerse: Partial<Verse> = word.verse ?? {};
 
     return {
       ...baseVerse,
@@ -241,16 +242,26 @@ const QuranWord = ({
     }
   }, [isRecitationEnabled, seekToWordIfPlaying, word]);
 
-  const handleOpenStudyModeFromOverlay = useCallback(() => {
-    logButtonClick('reading_word_overlay_open_study_mode', { verseKey: word.verseKey });
-    dispatch(setReadingViewHoveredVerseKey(null));
-    dispatch(openStudyMode({ verseKey: word.verseKey, highlightedWordLocation: word.location }));
-  }, [dispatch, word.verseKey, word.location]);
+  const handleOpenStudyModeFromOverlay = useCallback(
+    (source: ReadingWordHoverActionSource) => {
+      if (source !== '3dots') {
+        logButtonClick('reading_word_overlay_open_study_mode', { verseKey: word.verseKey });
+      }
+      dispatch(setReadingViewHoveredVerseKey(null));
+      dispatch(openStudyMode({ verseKey: word.verseKey, highlightedWordLocation: word.location }));
+    },
+    [dispatch, word.verseKey, word.location],
+  );
 
-  const handlePlayFromWord = useCallback(() => {
-    logButtonClick('reading_word_overlay_play_from_word', { verseKey: word.verseKey });
-    playFromWord(word, audioService);
-  }, [word, audioService]);
+  const handlePlayFromWord = useCallback(
+    (source: ReadingWordHoverActionSource) => {
+      if (source !== '3dots') {
+        logButtonClick('reading_word_overlay_play_from_word', { verseKey: word.verseKey });
+      }
+      playFromWord(word, audioService);
+    },
+    [word, audioService],
+  );
 
   const handleReadingModeWordClick = useCallback(() => {
     if (isRecitationEnabled) {

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/ReadingModeWordHoverActions.module.scss
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/ReadingModeWordHoverActions.module.scss
@@ -1,0 +1,38 @@
+.threeDotsContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xsmall-px);
+  border-radius: var(--spacing-xxsmall-px);
+  background: var(--color-background-elevated);
+  box-shadow: var(--shadow-small);
+  cursor: pointer;
+  border: none;
+}
+
+.threeDotsIcon {
+  inline-size: var(--spacing-medium-plus-px);
+  block-size: var(--spacing-medium-plus-px);
+  color: var(--color-success-medium);
+}
+
+.menuContent {
+  padding-block: var(--spacing-small-px);
+  border-radius: var(--spacing-xxsmall-px);
+  min-inline-size: auto;
+  z-index: var(--z-index-modal);
+  direction: ltr;
+}
+
+.menuItemContent {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1;
+  gap: var(--spacing-xxsmall);
+}
+
+.menuItemChevron {
+  inline-size: var(--spacing-small2-px);
+  block-size: var(--spacing-small2-px);
+}

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/ReadingModeWordHoverActions.module.scss
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/ReadingModeWordHoverActions.module.scss
@@ -1,3 +1,4 @@
+@use 'src/styles/theme';
 .threeDotsContainer {
   display: flex;
   align-items: center;
@@ -5,7 +6,7 @@
   padding: var(--spacing-xsmall-px);
   border-radius: var(--spacing-xxsmall-px);
   background: var(--color-background-elevated);
-  box-shadow: var(--shadow-small);
+  box-shadow: var(--shadow-reading-word-three-dots);
   cursor: pointer;
   border: none;
 }

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+import useTranslation from 'next-translate/useTranslation';
+
+import styles from './ReadingModeWordHoverActions.module.scss';
+
+import IconContainer, { IconColor, IconSize } from '@/dls/IconContainer/IconContainer';
+import PopoverMenu, { PopoverMenuAlign } from '@/dls/PopoverMenu/PopoverMenu';
+import ArrowIcon from '@/icons/arrow.svg';
+import BookIcon from '@/icons/book-open.svg';
+import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
+import PlayIcon from '@/icons/play-outline.svg';
+import RepeatIcon from '@/icons/repeat-new.svg';
+import { Direction } from '@/utils/locale';
+
+const DROPDOWN_SIDE_OFFSET = 5;
+
+type Props = {
+  onOpenChange?: (open: boolean) => void;
+  onMore: () => void;
+  onPlayFromWord: () => void;
+  onRepeatVerse: () => void;
+};
+
+const WordOptionsDropdown: React.FC<Props> = ({
+  onOpenChange,
+  onMore,
+  onPlayFromWord,
+  onRepeatVerse,
+}) => {
+  const { t } = useTranslation('common');
+
+  return (
+    <PopoverMenu
+      contentClassName={styles.menuContent}
+      dir={Direction.LTR}
+      align={PopoverMenuAlign.END}
+      sideOffset={DROPDOWN_SIDE_OFFSET}
+      onOpenChange={onOpenChange}
+      trigger={
+        <button
+          type="button"
+          className={styles.threeDotsContainer}
+          aria-label={t('more')}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <OverflowMenuIcon className={styles.threeDotsIcon} />
+        </button>
+      }
+    >
+      <PopoverMenu.Item
+        icon={
+          <IconContainer
+            icon={<BookIcon />}
+            color={IconColor.tertiary}
+            size={IconSize.Custom}
+            shouldFlipOnRTL={false}
+          />
+        }
+        onClick={onMore}
+        shouldCloseMenuAfterClick
+      >
+        <span className={styles.menuItemContent}>
+          {t('more')}
+          <ArrowIcon className={styles.menuItemChevron} />
+        </span>
+      </PopoverMenu.Item>
+
+      <PopoverMenu.Item
+        icon={
+          <IconContainer
+            icon={<PlayIcon />}
+            color={IconColor.tertiary}
+            size={IconSize.Custom}
+            shouldFlipOnRTL={false}
+          />
+        }
+        onClick={onPlayFromWord}
+        shouldCloseMenuAfterClick
+      >
+        {t('quran-reader:play-from-word')}
+      </PopoverMenu.Item>
+
+      <PopoverMenu.Item
+        icon={
+          <IconContainer
+            icon={<RepeatIcon />}
+            color={IconColor.tertiary}
+            size={IconSize.Custom}
+            shouldFlipOnRTL={false}
+          />
+        }
+        onClick={onRepeatVerse}
+        shouldCloseMenuAfterClick
+      >
+        {t('audio.player.repeat-1-verse')}
+      </PopoverMenu.Item>
+    </PopoverMenu>
+  );
+};
+
+export default WordOptionsDropdown;

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
@@ -4,6 +4,8 @@ import useTranslation from 'next-translate/useTranslation';
 
 import styles from './ReadingModeWordHoverActions.module.scss';
 
+import ReadingViewNoteAction from '@/components/Notes/modal/ReadingViewNoteAction';
+import BookmarkAction from '@/components/Verse/BookmarkAction';
 import IconContainer, { IconColor, IconSize } from '@/dls/IconContainer/IconContainer';
 import PopoverMenu, { PopoverMenuAlign } from '@/dls/PopoverMenu/PopoverMenu';
 import ArrowIcon from '@/icons/arrow.svg';
@@ -12,10 +14,12 @@ import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 import PlayIcon from '@/icons/play-outline.svg';
 import RepeatIcon from '@/icons/repeat-new.svg';
 import { Direction } from '@/utils/locale';
+import Verse from 'types/Verse';
 
 const DROPDOWN_SIDE_OFFSET = 5;
 
 type Props = {
+  verse: Verse;
   onOpenChange?: (open: boolean) => void;
   onMore: () => void;
   onPlayFromWord: () => void;
@@ -23,6 +27,7 @@ type Props = {
 };
 
 const WordOptionsDropdown: React.FC<Props> = ({
+  verse,
   onOpenChange,
   onMore,
   onPlayFromWord,
@@ -80,6 +85,20 @@ const WordOptionsDropdown: React.FC<Props> = ({
       >
         {t('quran-reader:play-from-word')}
       </PopoverMenu.Item>
+
+      <BookmarkAction
+        verse={verse}
+        isTranslationView={false}
+        forceMenuItem
+        shouldCloseMenuAfterClick
+        unbookmarkedLabel={t('quran-reader:save-verse-short')}
+      />
+
+      <ReadingViewNoteAction
+        verseKey={verse.verseKey}
+        shouldCloseMenuAfterClick
+        label={t('quran-reader:take-a-note')}
+      />
 
       <PopoverMenu.Item
         icon={

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
@@ -13,6 +13,7 @@ import BookIcon from '@/icons/book-open.svg';
 import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
 import PlayIcon from '@/icons/play-outline.svg';
 import RepeatIcon from '@/icons/repeat-new.svg';
+import { logButtonClick } from '@/utils/eventLogger';
 import { Direction } from '@/utils/locale';
 import Verse from 'types/Verse';
 
@@ -92,12 +93,18 @@ const WordOptionsDropdown: React.FC<Props> = ({
         forceMenuItem
         shouldCloseMenuAfterClick
         unbookmarkedLabel={t('quran-reader:save-verse-short')}
+        onActionClick={() => {
+          logButtonClick('reading_word_3dots_save_verse', { verseKey: verse.verseKey });
+        }}
       />
 
       <ReadingViewNoteAction
         verseKey={verse.verseKey}
         shouldCloseMenuAfterClick
         label={t('quran-reader:take-a-note')}
+        onActionClick={() => {
+          logButtonClick('reading_word_3dots_take_note', { verseKey: verse.verseKey });
+        }}
       />
 
       <PopoverMenu.Item

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/index.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/index.tsx
@@ -1,0 +1,102 @@
+import React, { ReactNode, useCallback, useState } from 'react';
+
+import useTranslation from 'next-translate/useTranslation';
+
+import WordOptionsDropdown from './WordOptionsDropdown';
+
+import RepeatAudioModal from '@/components/AudioPlayer/RepeatAudioModal/RepeatAudioModal';
+import { RepetitionMode } from '@/components/AudioPlayer/RepeatAudioModal/SelectRepetitionMode';
+import MobilePopover from '@/dls/Popover/HoverablePopover';
+import { TooltipType } from '@/dls/Tooltip';
+import ArrowIcon from '@/icons/arrow.svg';
+import { logButtonClick } from '@/utils/eventLogger';
+import { getChapterNumberFromKey } from '@/utils/verse';
+
+type Props = {
+  children: ReactNode;
+  isTooltipVisible: boolean;
+  tooltipContent: ReactNode;
+  tooltipDelay: number;
+  onOpenStudyMode: () => void;
+  onPlayFromWord: () => void;
+  verseKey: string;
+};
+
+const ReadingModeWordHoverActions: React.FC<Props> = ({
+  children,
+  isTooltipVisible,
+  tooltipContent,
+  tooltipDelay,
+  onOpenStudyMode,
+  onPlayFromWord,
+  verseKey,
+}) => {
+  const { t } = useTranslation('common');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isRepeatModalOpen, setIsRepeatModalOpen] = useState(false);
+
+  const handleDropdownOpenChange = useCallback((open: boolean) => {
+    setIsDropdownOpen(open);
+  }, []);
+
+  const handleMore = useCallback(() => {
+    logButtonClick('reading_word_3dots_more', { verseKey });
+    onOpenStudyMode();
+  }, [onOpenStudyMode, verseKey]);
+
+  const handlePlayFromWord = useCallback(() => {
+    logButtonClick('reading_word_3dots_play_from_word', { verseKey });
+    onPlayFromWord();
+  }, [onPlayFromWord, verseKey]);
+
+  const handleRepeatVerse = useCallback(() => {
+    logButtonClick('reading_word_3dots_repeat_verse', { verseKey });
+    setIsRepeatModalOpen(true);
+  }, [verseKey]);
+
+  const handleTooltipClick = useCallback(() => {
+    logButtonClick('reading_word_tooltip_open_study_mode', { verseKey });
+    onOpenStudyMode();
+  }, [onOpenStudyMode, verseKey]);
+
+  const chapterId = getChapterNumberFromKey(verseKey);
+
+  const dropdown = (
+    <WordOptionsDropdown
+      onOpenChange={handleDropdownOpenChange}
+      onMore={handleMore}
+      onPlayFromWord={handlePlayFromWord}
+      onRepeatVerse={handleRepeatVerse}
+    />
+  );
+
+  return (
+    <>
+      <MobilePopover
+        content={isTooltipVisible ? tooltipContent : null}
+        suffixContent={dropdown}
+        tooltipType={isTooltipVisible ? TooltipType.SUCCESS : undefined}
+        shouldContentBeClickable={isTooltipVisible}
+        onIconClick={isTooltipVisible ? handleTooltipClick : undefined}
+        icon={isTooltipVisible ? <ArrowIcon /> : undefined}
+        iconAriaLabel={isTooltipVisible ? t('quran-reader:aria.open-study-mode') : undefined}
+        defaultStyling={false}
+        isContainerSpan
+        tooltipDelay={tooltipDelay}
+        isTooltipOpen={isDropdownOpen || undefined}
+      >
+        {children}
+      </MobilePopover>
+
+      <RepeatAudioModal
+        defaultRepetitionMode={RepetitionMode.Single}
+        selectedVerseKey={verseKey}
+        chapterId={chapterId.toString()}
+        isOpen={isRepeatModalOpen}
+        onClose={() => setIsRepeatModalOpen(false)}
+      />
+    </>
+  );
+};
+
+export default ReadingModeWordHoverActions;

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/index.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/index.tsx
@@ -13,14 +13,16 @@ import { logButtonClick } from '@/utils/eventLogger';
 import { getChapterNumberFromKey } from '@/utils/verse';
 import Verse from 'types/Verse';
 
+export type ReadingWordHoverActionSource = '3dots' | 'tooltip';
+
 type Props = {
   children: ReactNode;
   isTooltipVisible: boolean;
   tooltipContent: ReactNode;
   tooltipDelay: number;
   verse: Verse;
-  onOpenStudyMode: () => void;
-  onPlayFromWord: () => void;
+  onOpenStudyMode: (source: ReadingWordHoverActionSource) => void;
+  onPlayFromWord: (source: ReadingWordHoverActionSource) => void;
   verseKey: string;
 };
 
@@ -38,18 +40,24 @@ const ReadingModeWordHoverActions: React.FC<Props> = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isRepeatModalOpen, setIsRepeatModalOpen] = useState(false);
 
-  const handleDropdownOpenChange = useCallback((open: boolean) => {
-    setIsDropdownOpen(open);
-  }, []);
+  const handleDropdownOpenChange = useCallback(
+    (open: boolean) => {
+      logButtonClick(open ? 'reading_word_3dots_open' : 'reading_word_3dots_close', {
+        verseKey,
+      });
+      setIsDropdownOpen(open);
+    },
+    [verseKey],
+  );
 
   const handleMore = useCallback(() => {
     logButtonClick('reading_word_3dots_more', { verseKey });
-    onOpenStudyMode();
+    onOpenStudyMode('3dots');
   }, [onOpenStudyMode, verseKey]);
 
   const handlePlayFromWord = useCallback(() => {
     logButtonClick('reading_word_3dots_play_from_word', { verseKey });
-    onPlayFromWord();
+    onPlayFromWord('3dots');
   }, [onPlayFromWord, verseKey]);
 
   const handleRepeatVerse = useCallback(() => {
@@ -59,7 +67,7 @@ const ReadingModeWordHoverActions: React.FC<Props> = ({
 
   const handleTooltipClick = useCallback(() => {
     logButtonClick('reading_word_tooltip_open_study_mode', { verseKey });
-    onOpenStudyMode();
+    onOpenStudyMode('tooltip');
   }, [onOpenStudyMode, verseKey]);
 
   const chapterId = getChapterNumberFromKey(verseKey);

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/index.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/index.tsx
@@ -11,12 +11,14 @@ import { TooltipType } from '@/dls/Tooltip';
 import ArrowIcon from '@/icons/arrow.svg';
 import { logButtonClick } from '@/utils/eventLogger';
 import { getChapterNumberFromKey } from '@/utils/verse';
+import Verse from 'types/Verse';
 
 type Props = {
   children: ReactNode;
   isTooltipVisible: boolean;
   tooltipContent: ReactNode;
   tooltipDelay: number;
+  verse: Verse;
   onOpenStudyMode: () => void;
   onPlayFromWord: () => void;
   verseKey: string;
@@ -27,6 +29,7 @@ const ReadingModeWordHoverActions: React.FC<Props> = ({
   isTooltipVisible,
   tooltipContent,
   tooltipDelay,
+  verse,
   onOpenStudyMode,
   onPlayFromWord,
   verseKey,
@@ -63,6 +66,7 @@ const ReadingModeWordHoverActions: React.FC<Props> = ({
 
   const dropdown = (
     <WordOptionsDropdown
+      verse={verse}
       onOpenChange={handleDropdownOpenChange}
       onMore={handleMore}
       onPlayFromWord={handlePlayFromWord}

--- a/src/components/dls/QuranWord/playFromWord.ts
+++ b/src/components/dls/QuranWord/playFromWord.ts
@@ -1,0 +1,71 @@
+import { InterpreterFrom } from 'xstate';
+
+import { milliSecondsToSeconds } from '@/utils/datetime';
+import { getChapterNumberFromKey, getVerseNumberFromKey } from '@/utils/verse';
+import { audioPlayerMachine } from 'src/xstate/actors/audioPlayer/audioPlayerMachine';
+import { getWordTimeSegment } from 'src/xstate/actors/audioPlayer/audioPlayerMachineHelper';
+import VerseTiming from 'types/VerseTiming';
+import Word from 'types/Word';
+
+type AudioService = InterpreterFrom<typeof audioPlayerMachine>;
+
+let activeCleanup: (() => void) | null = null;
+
+const seekToWord = (word: Word, audioService: AudioService, verseTimings: VerseTiming[]) => {
+  const wordSegment = getWordTimeSegment(verseTimings, word);
+  if (wordSegment) {
+    audioService.send({ type: 'SEEK_TO', timestamp: milliSecondsToSeconds(wordSegment[0]) });
+  }
+};
+
+const playAndSeekAfterLoad = (word: Word, audioService: AudioService): (() => void) => {
+  const wordSurah = Number(getChapterNumberFromKey(word.verseKey));
+  const verseNumber = Number(getVerseNumberFromKey(word.verseKey));
+
+  audioService.send({ type: 'PLAY_AYAH', surah: wordSurah, ayahNumber: verseNumber });
+
+  let unsubscribed = false;
+  const subscription = audioService.subscribe((state) => {
+    if (unsubscribed) return;
+    if (
+      state.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING') &&
+      state.context.audioData?.verseTimings
+    ) {
+      seekToWord(word, audioService, state.context.audioData.verseTimings);
+      subscription.unsubscribe();
+      unsubscribed = true;
+      activeCleanup = null;
+    }
+  });
+
+  return () => {
+    if (!unsubscribed) {
+      subscription.unsubscribe();
+      unsubscribed = true;
+      activeCleanup = null;
+    }
+  };
+};
+
+const playFromWord = (word: Word, audioService: AudioService): void => {
+  activeCleanup?.();
+  activeCleanup = null;
+
+  const currentState = audioService.getSnapshot();
+  const isPlaying = currentState.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING');
+  const isPaused = currentState.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED');
+  const wordSurah = Number(getChapterNumberFromKey(word.verseKey));
+  const isSameSurah = currentState.context.surah === wordSurah;
+
+  if ((isPlaying || isPaused) && isSameSurah) {
+    seekToWord(word, audioService, currentState.context.audioData.verseTimings);
+    if (isPaused) {
+      audioService.send({ type: 'TOGGLE' });
+    }
+    return;
+  }
+
+  activeCleanup = playAndSeekAfterLoad(word, audioService);
+};
+
+export default playFromWord;

--- a/src/components/dls/QuranWord/playFromWord.ts
+++ b/src/components/dls/QuranWord/playFromWord.ts
@@ -40,7 +40,7 @@ const playAndSeekAfterLoad = (word: Word, audioService: AudioService): (() => vo
     ) {
       seekToWord(word, audioService, state.context.audioData.verseTimings);
       cleanup();
-    } else if (state.matches('IDLE') || state.done) {
+    } else if (state.matches('HIDDEN') || state.done) {
       cleanup();
     }
   });

--- a/src/components/dls/Tooltip/Tooltip.module.scss
+++ b/src/components/dls/Tooltip/Tooltip.module.scss
@@ -16,9 +16,8 @@
   color: var(--color-text-inverse);
   background-color: var(--color-background-inverse);
   max-inline-size: calc(10 * var(--spacing-mega));
-  // Changed from text-align to flexbox to support icon alignment
-  // Flexbox allows the icon to be positioned at the end while keeping content centered
   display: flex;
+  direction: ltr;
   align-items: center;
   justify-content: center;
   gap: var(--spacing-micro2-px);
@@ -76,11 +75,28 @@
   flex-shrink: 0;
   margin-inline-start: auto;
   cursor: pointer;
+
+  [dir='rtl'] & svg {
+    transform: scaleX(1);
+  }
+}
+
+.contentWithPrefix {
+  z-index: var(--z-index-sticky);
+  display: flex;
+  direction: ltr;
+  align-items: center;
+  gap: var(--spacing-xxsmall2-px);
+
+  & > span {
+    fill: var(--color-success-medium);
+  }
 }
 
 .clickableContent {
   cursor: pointer;
   display: flex;
+  direction: ltr;
   align-items: center;
   gap: var(--spacing-micro2-px);
 

--- a/src/components/dls/Tooltip/index.tsx
+++ b/src/components/dls/Tooltip/index.tsx
@@ -126,29 +126,34 @@ const Tooltip: React.FC<Props> = ({
       <RadixTooltip.Trigger aria-label="Open tooltip" asChild>
         <span className={styles.trigger}>{children}</span>
       </RadixTooltip.Trigger>
-      <RadixTooltip.Portal>
+      {suffixContent ? (
+        <RadixTooltip.Portal>
+          <RadixTooltip.Content
+            sideOffset={2}
+            side={contentSide}
+            align={contentAlign}
+            avoidCollisions={avoidCollisions}
+            className={styles.contentWithPrefix}
+          >
+            {suffixContent}
+            {text && (
+              <div className={classNames(styles.content, typeClassNames)}>{innerContent}</div>
+            )}
+            {tip && <RadixTooltip.Arrow />}
+          </RadixTooltip.Content>
+        </RadixTooltip.Portal>
+      ) : (
         <RadixTooltip.Content
           sideOffset={2}
           side={contentSide}
           align={contentAlign}
           avoidCollisions={avoidCollisions}
-          className={
-            suffixContent ? styles.contentWithPrefix : classNames(styles.content, typeClassNames)
-          }
+          className={classNames(styles.content, typeClassNames)}
         >
-          {suffixContent ? (
-            <>
-              {suffixContent}
-              {text && (
-                <div className={classNames(styles.content, typeClassNames)}>{innerContent}</div>
-              )}
-            </>
-          ) : (
-            innerContent
-          )}
+          {innerContent}
           {tip && <RadixTooltip.Arrow />}
         </RadixTooltip.Content>
-      </RadixTooltip.Portal>
+      )}
     </RadixTooltip.Root>
   );
 };

--- a/src/components/dls/Tooltip/index.tsx
+++ b/src/components/dls/Tooltip/index.tsx
@@ -43,6 +43,7 @@ interface Props {
   onIconClick?: () => void;
   iconAriaLabel?: string;
   shouldContentBeClickable?: boolean;
+  suffixContent?: ReactNode;
 }
 
 const Tooltip: React.FC<Props> = ({
@@ -62,80 +63,94 @@ const Tooltip: React.FC<Props> = ({
   onIconClick,
   iconAriaLabel,
   shouldContentBeClickable = false,
-}) => (
-  <RadixTooltip.Root
-    delayDuration={delay}
-    {...(typeof open !== 'undefined' && { open })}
-    {...(onOpenChange && { onOpenChange })}
-  >
-    <RadixTooltip.Trigger aria-label="Open tooltip" asChild>
-      <span className={styles.trigger}>{children}</span>
-    </RadixTooltip.Trigger>
-    <RadixTooltip.Content
-      sideOffset={2}
-      side={contentSide}
-      align={contentAlign}
-      avoidCollisions={avoidCollisions}
-      className={classNames(styles.content, {
-        [styles.noInverse]: invertColors === false,
-        [styles.noCenter]: centerText === false,
-        [styles.success]: type === TooltipType.SUCCESS,
-        [styles.warning]: type === TooltipType.WARNING,
-        [styles.error]: type === TooltipType.ERROR,
-        [styles.secondary]: type === TooltipType.SECONDARY,
-        [styles.info]: type === TooltipType.INFO,
-      })}
+  suffixContent,
+}) => {
+  const typeClassNames = {
+    [styles.noInverse]: invertColors === false,
+    [styles.noCenter]: centerText === false,
+    [styles.success]: type === TooltipType.SUCCESS,
+    [styles.warning]: type === TooltipType.WARNING,
+    [styles.error]: type === TooltipType.ERROR,
+    [styles.secondary]: type === TooltipType.SECONDARY,
+    [styles.info]: type === TooltipType.INFO,
+  };
+
+  const handleIconClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onIconClick?.();
+  };
+  const handleIconKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      onIconClick?.();
+    }
+  };
+
+  const innerContent = shouldContentBeClickable ? (
+    <div
+      role="button"
+      tabIndex={0}
+      className={styles.clickableContent}
+      onClick={handleIconClick}
+      onKeyDown={handleIconKeyDown}
+      aria-label={iconAriaLabel}
     >
-      {shouldContentBeClickable ? (
-        <div
+      {text}
+      {icon && <span className={styles.icon}>{icon}</span>}
+    </div>
+  ) : (
+    <>
+      {text}
+      {icon && (
+        <span
+          className={styles.icon}
+          onClick={handleIconClick}
+          onKeyDown={handleIconKeyDown}
           role="button"
           tabIndex={0}
-          className={styles.clickableContent}
-          onClick={(e) => {
-            e.stopPropagation();
-            onIconClick?.();
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              e.stopPropagation();
-              onIconClick?.();
-            }
-          }}
           aria-label={iconAriaLabel}
         >
-          {icon && <span className={styles.icon}>{icon}</span>}
-          {text}
-        </div>
-      ) : (
-        <>
-          {icon && (
-            <span
-              className={styles.icon}
-              onClick={(e) => {
-                e.stopPropagation();
-                onIconClick?.();
-              }}
-              role="button"
-              tabIndex={0}
-              aria-label={iconAriaLabel}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onIconClick?.();
-                }
-              }}
-            >
-              {icon}
-            </span>
-          )}
-          {text}
-        </>
+          {icon}
+        </span>
       )}
-      {tip && <RadixTooltip.Arrow />}
-    </RadixTooltip.Content>
-  </RadixTooltip.Root>
-);
+    </>
+  );
+
+  return (
+    <RadixTooltip.Root
+      delayDuration={delay}
+      {...(typeof open !== 'undefined' && { open })}
+      {...(onOpenChange && { onOpenChange })}
+    >
+      <RadixTooltip.Trigger aria-label="Open tooltip" asChild>
+        <span className={styles.trigger}>{children}</span>
+      </RadixTooltip.Trigger>
+      <RadixTooltip.Portal>
+        <RadixTooltip.Content
+          sideOffset={2}
+          side={contentSide}
+          align={contentAlign}
+          avoidCollisions={avoidCollisions}
+          className={
+            suffixContent ? styles.contentWithPrefix : classNames(styles.content, typeClassNames)
+          }
+        >
+          {suffixContent ? (
+            <>
+              {suffixContent}
+              {text && (
+                <div className={classNames(styles.content, typeClassNames)}>{innerContent}</div>
+              )}
+            </>
+          ) : (
+            innerContent
+          )}
+          {tip && <RadixTooltip.Arrow />}
+        </RadixTooltip.Content>
+      </RadixTooltip.Portal>
+    </RadixTooltip.Root>
+  );
+};
 
 export default Tooltip;

--- a/src/styles/themes/_dark.scss
+++ b/src/styles/themes/_dark.scss
@@ -75,6 +75,7 @@
   --shadow-language-selector: 0px 2px 4px 0px rgba(0, 0, 0, 0.3);
   --shadow-chapter-header-actions: 0px 0px 4px rgba(0, 0, 0, 0.7);
   --shadow-tajweed-trigger: 0px 2px 4px rgba(0, 0, 0, 0.7);
+  --shadow-reading-word-three-dots: 0px 0px 4px 0px rgba(0, 0, 0, 0.7);
   font-palette: --Dark;
 
   // scrollbar styles

--- a/src/styles/themes/_light.scss
+++ b/src/styles/themes/_light.scss
@@ -66,6 +66,7 @@
   --color-highlight-dark: #22a5ad;
 
   --shadow-small: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-reading-word-three-dots: var(--shadow-small);
   --shadow-small-new: 0px 0px 4px 0px rgba(0, 0, 0, 0.1);
   --shadow-flat: 0px 0px 8px rgba(0, 0, 0, 0.12);
   --shadow-normal: 0px 4px 8px rgba(0, 0, 0, 0.12);

--- a/src/styles/themes/_sepia.scss
+++ b/src/styles/themes/_sepia.scss
@@ -60,6 +60,7 @@
   --color-highlight: #50e3c2;
 
   --shadow-small: 0px 2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-reading-word-three-dots: var(--shadow-small);
   --shadow-flat: 0px 0px 8px rgba(0, 0, 0, 0.12);
   --shadow-normal: 0px 4px 8px rgba(0, 0, 0, 0.12);
   --shadow-medium: 0px 4px 10px 0px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary

  - Adds a **3-dots overflow menu** when hovering or tapping words in **Arabic reading mode**.
  - The menu now provides five actions in this order:
  1. **More** → opens study mode
  2. **Play from Word** → starts audio from the selected word
  3. **Save verse** / **Bookmarked** → opens bookmark flow with existing stateful icon/label behavior
  4. **Take a note** → opens notes flow with existing stateful note icon behavior
  5. **Repeat Verse** → opens the repeat audio modal
  - When **translation/transliteration tooltips are enabled**, the 3-dots button appears alongside the tooltip.
  - When **tooltips are disabled**, only the 3-dots button appears.
  - Layout renders consistently in both **LTR and RTL locales**.
  - 3-dots shadow token is now handled across all three themes (**Light / Sepia / Dark**).

  Closes: [QF-4753](https://quranfoundation.atlassian.net/browse/QF-4753)

  ## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Open Arabic reading mode with translation tooltip enabled.
  2. Hover a word and verify 3-dots appears next to the tooltip with arrow icon after text.
  3. Click the tooltip text and verify study mode opens.
  4. Click the 3-dots and verify dropdown opens with:
     - More
     - Play from Word
     - Save verse / Bookmarked (state-based)
     - Take a note
     - Repeat Verse
  5. Click each dropdown action and verify the tooltip/dropdown close after action.
  6. Re-hover the same word and verify tooltip reappears normally.
  7. Disable translation/transliteration and hover a word; verify only 3-dots appears.
  8. Switch to an RTL locale and verify layout matches LTR (no unintended flipping).
  9. On mobile, tap a word and verify the same overlay appears via popover.
  10. Switch to translation/verse-by-verse mode and verify no regressions to existing tooltip behavior.
  11. Verify 3-dots shadow looks correct in **Light**, **Sepia**, and **Dark** themes.

  ### Edge Cases Verified

  - [x] Loading state handled
  - [x] Error state handled
  - [ ] Empty state handled
  - [x] Logged-in vs guest behavior (if applicable)

  ## Analytics / Event Logs

  ### New events added in this PR

  | Event | When it fires | Description |
  | --- | --- | --- |
  | `reading_word_3dots_open` | User opens the 3-dots menu | Tracks menu open interaction for word actions. |
  | `reading_word_3dots_close` | User closes the 3-dots menu | Tracks menu close interaction for word actions. |
  | `reading_word_3dots_more` | User clicks **More** | Tracks navigation from word menu into study mode. |
  | `reading_word_3dots_play_from_word` | User clicks **Play from Word** | Tracks explicit play-from-word action from 3-dots menu. |
  | `reading_word_3dots_save_verse` | User clicks **Save verse** / **Bookmarked** | Tracks bookmark intent from 3-dots menu specifically. |
  | `reading_word_3dots_take_note` | User clicks **Take a note** | Tracks note intent from 3-dots menu specifically. |
  | `reading_word_3dots_repeat_verse` | User clicks **Repeat Verse** | Tracks repeat-verse action from 3-dots menu. |


  ### Existing events intentionally suppressed for 3-dots source (dedupe)

  | Event | Status | Reason |
  | --- | --- | --- |
  | `reading_word_overlay_open_study_mode` | Suppressed for 3-dots actions | Avoid double logging with `reading_word_3dots_more`. |
  | `reading_word_overlay_play_from_word` | Suppressed for 3-dots actions | Avoid double logging with `reading_word_3dots_play_from_word`. |

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [x] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [x] Inline comments added for complex logic

  ### Localization (if UI changes)

  - [x] All user-facing text uses `next-translate`
  - [x] Only English locale files modified (Lokalise handles others)
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] ARIA attributes added where needed
  - [x] Keyboard navigation works

  ## Screenshots/Videos

## Screenshots/Videos

  | Theme | Screenshot |
  | --- | --- |
  | Light Mode | <img width="451" height="441" alt="image" src="https://github.com/user-attachments/assets/fba40dd9-e63b-420b-8771-b004591eaca7" /> |
  | Sepia Mode | <img width="437" height="490" alt="image" src="https://github.com/user-attachments/assets/285851da-7c96-4832-b4b3-57e0e4a579e8" /> |
  | Dark Mode | <img width="444" height="448" alt="image" src="https://github.com/user-attachments/assets/081e337c-38b3-497d-b817-f70b58ed44a3" /> |

  ## Reviewer Notes

  - `PopoverMenu` gained an optional `dir` prop to override page direction for Radix positioning, used by
  `WordOptionsDropdown`.
  - Bookmark and note actions in 3-dots reuse existing shared components (`BookmarkAction`, `ReadingViewNoteAction`) to
  avoid duplication.
  - Added `quran-reader:save-verse-short` for 3-dots unbookmarked label.

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

  [QF-4753]: https://quranfoundation.atlassian.net/browse/QF-4753?
  atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[QF-4753]: https://quranfoundation.atlassian.net/browse/QF-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QF-4753]: https://quranfoundation.atlassian.net/browse/QF-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ