### PR TITLE
Fix embed editor verse mismatch and open page in new tab

### DIFF
--- a/src/components/Verse/VerseActionEmbedWidget/index.tsx
+++ b/src/components/Verse/VerseActionEmbedWidget/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 
 import IconContainer, { IconColor, IconSize } from '@/dls/IconContainer/IconContainer';
@@ -24,6 +25,7 @@ const VerseActionEmbedWidget = ({
   onActionTriggered,
 }: VerseActionEmbedWidgetProps) => {
   const { t } = useTranslation('quran-reader');
+  const { locale } = useRouter();
 
   const onClick = () => {
     // eslint-disable-next-line i18next/no-literal-string
@@ -36,7 +38,8 @@ const VerseActionEmbedWidget = ({
 
     // Open widget builder with the selected verse in a new tab
     const versesParam = `${surah}:${ayah}`;
-    const url = `/embed?verses=${encodeURIComponent(versesParam)}`;
+    const localePrefix = locale === 'en' ? '' : `/${locale}`;
+    const url = `${localePrefix}/embed?verses=${encodeURIComponent(versesParam)}`;
     navigateToExternalUrl(url);
 
     if (onActionTriggered) {

--- a/src/components/Verse/VerseActionEmbedWidget/index.tsx
+++ b/src/components/Verse/VerseActionEmbedWidget/index.tsx
@@ -4,6 +4,7 @@ import IconContainer, { IconColor, IconSize } from '@/dls/IconContainer/IconCont
 import PopoverMenu from '@/dls/PopoverMenu/PopoverMenu';
 import CodeIcon from '@/icons/code-embed.svg';
 import { logButtonClick } from '@/utils/eventLogger';
+import { navigateToExternalUrl } from '@/utils/url';
 import Verse from 'types/Verse';
 
 type VerseActionEmbedWidgetProps = {
@@ -36,12 +37,7 @@ const VerseActionEmbedWidget = ({
     // Open widget builder with the selected verse in a new tab
     const versesParam = `${surah}:${ayah}`;
     const url = `/embed?verses=${encodeURIComponent(versesParam)}`;
-    const newWindow = window.open(url, '_blank');
-
-    // Fallback: if the popup is blocked, navigate in the current tab
-    if (!newWindow) {
-      window.location.href = url;
-    }
+    navigateToExternalUrl(url);
 
     if (onActionTriggered) {
       onActionTriggered();

--- a/src/components/Verse/VerseActionEmbedWidget/index.tsx
+++ b/src/components/Verse/VerseActionEmbedWidget/index.tsx
@@ -35,7 +35,13 @@ const VerseActionEmbedWidget = ({
 
     // Open widget builder with the selected verse in a new tab
     const versesParam = `${surah}:${ayah}`;
-    window.open(`/embed?verses=${encodeURIComponent(versesParam)}`, '_blank');
+    const url = `/embed?verses=${encodeURIComponent(versesParam)}`;
+    const newWindow = window.open(url, '_blank');
+
+    // Fallback: if the popup is blocked, navigate in the current tab
+    if (!newWindow) {
+      window.location.href = url;
+    }
 
     if (onActionTriggered) {
       onActionTriggered();

--- a/src/components/Verse/VerseActionEmbedWidget/index.tsx
+++ b/src/components/Verse/VerseActionEmbedWidget/index.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 
 import IconContainer, { IconColor, IconSize } from '@/dls/IconContainer/IconContainer';
@@ -24,7 +23,6 @@ const VerseActionEmbedWidget = ({
   onActionTriggered,
 }: VerseActionEmbedWidgetProps) => {
   const { t } = useTranslation('quran-reader');
-  const router = useRouter();
 
   const onClick = () => {
     // eslint-disable-next-line i18next/no-literal-string
@@ -35,8 +33,9 @@ const VerseActionEmbedWidget = ({
     const surah = Number(surahStr);
     const ayah = Number(ayahStr);
 
-    // Navigate to widget builder with the selected verse
-    router.push(`/embed/${surah}/${ayah}`);
+    // Open widget builder with the selected verse in a new tab
+    const versesParam = `${surah}:${ayah}`;
+    window.open(`/embed?verses=${encodeURIComponent(versesParam)}`, '_blank');
 
     if (onActionTriggered) {
       onActionTriggered();

--- a/src/pages/embed/index.tsx
+++ b/src/pages/embed/index.tsx
@@ -314,6 +314,15 @@ const AyahWidgetBuilderPage = () => {
       }
 
       const hasRange: boolean = Number.isFinite(rangeEnd);
+      const queryOverrides = {
+        selectedSurah: chapterId,
+        selectedAyah: verseNumber,
+        rangeEnabled: hasRange,
+        ...(hasRange && rangeEnd !== undefined ? { rangeEnd } : {}),
+      };
+
+      // Apply the verse selection overrides to the builder.
+      dispatch(updateAyahWidgetOverrides(queryOverrides));
 
       setUserPreferences((prev: Preferences) => ({
         ...prev,
@@ -322,10 +331,6 @@ const AyahWidgetBuilderPage = () => {
         rangeEnabled: hasRange,
         rangeEnd: rangeEnd ?? prev.rangeEnd,
       }));
-
-      if (!hasRange) {
-        dispatch(updateAyahWidgetOverrides({ rangeEnabled: false }));
-      }
 
       setLastParsedVersesParam(versesParam);
     } catch (error) {


### PR DESCRIPTION
## Summary

- Fixed a bug where the opened verse was not the one set in the embed editor  
- Opened the page in a new tab  

Closes: [no ticket]

## Type of Change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [X] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [X] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

<!-- If complex rollback needed, describe steps. Delete section if straightforward. -->

## Test Plan

<!-- Describe how this PR has been tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed

**Testing steps:**

1. Open /1/1
2. Click on the 3-dots menu, select "Emebed Widget"
3. Verify that the page loads up on a new tab and that verse 1:1 is selected

### Edge Cases Verified

- [ ] ⏳ Loading state handled
- [ ] ❌ Error state handled
- [ ] 📭 Empty state handled
- [ ] 👤 Logged-in vs guest behavior (if applicable)

### Code Quality

- [X] I have performed a **self-review** of my code (file by file)
- [X] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [X] No `any` types used (or justified if unavoidable)
- [X] No unused code, imports, or dead code included
- [X] Complex logic has inline comments explaining "why"
- [X] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [X] All tests pass locally (`yarn test`)
- [X] Linting passes (`yarn lint`)
- [X] Build succeeds (`yarn build`)
- [ ] Edge cases and error scenarios are handled

## Screenshots/Videos

https://github.com/user-attachments/assets/f8579147-2efb-4cf9-b1be-90bb2d3465ff

## AI Assistance Disclosure

<!-- If AI tools were used, confirm you have reviewed and understand all generated code -->

- [ ] AI tools were NOT used for this PR
- [X] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
