### PR TITLE
[QF-4793] - Display Arabic verse key in correct RTL order

### DIFF
--- a/src/components/Search/SearchResults/SearchResultItem/searchResultTextHelpers.test.ts
+++ b/src/components/Search/SearchResults/SearchResultItem/searchResultTextHelpers.test.ts
@@ -15,6 +15,7 @@ import { Direction } from '@/utils/locale';
 vi.mock('@/utils/locale', () => ({
   toLocalizedNumber: vi.fn((num) => `${num}`),
   toLocalizedVerseKey: vi.fn((key) => `KEY:${key}`),
+  toLocalizedVerseKeyRTL: vi.fn((key) => `RTLKEY:${key}`),
   isRTLLocale: vi.fn((lang) => lang === 'ar'),
   Direction: {
     LTR: 'ltr',
@@ -81,8 +82,17 @@ describe('searchResultTextHelpers', () => {
       const result = { resultType: SearchNavigationType.AYAH } as any;
       const data = getVerseTextData(result, '1:1', '1', {}, {}, 'en');
       expect(data.isAyahResult).toBe(true);
+      expect(data.arabicSuffixParts).toContain('RTLKEY:1:1');
       expect(data.arabicSuffixParts).toContain('الفاتحة');
       expect(data.translationSuffixParts).toContain('Al-Fatihah');
+      expect(data.translationSuffixParts).toContain('KEY:1:1');
+    });
+
+    it('uses RTL verse key in translation suffix when site language is Arabic', () => {
+      const result = { resultType: SearchNavigationType.AYAH } as any;
+      const data = getVerseTextData(result, '2:255', '1', {}, {}, 'ar');
+      expect(data.translationSuffixParts).toContain('RTLKEY:2:255');
+      expect(data.translationSuffixParts).not.toContain('KEY:2:255');
     });
   });
 

--- a/src/components/Search/SearchResults/SearchResultItem/searchResultTextHelpers.ts
+++ b/src/components/Search/SearchResults/SearchResultItem/searchResultTextHelpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* eslint-disable react-func/max-lines-per-function */
 import Language from '@/types/Language';
 import {
@@ -5,7 +6,13 @@ import {
   SearchNavigationType,
 } from '@/types/Search/SearchNavigationResult';
 import { getChapterData } from '@/utils/chapter';
-import { Direction, isRTLLocale, toLocalizedNumber, toLocalizedVerseKey } from '@/utils/locale';
+import {
+  Direction,
+  isRTLLocale,
+  toLocalizedNumber,
+  toLocalizedVerseKey,
+  toLocalizedVerseKeyRTL,
+} from '@/utils/locale';
 import { getResultType } from '@/utils/search';
 
 /**
@@ -145,8 +152,18 @@ export const getVerseTextData = (
   const arabicSurahName = arabicChapterData?.nameArabic || arabicChapterData?.translatedName;
 
   // Convert verse key to localized format for both Arabic and user's locale
-  const arabicVerseKey = resultKeyString ? toLocalizedVerseKey(resultKeyString, Language.AR) : '';
-  const localizedVerseKey = resultKeyString ? toLocalizedVerseKey(resultKeyString, lang) : '';
+  const arabicVerseKey = resultKeyString
+    ? toLocalizedVerseKeyRTL(resultKeyString, Language.AR)
+    : '';
+
+  let localizedVerseKey = '';
+  if (resultKeyString) {
+    if (lang === Language.AR) {
+      localizedVerseKey = toLocalizedVerseKeyRTL(resultKeyString, lang);
+    } else {
+      localizedVerseKey = toLocalizedVerseKey(resultKeyString, lang);
+    }
+  }
 
   // Build suffix arrays, filtering out undefined/null values
   const arabicSuffixParts = [arabicSurahName, arabicVerseKey].filter(Boolean) as string[];


### PR DESCRIPTION
## Summary

Fixes Arabic verse-key ordering in search result items.

- Arabic line now formats verse keys using RTL order (`VV:SS`) via `toLocalizedVerseKeyRTL`.
- Translation suffix also uses RTL verse-key formatting when site language is Arabic.
- Updated unit tests for both LTR and Arabic RTL cases.

Fixes [QF-4793](https://quranfoundation.atlassian.net/browse/QF-4793)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs


## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed

**Testing steps:**

1. Go to `/search?page=2&query=test`
2. Confirmed that the arabic verse has RTL verse key
3. Change website language to arabic
4. Confirmed that translation verse key is RTL too

## Screenshots/Videos

<!-- Add screenshots or videos for UI changes. Delete section if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="724" height="168" alt="image" src="https://github.com/user-attachments/assets/68d66254-6ff0-4724-8cc9-8d66fba585be" /> |  <img width="675" height="163" alt="image" src="https://github.com/user-attachments/assets/cf69a4ec-4f9c-44b5-b1e6-fff5d4a5bcb2" />  |
| <img width="750" height="176" alt="image" src="https://github.com/user-attachments/assets/1abae8bb-6996-4ca2-92cb-e66380b3df1e" /> | <img width="675" height="155" alt="image" src="https://github.com/user-attachments/assets/a46a0858-c266-4680-8218-de560a5c450a" /> |


## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [x] Complex logic has inline comments explaining "why"
- [ ] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4793]: https://quranfoundation.atlassian.net/browse/QF-4793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ