### PR TITLE
Fix edge-to-edge layout on Qiraat tab

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/JunctureTabs.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/JunctureTabs.module.scss
@@ -3,7 +3,6 @@
 @use 'src/styles/utility';
 
 .container {
-  @include utility.edgeHorizontalPadding;
   padding-block-end: calc(var(--spacing-xsmall) * 3);
 }
 
@@ -13,6 +12,7 @@
   padding-block-end: var(--spacing-xxsmall-px);
   margin-block-end: var(--spacing-medium-px);
   overflow-x: auto;
+  @include utility.edgeHorizontalPadding;
 
   &::-webkit-scrollbar {
     block-size: var(--spacing-xxsmall-px);
@@ -52,10 +52,10 @@
 }
 
 .content {
-  @include utility.edgeHorizontalPadding;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xxsmall-px);
+  @include utility.edgeHorizontalPadding;
 }
 
 .label {

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/StudyModeQiraatTab.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/StudyModeQiraatTab.module.scss
@@ -1,7 +1,7 @@
 @use 'src/styles/breakpoints';
 @use 'src/styles/utility';
 
-.edgeToEdge {
+div.edgeToEdge {
   @include utility.edgeHorizontalPadding;
 }
 


### PR DESCRIPTION
## PR Summary:
  This PR fixes the edge-to-edge horizontal padding on the Qiraat tab by moving the `edgeHorizontalPadding` utility from the `.container` element to the `.tabs` and `.content` elements in JunctureTabs. This ensures the horizontal padding is applied to the correct elements where it's actually needed. Additionally, the selector specificity in StudyModeQiraatTab is improved by changing `.edgeToEdge` to `div.edgeToEdge` to ensure the styling takes effect properly.

These changes ensure consistent edge-to-edge styling across the Qiraat tab interface, aligning it with the rest of the Study Mode design.