### PR TITLE
Add Edge to Edge Support on Hadith Tab

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBodyTabs.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBodyTabs.tsx
@@ -26,15 +26,27 @@ import QuestionType from '@/types/QuestionsAndAnswers/QuestionType';
 import { toLocalizedNumber } from '@/utils/locale';
 
 export const StudyModeTafsirTab = dynamic(() => import('./tabs/StudyModeTafsirTab'), {
-  loading: TafsirSkeleton,
+  loading: () => (
+    <div className={answerStyle.edgeToEdge}>
+      <TafsirSkeleton />
+    </div>
+  ),
 });
 
 export const StudyModeReflectionsTab = dynamic(() => import('./tabs/StudyModeReflectionsTab'), {
-  loading: TafsirSkeleton,
+  loading: () => (
+    <div className={answerStyle.edgeToEdge}>
+      <TafsirSkeleton />
+    </div>
+  ),
 });
 
 export const StudyModeLessonsTab = dynamic(() => import('./tabs/StudyModeLessonsTab'), {
-  loading: TafsirSkeleton,
+  loading: () => (
+    <div className={answerStyle.edgeToEdge}>
+      <TafsirSkeleton />
+    </div>
+  ),
 });
 
 export const StudyModeAnswersTab = dynamic(() => import('./tabs/StudyModeAnswersTab'), {
@@ -46,7 +58,11 @@ export const StudyModeAnswersTab = dynamic(() => import('./tabs/StudyModeAnswers
 });
 
 const StudyModeLayersTab = dynamic(() => import('./tabs/StudyModeLayersTab'), {
-  loading: TafsirSkeleton,
+  loading: () => (
+    <div className={answerStyle.edgeToEdge}>
+      <TafsirSkeleton />
+    </div>
+  ),
 });
 
 const StudyModeQiraatTab = dynamic(() => import('./tabs/StudyModeQiraatTab'), {
@@ -57,7 +73,13 @@ const StudyModeQiraatTab = dynamic(() => import('./tabs/StudyModeQiraatTab'), {
   ),
 });
 
-const StudyModeHadithTab = dynamic(() => import('./tabs/Hadith'), { loading: TafsirSkeleton });
+const StudyModeHadithTab = dynamic(() => import('./tabs/Hadith'), {
+  loading: () => (
+    <div className={answerStyle.edgeToEdge}>
+      <TafsirSkeleton />
+    </div>
+  ),
+});
 
 export const StudyModeRelatedVersesTab = dynamic(
   () => import('./tabs/StudyModeRelatedVerses/StudyModeRelatedVersesTab'),

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/StudyModeHadithTab.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/StudyModeHadithTab.module.scss
@@ -1,5 +1,6 @@
 @use 'src/styles/breakpoints';
 @use 'src/styles/mixins/qna-font-scales';
+@use 'src/styles/utility';
 
 // Font scale generation for Hadith components
 $hadith-scales: (
@@ -47,5 +48,7 @@ $hadith-scales: (
 }
 
 .hadithsContainer {
+  @include utility.edgeHorizontalPadding;
   padding-block-end: var(--spacing-max);
+  margin-block-start: var(--spacing-small-px);
 }

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/Hadith/index.tsx
@@ -67,7 +67,13 @@ const StudyModeHadithTab: React.FC<StudyModeHadithTabProps> = ({
   };
 
   const renderBody = () => {
-    if (isLoading) return <TafsirSkeleton />;
+    if (isLoading) {
+      return (
+        <div className={styles.hadithsContainer}>
+          <TafsirSkeleton />
+        </div>
+      );
+    }
 
     return (
       <div className={classNames(styles.hadithsContainer, scaleClass)}>


### PR DESCRIPTION

  ## Summary
  - Add edge-to-edge layout to Hadith tab with horizontal padding utility
  - Improve loading state consistency across Study Mode tabs
  - Add proper margin spacing for hadiths container

  ## Changes
  - Update Hadith tab skeleton loading to use edge-to-edge container
  - Apply edgeHorizontalPadding mixin to hadithsContainer
  - Add margin-block-start spacing for better visual separation
  - Standardize loading states across all Study Mode tabs (Tafsir, Reflections, Lessons, Answers, Layers, Qiraat, and
  Hadith)

  ## Test plan
  - [ ] Navigate to Study Mode in Quran Reader
  - [ ] Switch to Hadith tab and verify edge-to-edge layout
  - [ ] Check loading states appear correctly with proper padding
  - [ ] Verify consistent spacing across all Study Mode tabs
  - [ ] Test on mobile and desktop viewport sizes