### PR TITLE
Add Edge to Edge Support On Layers Tab

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeLayersTab/StudyModeLayersTab.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeLayersTab/StudyModeLayersTab.module.scss
@@ -1,5 +1,6 @@
 @use '@/styles/breakpoints';
 @use '@/styles/constants';
+@use '@/styles/utility';
 
 $layers-scales: (
   tablet: (
@@ -77,6 +78,7 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   gap: var(--spacing-medium2-px);
   padding-block-start: var(--spacing-medium);
   padding-block-end: var(--spacing-mega);
+  @include utility.edgeHorizontalPadding;
 }
 
 .errorContainer {
@@ -84,7 +86,8 @@ $font-scale-15: 0.9375; // 16px * 0.9375 = 15px
   align-items: center;
   justify-content: center;
   min-block-size: calc(var(--spacing-mega-px) * 2);
-  padding: var(--spacing-large);
+  padding-block: var(--spacing-large);
+  @include utility.edgeHorizontalPadding;
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- Apply edge-to-edge horizontal padding utility to StudyModeLayersTab container for consistent layout behavior
- Import and use the `utility.edgeHorizontalPadding` mixin to align with other study mode tabs (Hadith and Qiraat tabs)

## Changes
- Add `@use '@/styles/utility'` import to StudyModeLayersTab.module.scss
- Apply `@include utility.edgeHorizontalPadding` to the root container

## Technical Details
This change continues the edge-to-edge layout implementation across study mode tabs, ensuring consistent spacing and behavior on different screen sizes. The horizontal padding utility handles responsive spacing automatically based on viewport breakpoints.

## Related
- #3171
- #3170
