### PR TITLE
Reorganize Homepage Sections and Update Ramadan Topic Priority

### DIFF
--- a/src/components/HomePage/ExploreTopicsSection/index.tsx
+++ b/src/components/HomePage/ExploreTopicsSection/index.tsx
@@ -11,25 +11,20 @@ import { logButtonClick } from '@/utils/eventLogger';
 
 const TOPICS = [
   {
+    slug: 'what-is-ramadan',
+    logKey: 'what-is-ramadan',
+    key: 'what-is-ramadan',
+    isHighlighted: true,
+  },
+  {
     slug: 'about-the-quran',
     logKey: 'about-quran',
     key: 'about-quran',
-    isHighlighted: true,
   },
-  // {
-  //   slug: 'jesus-in-the-quran',
-  //   logKey: 'jesus-in-quran',
-  //   key: 'jesus-in-quran',
-  // },
   {
     slug: 'collections/the-authority-and-importance-of-the-sunnah-clem7p7lf15921610rsdk4xzulfj',
     key: 'sunnah',
     logKey: 'sunnah_collection',
-  },
-  {
-    slug: 'what-is-ramadan',
-    logKey: 'what-is-ramadan',
-    key: 'what-is-ramadan',
   },
 ];
 

--- a/src/components/HomePage/HomePageApps.tsx
+++ b/src/components/HomePage/HomePageApps.tsx
@@ -46,7 +46,7 @@ const HomePageApps: React.FC = () => {
       description: t('apps.quran-space.description'),
       iconSrc: '/images/app-portal/quran-space-100.jpg',
       iconAlt: t('apps.quran-space.name'),
-      href: 'https://space.quran.com/',
+      href: 'https://quran.space/',
     },
     {
       id: 'quran-ios',

--- a/src/components/HomePage/HomePageApps.tsx
+++ b/src/components/HomePage/HomePageApps.tsx
@@ -38,7 +38,7 @@ const HomePageApps: React.FC = () => {
       description: t('apps.qariah.description'),
       iconSrc: '/images/app-portal/featured/qaariah-icon.webp',
       iconAlt: t('apps.qariah.name'),
-      href: 'https://qariah.app',
+      href: 'https://qariah.app/',
     },
     {
       id: 'quran-space',
@@ -46,7 +46,7 @@ const HomePageApps: React.FC = () => {
       description: t('apps.quran-space.description'),
       iconSrc: '/images/app-portal/quran-space-100.jpg',
       iconAlt: t('apps.quran-space.name'),
-      href: 'https://spaces.labs.quran.com',
+      href: 'https://space.quran.com/',
     },
     {
       id: 'quran-ios',
@@ -54,7 +54,7 @@ const HomePageApps: React.FC = () => {
       description: t('apps.quran-ios.description'),
       iconSrc: '/images/app-portal/qdc-ios-logo.webp',
       iconAlt: t('apps.quran-ios.name'),
-      href: 'https://apps.apple.com/us/app/quran-by-quran-com-%D9%82%D8%B1%D8%A2%D9%86/id1118663303',
+      href: 'https://apps.apple.com/us/app/quran-by-quran-com-قرآن/id1118663303',
     },
     {
       id: 'quran-android',
@@ -87,9 +87,11 @@ const HomePageApps: React.FC = () => {
           {apps.map((app) => (
             <Link
               key={app.id}
-              href={APPS_URL}
               className={classNames(styles.appCard, styles[app.id])}
               onClick={() => handleAppClick(app.id)}
+              href={app.href}
+              target="_blank"
+              rel="noopener noreferrer"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={app.iconSrc} alt={app.iconAlt} className={styles.appIconImage} />

--- a/src/components/HomePage/MobileHomepageSections/index.tsx
+++ b/src/components/HomePage/MobileHomepageSections/index.tsx
@@ -20,19 +20,19 @@ type Props = {
 const MobileHomepageSections: React.FC<Props> = ({ isUserLoggedIn, todayAyah, chaptersData }) => {
   return isUserLoggedIn ? (
     <>
+      <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
+        <LearningPlansSection />
+      </div>
       {todayAyah && (
         <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
           <QuranInYearSection chaptersData={chaptersData} />
         </div>
       )}
       <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
-        <LearningPlansSection />
+        <ExploreTopicsSection />
       </div>
       <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
         <CommunitySection />
-      </div>
-      <div className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}>
-        <ExploreTopicsSection />
       </div>
     </>
   ) : (

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerList.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerList.tsx
@@ -8,7 +8,7 @@ import NavigationDrawerItem from './NavigationDrawerItem';
 import OurProjectsCollapsible from './OurProjectsCollapsible';
 
 import useGetContinueReadingUrl from '@/hooks/useGetContinueReadingUrl';
-// import IconApps from '@/icons/apps.svg';
+import IconApps from '@/icons/apps.svg';
 import IconBookmarkFilled from '@/icons/bookmark_filled.svg';
 import IconCode from '@/icons/code.svg';
 import DiamondIcon from '@/icons/diamond.svg';
@@ -19,7 +19,7 @@ import { setIsNavigationDrawerOpen } from '@/redux/slices/navbar';
 import Language from '@/types/Language';
 import { logButtonClick } from '@/utils/eventLogger';
 import {
-  // APPS_URL,
+  APPS_URL,
   DEVELOPERS_URL,
   getMyQuranNavigationUrl,
   LEARNING_PLANS_URL,
@@ -86,12 +86,12 @@ const NavigationDrawerList: React.FC<NavigationDrawerListProps> = ({
       href: RECITERS_URL,
       eventName: 'navigation_drawer_reciters',
     },
-    /*     {
+    {
       title: t('quran-apps'),
       icon: <IconApps />,
       href: APPS_URL,
       eventName: 'navigation_drawer_quran_apps',
-    }, */
+    },
     {
       title: t('developers'),
       icon: <IconCode />,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,6 +77,11 @@ const Index: NextPage<IndexProps> = ({
               <>
                 {isUserLoggedIn ? (
                   <>
+                    <div
+                      className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}
+                    >
+                      <LearningPlansSection />
+                    </div>
                     {todayAyah && (
                       <div
                         className={classNames(
@@ -88,11 +93,6 @@ const Index: NextPage<IndexProps> = ({
                         <QuranInYearSection chaptersData={chaptersData} />
                       </div>
                     )}
-                    <div
-                      className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}
-                    >
-                      <LearningPlansSection />
-                    </div>
                     <div
                       className={classNames(styles.flowItem, styles.fullWidth, styles.homepageCard)}
                     >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ import ChapterAndJuzListWrapper from '@/components/chapters/ChapterAndJuzList';
 import HomepageFundraisingBanner from '@/components/Fundraising/HomepageFundraisingBanner';
 import CommunitySection from '@/components/HomePage/CommunitySection';
 import ExploreTopicsSection from '@/components/HomePage/ExploreTopicsSection';
-// import HomePageApps from '@/components/HomePage/HomePageApps';
+import HomePageApps from '@/components/HomePage/HomePageApps';
 import HomePageHero from '@/components/HomePage/HomePageHero';
 import LearningPlansSection from '@/components/HomePage/LearningPlansSection';
 import MobileHomepageSections from '@/components/HomePage/MobileHomepageSections';
@@ -137,7 +137,7 @@ const Index: NextPage<IndexProps> = ({
               </>
             )}
 
-            {/*             <div
+            <div
               className={classNames(
                 styles.flowItem,
                 styles.fullWidth,
@@ -146,7 +146,7 @@ const Index: NextPage<IndexProps> = ({
               )}
             >
               <HomePageApps />
-            </div> */}
+            </div>
 
             <div className={styles.flowItem}>
               <ChapterAndJuzListWrapper chapters={chapters} />


### PR DESCRIPTION
# Summary
- Reorder homepage sections to show LearningPlansSection first for logged-in users (both mobile and desktop views)
- Prioritize "What is Ramadan" topic by moving it to the top of ExploreTopicsSection and marking it as highlighted
- Update app links in HomePageApps to use direct URLs with proper external link attributes
- Fix app link hrefs to use canonical URLs (Qariah, Quran Space, iOS app)

# Changes
- Moved `LearningPlansSection` to appear first in the logged-in user homepage flow (before QuranInYearSection)
- Moved "What is Ramadan" topic to top of TOPICS array in ExploreTopicsSection and set as highlighted
- Changed app links from generic `APPS_URL` to specific app URLs with `target="_blank"` and `rel="noopener noreferrer"`
- Updated app URLs to use canonical/primary links:
  - Qariah: `https://qariah.app/`
  - Quran Space: `https://space.quran.com/`

# Test plan
- [ ] Verify homepage sections load in correct order for logged-in users (Learning Plans ΓåÆ Quran In Year ΓåÆ Community ΓåÆ Explore Topics)
- [ ] Verify mobile homepage section order matches desktop order
- [ ] Confirm "What is Ramadan" topic appears highlighted and first in Explore Topics section
- [ ] Test all app links open correctly in new tabs with proper security attributes
- [ ] Verify no visual regressions in homepage layout
- [ ] Verify Orders
         1. Continue reading
         2. donation section
         3. learning plans
         4. QiaY
         5. Explore topic (and move Ramadan to the left)
         6. community

| Login | Gueest|
|--------|--------|
| <img width="413" height="735" alt="image" src="https://github.com/user-attachments/assets/e36b96f3-a208-47dc-b1dd-e760e8a0d226" /> | <img width="413" height="734" alt="image" src="https://github.com/user-attachments/assets/4fe76ffd-14e8-41f7-a92d-f3f3ee325b54" /> | 




