### PR TITLE
 [QF-4790] Fix settings verse preview script for QPC Uthmani Hafs and IndoPak fonts

### DIFF
--- a/src/components/Navbar/SettingsDrawer/VersePreview.tsx
+++ b/src/components/Navbar/SettingsDrawer/VersePreview.tsx
@@ -82,10 +82,29 @@ const VersePreview = () => {
   const hasBothTooltipTypes =
     showTooltipFor.includes(WordByWordType.Translation) &&
     showTooltipFor.includes(WordByWordType.Transliteration);
+
   const highlightedWord = useMemo(
     () =>
       (sampleVerse?.words as Word[])?.find((w) => w.position === HIGHLIGHTED_WORD_POSITION) ?? null,
     [sampleVerse?.words],
+  );
+
+  const previewWords = useMemo(
+    () =>
+      (sampleVerse?.words as Word[])?.map((word) => {
+        const { quranFont } = quranReaderStyles;
+
+        if (quranFont === QuranFont.QPCHafs) {
+          return { ...word, text: word.qpcUthmaniHafs ?? word.text };
+        }
+
+        if (quranFont === QuranFont.IndoPak) {
+          return { ...word, text: word.textIndopak ?? word.text };
+        }
+
+        return word;
+      }) ?? [],
+    [sampleVerse?.words, quranReaderStyles],
   );
 
   useEffect(() => {
@@ -140,7 +159,7 @@ const VersePreview = () => {
               />
             )}
             <VerseText
-              words={sampleVerse.words as Word[]}
+              words={previewWords}
               highlightedWordPosition={HIGHLIGHTED_WORD_POSITION}
               isWordInteractionDisabled
               shouldDisableForceTooltip

--- a/src/components/Navbar/SettingsDrawer/VersePreview.tsx
+++ b/src/components/Navbar/SettingsDrawer/VersePreview.tsx
@@ -89,11 +89,10 @@ const VersePreview = () => {
     [sampleVerse?.words],
   );
 
+  const { quranFont } = quranReaderStyles;
   const previewWords = useMemo(
     () =>
       (sampleVerse?.words as Word[])?.map((word) => {
-        const { quranFont } = quranReaderStyles;
-
         if (quranFont === QuranFont.QPCHafs) {
           return { ...word, text: word.qpcUthmaniHafs ?? word.text };
         }
@@ -104,7 +103,7 @@ const VersePreview = () => {
 
         return word;
       }) ?? [],
-    [sampleVerse?.words, quranReaderStyles],
+    [sampleVerse?.words, quranFont],
   );
 
   useEffect(() => {

--- a/src/utils/sample-verse.json
+++ b/src/utils/sample-verse.json
@@ -20,6 +20,7 @@
       "lineNumber": 9,
       "hizbNumber": 1,
       "qpcUthmaniHafs": "بِسۡمِ",
+      "textIndopak": "بِسْمِ",
       "text": "بِسْمِ",
       "audioUrl": null,
       "translation": {
@@ -42,6 +43,7 @@
       "lineNumber": 9,
       "hizbNumber": 1,
       "qpcUthmaniHafs": "ٱللَّهِ",
+      "textIndopak": "اللّٰهِ",
       "text": "ٱللَّهِ",
       "audioUrl": null,
       "translation": {
@@ -64,6 +66,7 @@
       "lineNumber": 9,
       "hizbNumber": 1,
       "qpcUthmaniHafs": "ٱلرَّحۡمَٰنِ",
+      "textIndopak": "الرَّحْمٰنِ",
       "text": "ٱلرَّحْمَـٰنِ",
       "audioUrl": null,
       "translation": {
@@ -86,6 +89,7 @@
       "lineNumber": 9,
       "hizbNumber": 1,
       "qpcUthmaniHafs": "ٱلرَّحِيمِ",
+      "textIndopak": "الرَّحِیْمِ",
       "text": "ٱلرَّحِيمِ",
       "audioUrl": null,
       "translation": {
@@ -108,6 +112,7 @@
       "lineNumber": 9,
       "hizbNumber": 1,
       "qpcUthmaniHafs": "١",
+      "textIndopak": "١",
       "text": "١",
       "audioUrl": null,
       "translation": {


### PR DESCRIPTION
## Summary                                                                                       
                                                                        
  The settings drawer verse preview was rendering the wrong script for **QPC Uthmani Hafs** and    
  **IndoPak** fonts — it was always displaying Uthmanic text regardless of the selected font. This 
  is a bug fix that makes the preview 1:1 accurate to what the reader shows for each font.         
                                                                                                   
  **Root cause:** `VersePreview` passed `sampleVerse.words` directly to `VerseText`, but           
  `word.text` in the static sample JSON is always Uthmanic. The static JSON already had
  `qpcUthmaniHafs` per word but had no IndoPak equivalent.

  **Fix:**
  1. Added `textIndopak` per word to `sample-verse.json` with the exact bytes for IndoPak script
  (fetched from the API at mushaf=6, which covers both 15 and 16 Line variants ).
  2. Added a `previewWords` memo in `VersePreview.tsx` that overrides `word.text` based on the
  selected font before passing words to `VerseText`:
     - **QPCHafs** → uses the pre-existing `word.qpcUthmaniHafs`
     - **IndoPak** → uses the new `word.textIndopak`
     - All other fonts (Uthmani, Tajweed, QCF) → unchanged

  Closes: [QF-4790](https://quranfoundation.atlassian.net/browse/QF-4790)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Environment Variables

  N/A

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Open the settings drawer
  2. Switch font to **QPC Uthmani Hafs** → verify preview shows QPC-specific diacritics (e.g.
  `ٱلرَّحۡمَٰنِ` with high sukun U+06E1)
  3. Switch font to **IndoPak** (15 Lines or 16 Lines) → verify preview shows IndoPak script (e.g.
  `اللّٰهِ` with alef instead of alef wasla)
  4. Switch font to **Uthmani**, **Tajweed**, or any QCF font → verify no regression

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled (skeleton shown until `sampleVerse` loads)
  - [x] 📭 Empty state handled (`previewWords` returns `[]` if `sampleVerse` is undefined)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the project style guidelines
  - [x] No `any` types used
  - [x] No unused code, imports, or dead code included
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [x] Linting passes

  ### Localization (if UI changes)

  - [x] No user-facing text changed

  ### Accessibility (if UI changes)

  - [x] No accessibility-impacting changes

  ## Screenshots/Videos

  | Before | After |
  | ------ | ----- |
  |<img width="289" height="176" alt="image" src="https://github.com/user-attachments/assets/aa680ef9-d637-4294-8430-88561b633e7f" /> | <img width="292" height="185" alt="image" src="https://github.com/user-attachments/assets/79df88d7-da9d-4152-99ed-966757fbc720" /> |
 |<img width="291" height="182" alt="image" src="https://github.com/user-attachments/assets/b631fd80-928b-4e68-87b2-c14009c4b0a5" /> |<img width="289" height="190" alt="image" src="https://github.com/user-attachments/assets/6e7b6c6b-7b95-4e18-afe5-0d76342a5e03" />  |


  ## AI Assistance Disclosure

  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4790]: https://quranfoundation.atlassian.net/browse/QF-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ