### PR TITLE
  fix: play word recitation without opening study mode when tooltip is disabled

### DIFF
--- a/src/components/dls/QuranWord/QuranWord.tsx
+++ b/src/components/dls/QuranWord/QuranWord.tsx
@@ -253,9 +253,6 @@ const QuranWord = ({
 
     if (isRecitationEnabled && word.charTypeName === CharType.Word && !showTooltip) {
       handleWordAction();
-      logButtonClick(`study_mode_open_word_${modeSuffix}`, { verseKey: word.verseKey });
-      dispatch(setReadingViewHoveredVerseKey(null));
-      dispatch(openStudyMode({ verseKey: word.verseKey, highlightedWordLocation: word.location }));
       return;
     }
 


### PR DESCRIPTION
## Summary                                                                                                               

  When word-click recitation is enabled and both translation and translation tooltip are disabled, clicking a Quranic word
  was opening the Study Mode modal in addition to playing the word's audio. 
This PR removes the  `openStudyMode` dispatch from that code path so clicking a word only plays the recitation as expected.

  Closes: [QF-XXXX](https://quranfoundation.atlassian.net/browse/QF-XXXX)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [x] Manual testing performed

  **Testing steps:**

  1. Open the Quran reader.
  2. In settings, disable **Translation** and **Translation Tooltip**, and enable ** Recitation**.
  3. Click any Arabic word — audio plays and the Study Mode modal does **not** open.
  4. Re-enable Translation Tooltip and click a word — tooltip still appears correctly .
  5. Disable recitation and click a word — Study Mode still opens correctly (unaffected ).
 
  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [x] Linting passes (`yarn lint`)

  ### Localization (if UI changes)

  N/A — no user-facing text changes.

  ### Accessibility (if UI changes)

  N/A — no structural/HTML changes.


  ## AI Assistance Disclosure

  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
