### PR TITLE
Show Quran Apps Section on Homepage

### DIFF
--- a/src/components/HomePage/HomePageApps.tsx
+++ b/src/components/HomePage/HomePageApps.tsx
@@ -46,7 +46,7 @@ const HomePageApps: React.FC = () => {
       description: t('apps.quran-space.description'),
       iconSrc: '/images/app-portal/quran-space-100.jpg',
       iconAlt: t('apps.quran-space.name'),
-      href: 'https://space.quran.com/',
+      href: 'https://quran.space/',
     },
     {
       id: 'quran-ios',

--- a/src/components/Navbar/NavigationDrawer/NavigationDrawerList.tsx
+++ b/src/components/Navbar/NavigationDrawer/NavigationDrawerList.tsx
@@ -8,7 +8,7 @@ import NavigationDrawerItem from './NavigationDrawerItem';
 import OurProjectsCollapsible from './OurProjectsCollapsible';
 
 import useGetContinueReadingUrl from '@/hooks/useGetContinueReadingUrl';
-// import IconApps from '@/icons/apps.svg';
+import IconApps from '@/icons/apps.svg';
 import IconBookmarkFilled from '@/icons/bookmark_filled.svg';
 import IconCode from '@/icons/code.svg';
 import DiamondIcon from '@/icons/diamond.svg';
@@ -19,7 +19,7 @@ import { setIsNavigationDrawerOpen } from '@/redux/slices/navbar';
 import Language from '@/types/Language';
 import { logButtonClick } from '@/utils/eventLogger';
 import {
-  // APPS_URL,
+  APPS_URL,
   DEVELOPERS_URL,
   getMyQuranNavigationUrl,
   LEARNING_PLANS_URL,
@@ -86,12 +86,12 @@ const NavigationDrawerList: React.FC<NavigationDrawerListProps> = ({
       href: RECITERS_URL,
       eventName: 'navigation_drawer_reciters',
     },
-    /*     {
+    {
       title: t('quran-apps'),
       icon: <IconApps />,
       href: APPS_URL,
       eventName: 'navigation_drawer_quran_apps',
-    }, */
+    },
     {
       title: t('developers'),
       icon: <IconCode />,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ import ChapterAndJuzListWrapper from '@/components/chapters/ChapterAndJuzList';
 import HomepageFundraisingBanner from '@/components/Fundraising/HomepageFundraisingBanner';
 import CommunitySection from '@/components/HomePage/CommunitySection';
 import ExploreTopicsSection from '@/components/HomePage/ExploreTopicsSection';
-// import HomePageApps from '@/components/HomePage/HomePageApps';
+import HomePageApps from '@/components/HomePage/HomePageApps';
 import HomePageHero from '@/components/HomePage/HomePageHero';
 import LearningPlansSection from '@/components/HomePage/LearningPlansSection';
 import MobileHomepageSections from '@/components/HomePage/MobileHomepageSections';
@@ -137,7 +137,7 @@ const Index: NextPage<IndexProps> = ({
               </>
             )}
 
-            {/*             <div
+            <div
               className={classNames(
                 styles.flowItem,
                 styles.fullWidth,
@@ -146,7 +146,7 @@ const Index: NextPage<IndexProps> = ({
               )}
             >
               <HomePageApps />
-            </div> */}
+            </div>
 
             <div className={styles.flowItem}>
               <ChapterAndJuzListWrapper chapters={chapters} />


### PR DESCRIPTION
## Summary
  - Re-enable the Quran Apps section on the homepage to showcase official Quran.com applications
  - Add Quran Apps link to the navigation drawer for better discoverability
  - Update Quran Space URL from `space.quran.com` to `quran.space`

  ## Changes
  - Uncomment and restore `HomePageApps` component on the homepage (`src/pages/index.tsx`)
  - Enable Quran Apps navigation item in the navigation drawer
  (`src/components/Navbar/NavigationDrawer/NavigationDrawerList.tsx`)
  - Update Quran Space app URL to use the new domain (`src/components/HomePage/HomePageApps.tsx`)

  This makes the Quran Apps section visible to users, providing easy access to Quran.com mobile and web applications.

  The changes primarily involve un-commenting previously disabled code for the Quran Apps feature, with a minor URL update for the Quran Space app.