### PR TITLE
Apply Kitab font to Arabic source attribution labels

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationText/index.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/index.tsx
@@ -198,6 +198,7 @@ const TranslationText: React.FC<Props> = ({
             styles[langData.direction],
             styles[langData.font],
           )}
+          lang={langData.code}
           // eslint-disable-next-line i18next/no-literal-string
         >
           — {resourceName}


### PR DESCRIPTION
## Summary
- Added `lang` attribute to the translation/tafsir source attribution text (e.g. "— التفسير الميسر") so the Kitab font is applied when the content is Arabic, regardless of the site locale.

## Test plan
- Visit any surah page (e.g. /2 or /fa/2) with an Arabic tafsir selected
- Verify "— التفسير الميسر" renders in Kitab font inline on the page
- Open the Tafsirs dialog and verify the source attribution also renders in Kitab font

Before: 
<img width="1224" height="226" alt="Screenshot 2026-02-20 at 7 45 50 AM" src="https://github.com/user-attachments/assets/11a45572-8c7a-486f-a748-f1fe71d75fa3" />


After: 
<img width="1258" height="203" alt="Screenshot 2026-02-20 at 7 41 43 AM" src="https://github.com/user-attachments/assets/09fff98c-455f-4e9c-a202-287edab53f8c" />
