### PR TITLE
PoC: Open Study Mode from footnote verse references

### DIFF
--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable react/no-danger */
+/*
+ * Keyboard interaction is handled by native child anchors rendered from trusted HTML.
+ * This container only delegates click events to route verse-reference links to Study Mode.
+ */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 
-import React, { MouseEvent, useMemo } from 'react';
+import React, { MouseEvent, useCallback, useMemo } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
@@ -16,6 +20,7 @@ import Spinner from '@/dls/Spinner/Spinner';
 import CloseIcon from '@/icons/close.svg';
 import { openStudyMode } from '@/redux/slices/QuranReader/studyMode';
 import Language from '@/types/Language';
+import { logButtonClick } from '@/utils/eventLogger';
 import { getLanguageDataById, findLanguageIdByLocale, toLocalizedNumber } from '@/utils/locale';
 import { formatVerseReferencesToLinks, isNumericString } from '@/utils/string';
 import Footnote from 'types/Footnote';
@@ -67,20 +72,24 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
    * opens Study Mode for the referenced verse.
    * @param {MouseEvent} event - The mouse event
    */
-  const onContentClick = (event: MouseEvent) => {
-    const target = event.target as HTMLElement;
-    const anchorElement = target.closest('a[href]');
-    const verseKey = anchorElement?.getAttribute('data-verse-key');
+  const onContentClick = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      const anchorElement = target.closest('a[href]');
+      const verseKey = anchorElement?.getAttribute('data-verse-key');
 
-    if (verseKey) {
-      event.preventDefault();
-      event.stopPropagation();
-      dispatch(openStudyMode({ verseKey }));
-      return;
-    }
+      if (verseKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        logButtonClick('study_mode_open_footnote_verse_reference', { verseKey });
+        dispatch(openStudyMode({ verseKey }));
+        return;
+      }
 
-    onTextClicked?.(event);
-  };
+      onTextClicked?.(event);
+    },
+    [dispatch, onTextClicked],
+  );
 
   return (
     <div

--- a/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/FootnoteText.tsx
@@ -1,9 +1,12 @@
 /* eslint-disable react/no-danger */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 
 import React, { MouseEvent, useMemo } from 'react';
 
 import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
+import { useDispatch } from 'react-redux';
 
 import styles from './FootnoteText.module.scss';
 import transStyles from './TranslationText.module.scss';
@@ -11,6 +14,7 @@ import transStyles from './TranslationText.module.scss';
 import Button, { ButtonSize, ButtonShape, ButtonVariant } from '@/dls/Button/Button';
 import Spinner from '@/dls/Spinner/Spinner';
 import CloseIcon from '@/icons/close.svg';
+import { openStudyMode } from '@/redux/slices/QuranReader/studyMode';
 import Language from '@/types/Language';
 import { getLanguageDataById, findLanguageIdByLocale, toLocalizedNumber } from '@/utils/locale';
 import { formatVerseReferencesToLinks, isNumericString } from '@/utils/string';
@@ -32,6 +36,7 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
   isLoading,
 }) => {
   const { t, lang } = useTranslation('quran-reader');
+  const dispatch = useDispatch();
 
   // App locale language data (for container/header direction)
   const appLanguageData = useMemo(() => {
@@ -56,6 +61,26 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
     if (!footnote?.text) return '';
     return formatVerseReferencesToLinks(footnote.text);
   }, [footnote?.text]);
+
+  /**
+   * Handles clicks on the footnote content. If a verse link is clicked,
+   * opens Study Mode for the referenced verse.
+   * @param {MouseEvent} event - The mouse event
+   */
+  const onContentClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    const anchorElement = target.closest('a[href]');
+    const verseKey = anchorElement?.getAttribute('data-verse-key');
+
+    if (verseKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      dispatch(openStudyMode({ verseKey }));
+      return;
+    }
+
+    onTextClicked?.(event);
+  };
 
   return (
     <div
@@ -85,7 +110,7 @@ const FootnoteText: React.FC<FootnoteTextProps> = ({
             transStyles[footnoteLanguageData.font],
           )}
           dangerouslySetInnerHTML={{ __html: updatedText }}
-          {...(onTextClicked && { onClick: onTextClicked })}
+          onClick={onContentClick}
         />
       )}
     </div>

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -307,26 +307,29 @@ describe('truncateHtml', () => {
 describe('Test formatVerseReferencesToLinks', () => {
   it('should convert single verse reference to link', () => {
     const input = 'See verse 1:1 for more details';
-    const expected = 'See verse <a href="/1:1" target="_blank">1:1</a> for more details';
+    const expected =
+      'See verse <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> for more details';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse reference with three digit verse number to link', () => {
     const input = 'Verse 2:123 is important';
-    const expected = 'Verse <a href="/2:123" target="_blank">2:123</a> is important';
+    const expected =
+      'Verse <a href="/2:123" target="_blank" data-verse-key="2:123">2:123</a> is important';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse range to link', () => {
     const input = 'Verses 1:1-3 are important';
-    const expected = 'Verses <a href="/1:1-3" target="_blank">1:1-3</a> are important';
+    const expected =
+      'Verses <a href="/1:1-3" target="_blank" data-verse-key="1:1">1:1-3</a> are important';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert multiple verse references to links', () => {
     const input = 'See 1:1 and 2:1-3 for details';
     const expected =
-      'See <a href="/1:1" target="_blank">1:1</a> and <a href="/2:1-3" target="_blank">2:1-3</a> for details';
+      'See <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> and <a href="/2:1-3" target="_blank" data-verse-key="2:1">2:1-3</a> for details';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
@@ -344,76 +347,91 @@ describe('Test formatVerseReferencesToLinks', () => {
     expect(formatVerseReferencesToLinks(undefined as any)).toEqual('');
   });
 
+  it('should add verse key data attribute when enabled for single verse', () => {
+    const input = 'See 2:255';
+    const expected = 'See <a href="/2:255" target="_blank" data-verse-key="2:255">2:255</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
+  it('should add verse key data attribute when enabled for verse range using first verse', () => {
+    const input = 'See 2:1-3';
+    const expected = 'See <a href="/2:1-3" target="_blank" data-verse-key="2:1">2:1-3</a>';
+    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+  });
+
   // Additional positive test cases
   it('should handle verse references at the start of text', () => {
     const input = '1:1 is the first verse';
-    const expected = '<a href="/1:1" target="_blank">1:1</a> is the first verse';
+    const expected =
+      '<a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> is the first verse';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should handle verse references at the end of text', () => {
     const input = 'The last verse is 1:1';
-    const expected = 'The last verse is <a href="/1:1" target="_blank">1:1</a>';
+    const expected =
+      'The last verse is <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should handle verse references with multiple digits', () => {
     const input = 'See verses 114:1-3 and 1:1-7';
     const expected =
-      'See verses <a href="/114:1-3" target="_blank">114:1-3</a> and <a href="/1:1-7" target="_blank">1:1-7</a>';
+      'See verses <a href="/114:1-3" target="_blank" data-verse-key="114:1">114:1-3</a> and <a href="/1:1-7" target="_blank" data-verse-key="1:1">1:1-7</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should handle verse references with different separators', () => {
     const input = 'See 1:1, 2:1-3 and 3:1';
     const expected =
-      'See <a href="/1:1" target="_blank">1:1</a>, <a href="/2:1-3" target="_blank">2:1-3</a> and <a href="/3:1" target="_blank">3:1</a>';
+      'See <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a>, <a href="/2:1-3" target="_blank" data-verse-key="2:1">2:1-3</a> and <a href="/3:1" target="_blank" data-verse-key="3:1">3:1</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should handle verse ranges across chapters', () => {
     const input = 'See verses 1:1-2:3 and 3:1-4:2';
     const expected =
-      'See verses <a href="/1:1-2:3" target="_blank">1:1-2:3</a> and <a href="/3:1-4:2" target="_blank">3:1-4:2</a>';
+      'See verses <a href="/1:1-2:3" target="_blank" data-verse-key="1:1">1:1-2:3</a> and <a href="/3:1-4:2" target="_blank" data-verse-key="3:1">3:1-4:2</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should handle verse references in Arabic text', () => {
     const input = 'الآية 1:1 والآية 2:1-3';
     const expected =
-      'الآية <a href="/1:1" target="_blank">1:1</a> والآية <a href="/2:1-3" target="_blank">2:1-3</a>';
+      'الآية <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> والآية <a href="/2:1-3" target="_blank" data-verse-key="2:1">2:1-3</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   // Additional test cases that match current behavior
   it('should convert partial verse references', () => {
     const input = 'See 1: and :1 and 1-1';
-    const expected = 'See 1: and :1 and <a href="/1-1" target="_blank">1-1</a>';
+    const expected = 'See 1: and :1 and <a href="/1-1" target="_blank" data-verse-key="">1-1</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert dates that look like verse references', () => {
     const input = 'The date 1:1:2023 is not a verse reference';
     const expected =
-      'The date <a href="/1:1" target="_blank">1:1</a>:2023 is not a verse reference';
+      'The date <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a>:2023 is not a verse reference';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert time that looks like verse references', () => {
     const input = 'The time is 1:1 PM';
-    const expected = 'The time is <a href="/1:1" target="_blank">1:1</a> PM';
+    const expected = 'The time is <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> PM';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references within HTML tags', () => {
     const input = '<div>1:1</div>';
-    const expected = '<div><a href="/1:1" target="_blank">1:1</a></div>';
+    const expected = '<div><a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a></div>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references within script tags', () => {
     const input = '<script>const verse = "1:1";</script>';
-    const expected = '<script>const verse = "<a href="/1:1" target="_blank">1:1</a>";</script>';
+    const expected =
+      '<script>const verse = "<a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a>";</script>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
@@ -421,56 +439,56 @@ describe('Test formatVerseReferencesToLinks', () => {
   it('should convert verse references in English text', () => {
     const input = 'This is a normal text with verse 1:1 and 2:3 in it';
     const expected =
-      'This is a normal text with verse <a href="/1:1" target="_blank">1:1</a> and <a href="/2:3" target="_blank">2:3</a> in it';
+      'This is a normal text with verse <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> and <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a> in it';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in Arabic text', () => {
     const input = 'هذا نص عادي يحتوي على الآية 1:1 والآية 2:3';
     const expected =
-      'هذا نص عادي يحتوي على الآية <a href="/1:1" target="_blank">1:1</a> والآية <a href="/2:3" target="_blank">2:3</a>';
+      'هذا نص عادي يحتوي على الآية <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> والآية <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in French text', () => {
     const input = 'Ceci est un texte normal avec le verset 1:1 et 2:3';
     const expected =
-      'Ceci est un texte normal avec le verset <a href="/1:1" target="_blank">1:1</a> et <a href="/2:3" target="_blank">2:3</a>';
+      'Ceci est un texte normal avec le verset <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> et <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in Spanish text', () => {
     const input = 'Este es un texto normal con el versículo 1:1 y 2:3';
     const expected =
-      'Este es un texto normal con el versículo <a href="/1:1" target="_blank">1:1</a> y <a href="/2:3" target="_blank">2:3</a>';
+      'Este es un texto normal con el versículo <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> y <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in Chinese text', () => {
     const input = '这是一个普通文本，包含经文 1:1 和 2:3';
     const expected =
-      '这是一个普通文本，包含经文 <a href="/1:1" target="_blank">1:1</a> 和 <a href="/2:3" target="_blank">2:3</a>';
+      '这是一个普通文本，包含经文 <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> 和 <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in Japanese text', () => {
     const input = 'これは普通のテキストで、聖句 1:1 と 2:3 を含みます';
     const expected =
-      'これは普通のテキストで、聖句 <a href="/1:1" target="_blank">1:1</a> と <a href="/2:3" target="_blank">2:3</a> を含みます';
+      'これは普通のテキストで、聖句 <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> と <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a> を含みます';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in Korean text', () => {
     const input = '이것은 일반 텍스트로, 성구 1:1과 2:3을 포함합니다';
     const expected =
-      '이것은 일반 텍스트로, 성구 <a href="/1:1" target="_blank">1:1</a>과 <a href="/2:3" target="_blank">2:3</a>을 포함합니다';
+      '이것은 일반 텍스트로, 성구 <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a>과 <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a>을 포함합니다';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
   it('should convert verse references in Russian text', () => {
     const input = 'Это обычный текст с аятом 1:1 и 2:3';
     const expected =
-      'Это обычный текст с аятом <a href="/1:1" target="_blank">1:1</a> и <a href="/2:3" target="_blank">2:3</a>';
+      'Это обычный текст с аятом <a href="/1:1" target="_blank" data-verse-key="1:1">1:1</a> и <a href="/2:3" target="_blank" data-verse-key="2:3">2:3</a>';
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 

--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -7,6 +7,7 @@ import {
   stripHtml,
   getHtmlTextLength,
   truncateHtml,
+  getFirstVerseKeyFromReference,
   formatVerseReferencesToLinks,
   getWordCount,
   isNumericString,
@@ -531,6 +532,40 @@ describe('Test formatVerseReferencesToLinks', () => {
   it('should not modify Russian text without verse references', () => {
     const input = 'Это обычный текст без ссылок на аяты';
     expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+});
+
+describe('Test getFirstVerseKeyFromReference', () => {
+  it('returns verse key for a simple verse reference', () => {
+    expect(getFirstVerseKeyFromReference('1:1')).toBe('1:1');
+  });
+
+  it('returns the first verse key for a same-chapter range', () => {
+    expect(getFirstVerseKeyFromReference('2:1-3')).toBe('2:1');
+  });
+
+  it('returns the first verse key for a cross-chapter range', () => {
+    expect(getFirstVerseKeyFromReference('2:286-3:2')).toBe('2:286');
+  });
+
+  it('returns null for references without colon', () => {
+    expect(getFirstVerseKeyFromReference('1-1')).toBeNull();
+  });
+
+  it('returns null for references with extra segment', () => {
+    expect(getFirstVerseKeyFromReference('1:1:2')).toBeNull();
+  });
+
+  it('returns null for non-numeric chapter id', () => {
+    expect(getFirstVerseKeyFromReference('a:1')).toBeNull();
+  });
+
+  it('returns null for non-numeric verse number', () => {
+    expect(getFirstVerseKeyFromReference('1:b')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(getFirstVerseKeyFromReference('')).toBeNull();
   });
 });
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -188,7 +188,7 @@ export const cleanTranscript = (text: string): string => {
  * @param {string} reference - The reference string (e.g. "1:1-2")
  * @returns {string | null} The first verse key (e.g. "1:1") or null if invalid
  */
-const getFirstVerseKeyFromReference = (reference: string): string | null => {
+export const getFirstVerseKeyFromReference = (reference: string): string | null => {
   const fromSegment = reference.split('-')[0];
   const [chapterId, verseNumber, extraSegment] = fromSegment.split(':');
   if (extraSegment || !isNumericString(chapterId) || !isNumericString(verseNumber)) {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -184,6 +184,21 @@ export const cleanTranscript = (text: string): string => {
 };
 
 /**
+ * Get the first verse key from a reference string.
+ * @param {string} reference - The reference string (e.g. "1:1-2")
+ * @returns {string | null} The first verse key (e.g. "1:1") or null if invalid
+ */
+const getFirstVerseKeyFromReference = (reference: string): string | null => {
+  const fromSegment = reference.split('-')[0];
+  const [chapterId, verseNumber, extraSegment] = fromSegment.split(':');
+  if (extraSegment || !isNumericString(chapterId) || !isNumericString(verseNumber)) {
+    return null;
+  }
+
+  return `${chapterId}:${verseNumber}`;
+};
+
+/**
  * Converts verse references in text to clickable links.
  * Example: "1:1" or "1:1-2" or "1:1-2:3" will be converted to HTML anchor tags.
  *
@@ -194,7 +209,10 @@ export const formatVerseReferencesToLinks = (text: string): string => {
   if (!text) return '';
   return text.replace(
     /(\d{1,3}[:-]\d{1,3}(?:-\d{1,3}(?::\d{1,3})?)?)(?![^<]*<\/a>)/g,
-    (match) => `<a href="${`/${match}`}" target="_blank">${match}</a>`,
+    (match) =>
+      `<a href="${`/${match}`}" target="_blank" data-verse-key="${
+        getFirstVerseKeyFromReference(match) || ''
+      }">${match}</a>`,
   );
 };
 


### PR DESCRIPTION
## Summary

This PoC enables opening Study Mode directly when clicking verse references inside translation footnotes.

What changed:
- `formatVerseReferencesToLinks` now always injects `data-verse-key` on generated verse-reference anchors.
- `FootnoteText` now reads `data-verse-key` on click and opens Study Mode (`openStudyMode`) for that verse.

Closes: [No Ticket]

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)


## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations
- [ ] Rollback requires special steps (describe below):

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed

**Testing steps:**

1. Run unit tests:
   `npx vitest run src/utils/string.test.ts`
2. In app (manual check), open a footnote containing `1:1`, `1:1-3`, or `1:1-2:3` and click the reference; Study Mode should open on the first verse key.

### Edge Cases Verified

- [ ] ⏳ Loading state handled
- [ ] ❌ Error state handled
- [x] 📭 Empty state handled
- [ ] 👤 Logged-in vs guest behavior (if applicable)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included
- [ ] Complex logic has inline comments explaining "why"
- [x] Functions are under 30 lines and follow single responsibility

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [ ] Linting passes (`yarn lint`)
- [ ] Build succeeds (`yarn build`)
- [x] Edge cases and error scenarios are handled

### Documentation

- [x] Code is self-documenting with clear naming
- [ ] README updated (if adding features or setup changes)
- [ ] Inline comments added for complex logic

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] Only English locale files modified (Lokalise handles others)
- [ ] RTL layout verified

### Accessibility (if UI changes)

- [x] Semantic HTML elements used
- [ ] ARIA attributes added where needed
- [ ] Keyboard navigation works

## Screenshots/Videos

https://github.com/user-attachments/assets/ab7cd027-bacb-4671-91ce-aea5b780cd39

## Reviewer Notes

- Study Mode interception only applies when `data-verse-key` exists; other links keep normal behavior.

## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
