### PR TITLE
sentry: drop generic hydration events in beforeSend

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -18,6 +18,7 @@ const IGNORED_ERRORS: Array<string | RegExp> = [
   /expected server html to contain a matching/i,
   /did not match\. server:/i,
   /hydration error/i,
+  /(reactjs\.org\/docs\/error-decoder\.html\?invariant=|react\.dev\/errors\/)(418|419|422|423|425)/i,
   /minified react error #418/i,
   /invariant=418/i,
 ];
@@ -29,6 +30,15 @@ type HydrationFilterEvent = Sentry.Event & {
   logentry?: {
     message?: string;
     formatted?: string;
+  };
+};
+
+type ReplayRecordingEvent = {
+  data?: {
+    tag?: string;
+    payload?: {
+      category?: string;
+    };
   };
 };
 
@@ -61,6 +71,9 @@ const shouldDropHydrationEvent = (event: HydrationFilterEvent, hint: Sentry.Even
   return messages.some((message) => matchesIgnoredError(message));
 };
 
+const shouldDropHydrationEventWithoutHint = (event: HydrationFilterEvent): boolean =>
+  shouldDropHydrationEvent(event, {});
+
 const hydrationFilterIntegration: Sentry.Integration = {
   name: 'HydrationFilter',
   processEvent: (event, hint) => {
@@ -85,6 +98,18 @@ Sentry.init({
     Sentry.replayIntegration({
       maskAllText: false,
       blockAllMedia: true,
+      beforeErrorSampling: (event) => !shouldDropHydrationEventWithoutHint(event),
+      beforeAddRecordingEvent: (recordingEvent) => {
+        const replayRecordingEvent = recordingEvent as ReplayRecordingEvent;
+        if (
+          replayRecordingEvent.data?.tag === 'breadcrumb' &&
+          replayRecordingEvent.data.payload?.category === 'replay.hydrate-error'
+        ) {
+          return null;
+        }
+
+        return recordingEvent;
+      },
     }),
   ],
 });

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -22,6 +22,26 @@ const IGNORED_ERRORS: Array<string | RegExp> = [
   /invariant=418/i,
 ];
 
+type HydrationFilterEvent = Sentry.ErrorEvent & {
+  metadata?: {
+    title?: string;
+  };
+  logentry?: {
+    message?: string;
+    formatted?: string;
+  };
+};
+
+const matchesIgnoredError = (value?: string): boolean =>
+  Boolean(
+    value &&
+      IGNORED_ERRORS.some((ignoredError) =>
+        typeof ignoredError === 'string'
+          ? value.toLowerCase().includes(ignoredError.toLowerCase())
+          : ignoredError.test(value),
+      ),
+  );
+
 Sentry.init({
   enabled: SENTRY_ENABLED,
   dsn: SENTRY_ENABLED ? SENTRY_DSN : null,
@@ -32,6 +52,27 @@ Sentry.init({
   replaysSessionSampleRate: isDev ? 1.0 : 0,
   release: version,
   ignoreErrors: IGNORED_ERRORS,
+  beforeSend: (event, hint) => {
+    const hydrationFilterEvent = event as HydrationFilterEvent;
+    const messages = [
+      hydrationFilterEvent.message,
+      hydrationFilterEvent.metadata?.title,
+      hydrationFilterEvent.logentry?.message,
+      hydrationFilterEvent.logentry?.formatted,
+      ...(hydrationFilterEvent.exception?.values?.flatMap((exception) => [
+        exception.value,
+        exception.type && exception.value ? `${exception.type}: ${exception.value}` : undefined,
+      ]) ?? []),
+    ];
+
+    const originalException = hint?.originalException;
+    if (typeof originalException === 'string') messages.push(originalException);
+    if (originalException instanceof Error) messages.push(originalException.message);
+
+    if (messages.some((message) => matchesIgnoredError(message))) return null;
+
+    return event;
+  },
   integrations: [
     // Add the replay integration for session replays
     Sentry.replayIntegration({

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -22,7 +22,7 @@ const IGNORED_ERRORS: Array<string | RegExp> = [
   /invariant=418/i,
 ];
 
-type HydrationFilterEvent = Sentry.ErrorEvent & {
+type HydrationFilterEvent = Sentry.Event & {
   metadata?: {
     title?: string;
   };
@@ -42,6 +42,33 @@ const matchesIgnoredError = (value?: string): boolean =>
       ),
   );
 
+const shouldDropHydrationEvent = (event: HydrationFilterEvent, hint: Sentry.EventHint): boolean => {
+  const messages = [
+    event.message,
+    event.metadata?.title,
+    event.logentry?.message,
+    event.logentry?.formatted,
+    ...(event.exception?.values?.flatMap((exception) => [
+      exception.value,
+      exception.type && exception.value ? `${exception.type}: ${exception.value}` : undefined,
+    ]) ?? []),
+  ];
+
+  const { originalException } = hint;
+  if (typeof originalException === 'string') messages.push(originalException);
+  if (originalException instanceof Error) messages.push(originalException.message);
+
+  return messages.some((message) => matchesIgnoredError(message));
+};
+
+const hydrationFilterIntegration: Sentry.Integration = {
+  name: 'HydrationFilter',
+  processEvent: (event, hint) => {
+    if (event.type === 'transaction') return event;
+    return shouldDropHydrationEvent(event as HydrationFilterEvent, hint) ? null : event;
+  },
+};
+
 Sentry.init({
   enabled: SENTRY_ENABLED,
   dsn: SENTRY_ENABLED ? SENTRY_DSN : null,
@@ -52,28 +79,8 @@ Sentry.init({
   replaysSessionSampleRate: isDev ? 1.0 : 0,
   release: version,
   ignoreErrors: IGNORED_ERRORS,
-  beforeSend: (event, hint) => {
-    const hydrationFilterEvent = event as HydrationFilterEvent;
-    const messages = [
-      hydrationFilterEvent.message,
-      hydrationFilterEvent.metadata?.title,
-      hydrationFilterEvent.logentry?.message,
-      hydrationFilterEvent.logentry?.formatted,
-      ...(hydrationFilterEvent.exception?.values?.flatMap((exception) => [
-        exception.value,
-        exception.type && exception.value ? `${exception.type}: ${exception.value}` : undefined,
-      ]) ?? []),
-    ];
-
-    const originalException = hint?.originalException;
-    if (typeof originalException === 'string') messages.push(originalException);
-    if (originalException instanceof Error) messages.push(originalException.message);
-
-    if (messages.some((message) => matchesIgnoredError(message))) return null;
-
-    return event;
-  },
   integrations: [
+    hydrationFilterIntegration,
     // Add the replay integration for session replays
     Sentry.replayIntegration({
       maskAllText: false,


### PR DESCRIPTION
## Summary
Stop hydration-related Replay issue traffic at the browser source so clients do not send the `Hydration Error` replay signal that is flooding Sentry.

## Why this is the right layer
From the installed SDK internals (`@sentry-internal/replay`):
- Replay listens on `beforeSendEvent` for error events.
- On hydration signatures, it adds a custom replay breadcrumb with category `replay.hydrate-error`.
- That replay breadcrumb drives the Sentry-side `replay_hydration_error` issue type.

So this is not only about normal JS error filtering. We must block Replay hydration frames client-side.

## What this PR now does
In `src/instrumentation-client.ts`:
1. Keeps hydration regex filtering for regular error event flow.
2. Adds Replay-level guards in `Sentry.replayIntegration({...})`:
   - `beforeAddRecordingEvent`: drops custom recording events where
     - `event.data.tag === 'breadcrumb'`
     - `event.data.payload.category === 'replay.hydrate-error'`
   - `beforeErrorSampling`: prevents hydration errors from triggering replay error sampling in buffer mode.
3. Extends hydration pattern coverage for React production links (`react.dev/errors/418...` and legacy decoder URLs).

## Expected effect
- Clients stop emitting replay hydration breadcrumbs that create `Hydration Error` replay issues.
- Hydration errors stop triggering replay-error sampling.
- This reduces ingest volume at source (browser) instead of relying on server-side suppression.

## Scope / risk
- One file changed: `src/instrumentation-client.ts`.
- Transactions and non-hydration replay behavior remain intact.
- Regular Sentry error reporting is preserved.

## Validation
- `yarn eslint src/instrumentation-client.ts` ✅
