### PR TITLE
Make NoteCard and ReflectionCard Titles Clickable Links to Verses

### DIFF
--- a/src/components/Notes/modal/MyNotes/Card/Card.module.scss
+++ b/src/components/Notes/modal/MyNotes/Card/Card.module.scss
@@ -33,7 +33,7 @@ $note_title_line_height: 1.5;
   line-height: $note_title_line_height;
   text-decoration: none;
 
-  &:hover {
+  &[data-link='true']:hover {
     text-decoration: underline;
     text-underline-offset: var(--spacing-micro-px);
   }

--- a/src/components/Notes/modal/MyNotes/Card/Card.module.scss
+++ b/src/components/Notes/modal/MyNotes/Card/Card.module.scss
@@ -31,6 +31,12 @@ $note_title_line_height: 1.5;
   font-size: var(--font-size-normal);
   font-weight: var(--font-weight-medium);
   line-height: $note_title_line_height;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: var(--spacing-micro-px);
+  }
 }
 
 .noteDate {

--- a/src/components/Notes/modal/MyNotes/Card/NoteCard.tsx
+++ b/src/components/Notes/modal/MyNotes/Card/NoteCard.tsx
@@ -66,13 +66,15 @@ const NoteCard: React.FC<NoteCardProps> = ({
     return '';
   }, []);
 
+  const LinkOrDiv = showReadMore ? Link : 'div';
+
   return (
     <div key={note.id} className={styles.noteCard} data-testid={`note-card-${note.id}`}>
       <div className={styles.noteHeader}>
         <div className={styles.noteInfo}>
-          <Link href={getVerseLink(note)} className={styles.noteTitle}>
+          <LinkOrDiv href={getVerseLink(note)} className={styles.noteTitle}>
             <h3>{formatNoteTitle(note)}</h3>
-          </Link>
+          </LinkOrDiv>
           <time className={styles.noteDate} dateTime={toSafeISOString(note.createdAt)}>
             {dateToMonthDayYearFormat(note.createdAt, lang)}
           </time>

--- a/src/components/Notes/modal/MyNotes/Card/NoteCard.tsx
+++ b/src/components/Notes/modal/MyNotes/Card/NoteCard.tsx
@@ -72,7 +72,11 @@ const NoteCard: React.FC<NoteCardProps> = ({
     <div key={note.id} className={styles.noteCard} data-testid={`note-card-${note.id}`}>
       <div className={styles.noteHeader}>
         <div className={styles.noteInfo}>
-          <LinkOrDiv href={getVerseLink(note)} className={styles.noteTitle}>
+          <LinkOrDiv
+            href={getVerseLink(note)}
+            className={styles.noteTitle}
+            data-link={showReadMore}
+          >
             <h3>{formatNoteTitle(note)}</h3>
           </LinkOrDiv>
           <time className={styles.noteDate} dateTime={toSafeISOString(note.createdAt)}>

--- a/src/components/Notes/modal/MyNotes/Card/NoteCard.tsx
+++ b/src/components/Notes/modal/MyNotes/Card/NoteCard.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext } from 'react';
 
+import Link from 'next/link';
 import useTranslation from 'next-translate/useTranslation';
 
 import styles from './Card.module.scss';
@@ -15,7 +16,8 @@ import EditIcon from '@/icons/edit.svg';
 import { Note } from '@/types/auth/Note';
 import { toSafeISOString, dateToMonthDayYearFormat } from '@/utils/datetime';
 import { toLocalizedNumber } from '@/utils/locale';
-import { readableVerseRangeKeys } from '@/utils/verseKeys';
+import { getSurahRangeNavigationUrlByVerseKey } from '@/utils/navigation';
+import { parseVerseRange, readableVerseRangeKeys } from '@/utils/verseKeys';
 
 export interface NoteCardProps {
   note: NoteWithRecentReflection;
@@ -48,11 +50,29 @@ const NoteCard: React.FC<NoteCardProps> = ({
     [chaptersData, lang],
   );
 
+  const getVerseLink = useCallback((noteWithPostUrl: NoteWithRecentReflection) => {
+    if (!noteWithPostUrl.ranges || noteWithPostUrl.ranges.length === 0) return '';
+    const firstRange = noteWithPostUrl.ranges[0];
+    const parsedRange = parseVerseRange(firstRange, true);
+
+    if (parsedRange && parsedRange.length === 2) {
+      const from = parsedRange[0];
+      const to = parsedRange[1];
+
+      const rangeKey = `${from.chapter}:${from.verse}-${to.verse}`;
+      return getSurahRangeNavigationUrlByVerseKey(rangeKey);
+    }
+
+    return '';
+  }, []);
+
   return (
     <div key={note.id} className={styles.noteCard} data-testid={`note-card-${note.id}`}>
       <div className={styles.noteHeader}>
         <div className={styles.noteInfo}>
-          <h3 className={styles.noteTitle}>{formatNoteTitle(note)}</h3>
+          <Link href={getVerseLink(note)} className={styles.noteTitle}>
+            <h3>{formatNoteTitle(note)}</h3>
+          </Link>
           <time className={styles.noteDate} dateTime={toSafeISOString(note.createdAt)}>
             {dateToMonthDayYearFormat(note.createdAt, lang)}
           </time>

--- a/src/components/Notes/modal/MyNotes/Card/ReflectionCard.tsx
+++ b/src/components/Notes/modal/MyNotes/Card/ReflectionCard.tsx
@@ -47,7 +47,7 @@ const ReflectionCard: React.FC<ReflectionCardProps> = ({ reflection, showReadMor
     if (!ref.references || ref.references.length === 0) return '';
     const firstRef = ref.references[0];
     if (firstRef.chapterId && firstRef.from) {
-      const rangeKey = `${firstRef.chapterId}:${firstRef.from}-${firstRef.to}`;
+      const rangeKey = `${firstRef.chapterId}:${firstRef.from}-${firstRef.to ?? firstRef.from}`;
       return getSurahRangeNavigationUrlByVerseKey(rangeKey);
     }
 

--- a/src/components/Notes/modal/MyNotes/Card/ReflectionCard.tsx
+++ b/src/components/Notes/modal/MyNotes/Card/ReflectionCard.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext } from 'react';
 
+import Link from 'next/link';
 import useTranslation from 'next-translate/useTranslation';
 
 import styles from './Card.module.scss';
@@ -14,6 +15,7 @@ import AyahReflection from '@/types/QuranReflect/AyahReflection';
 import { toSafeISOString, dateToMonthDayYearFormat } from '@/utils/datetime';
 import { logButtonClick } from '@/utils/eventLogger';
 import { toLocalizedNumber } from '@/utils/locale';
+import { getSurahRangeNavigationUrlByVerseKey } from '@/utils/navigation';
 import { getQuranReflectPostUrl } from '@/utils/quranReflect/navigation';
 import { readableVerseRangeKeys } from '@/utils/verseKeys';
 
@@ -41,6 +43,17 @@ const ReflectionCard: React.FC<ReflectionCardProps> = ({ reflection, showReadMor
     [chaptersData, lang],
   );
 
+  const getVerseLink = useCallback((ref: AyahReflection) => {
+    if (!ref.references || ref.references.length === 0) return '';
+    const firstRef = ref.references[0];
+    if (firstRef.chapterId && firstRef.from) {
+      const rangeKey = `${firstRef.chapterId}:${firstRef.from}-${firstRef.to}`;
+      return getSurahRangeNavigationUrlByVerseKey(rangeKey);
+    }
+
+    return '';
+  }, []);
+
   const onViewOnQrClicked = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     logButtonClick('posted_ref_view_on_qr', { postId: reflection.id });
@@ -64,7 +77,10 @@ const ReflectionCard: React.FC<ReflectionCardProps> = ({ reflection, showReadMor
     >
       <div className={styles.noteHeader}>
         <div className={styles.noteInfo}>
-          <h3 className={styles.noteTitle}>{formatReflectionTitle(reflection)}</h3>
+          <Link href={getVerseLink(reflection)} className={styles.noteTitle}>
+            <h3>{formatReflectionTitle(reflection)}</h3>
+          </Link>
+
           <time className={styles.noteDate} dateTime={toSafeISOString(reflection.createdAt)}>
             {dateToMonthDayYearFormat(reflection.createdAt, lang)}
           </time>


### PR DESCRIPTION

### Summary

- Convert NoteCard and ReflectionCard titles from plain headings to clickable links
- Links navigate directly to the corresponding verse range in the Quran reader
- Add hover state with underline to improve discoverability
- Reuse existing `getSurahRangeNavigationUrlByVerseKey` utility for consistent URL generation

### NoteCard
- Wrapped title in Next.js `Link` component with dynamic verse URL
- Added `getVerseLink` helper to parse verse ranges and generate navigation URLs
- Updated `Card.module.scss` to remove default text decoration and add hover state

### ReflectionCard
- Wrapped title in Next.js `Link` component with dynamic verse URL
- Added `getVerseLink` helper to extract verse references from reflection data
- Shares same styling updates with NoteCard

### Test Plan

- [x] Verify clicking note titles navigates to correct verse range
- [x] Verify clicking reflection titles navigates to correct verse range
- [x] Confirm hover state shows underline on titles
- [x] Test with notes/reflections that have multiple ranges (should link to first range)
- [x] Verify links work with various chapter and verse numbers

