### PR TITLE
sentry,replay: disable prod replay-on-error sampling

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -27,7 +27,7 @@ Sentry.init({
   dsn: SENTRY_ENABLED ? SENTRY_DSN : null,
   debug: isDev,
   tracesSampleRate: isDev ? 1 : 0.1,
-  replaysOnErrorSampleRate: isDev ? 1 : 0.1,
+  replaysOnErrorSampleRate: isDev ? 1 : 0,
   // Session replays sample rate - only capture dev sessions
   replaysSessionSampleRate: isDev ? 1.0 : 0,
   release: version,


### PR DESCRIPTION
## Summary
This hotfix disables `replaysOnErrorSampleRate` in production (`0.1 -> 0`) to immediately reduce client-side emission that is currently overwhelming self-hosted Sentry.

## Why this is needed
We verified on the self-hosted Sentry host (`/opt/Sentry/self-hosted`) that the hydration flood is not arriving through the classic JS error table path:

- `errors_local` had no matching `Hydration Error` rows for this flood.
- The events are instead appearing in `search_issues_local_v2` as Issue Platform occurrences with `occurrence_type_id = 5003`.
- For the affected frontend project/group in the last 24h, volume was ~148k occurrences and almost all from `quran.com-frontend-next@26.2.2003`.
- `replay_id` was present on 100% of sampled rows for this stream.

This points to replay/occurrence ingestion behavior for hydration issues, which can bypass expectations around normal client `ignoreErrors` behavior and still generate very high issue volume.

Given current server pressure, the safest immediate mitigation is to stop replay-on-error uploads in production while keeping dev behavior intact.

## Change
- `src/instrumentation-client.ts`
  - `replaysOnErrorSampleRate: isDev ? 1 : 0.1`
  - -> `replaysOnErrorSampleRate: isDev ? 1 : 0`

No other behavior was changed in this PR.

## Risk / tradeoff
- We lose automatic replay capture triggered by production errors during this period.
- We keep normal browser error ingestion and tracing settings untouched.

## Follow-up (separate PR)
- Keep / strengthen hydration-specific client filtering for replay and issue events.
- Re-enable production replay-on-error at a controlled rate only after confirming sustained ingestion stability.
