### PR TITLE
Return 404 when Hadith data is empty or missing

### DIFF
--- a/src/pages/[chapterId]/hadith.tsx
+++ b/src/pages/[chapterId]/hadith.tsx
@@ -119,6 +119,13 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
       getPagesLookup({ chapterNumber: Number(chapterNumber), mushaf: mushafId }),
     ]);
 
+    if (!hadithsData?.hadiths?.length) {
+      return {
+        notFound: true,
+        revalidate: REVALIDATION_PERIOD_ON_ERROR_SECONDS,
+      };
+    }
+
     const versesResponse = buildVersesResponse(chaptersData, pagesLookupResponse);
 
     return {

--- a/src/pages/[chapterId]/hadith.tsx
+++ b/src/pages/[chapterId]/hadith.tsx
@@ -119,12 +119,7 @@ export const getStaticProps: GetStaticProps = async ({ params, locale }) => {
       getPagesLookup({ chapterNumber: Number(chapterNumber), mushaf: mushafId }),
     ]);
 
-    if (!hadithsData?.hadiths?.length) {
-      return {
-        notFound: true,
-        revalidate: REVALIDATION_PERIOD_ON_ERROR_SECONDS,
-      };
-    }
+    if (!hadithsData?.hadiths?.length) return { notFound: true };
 
     const versesResponse = buildVersesResponse(chaptersData, pagesLookupResponse);
 


### PR DESCRIPTION
### Summary
  - Return 404 page when hadith data is empty, null, or missing for a specific verse
  - Prevents rendering pages with no hadith content

  Previously, if a verse had no associated hadiths, the page would still attempt to render with empty data. This change ensures that users see a proper 404 page when:
  - No hadiths exist for a verse
  - Hadith data is null/undefined
  - Hadith API returns empty array

  ### Test plan
  - [x] Test verse with no hadiths - should show 404
  - [x] Test verse with hadiths - should render normally