### PR TITLE
[QF-4808] Prevent verse number flipping for Urdu language

### DIFF
--- a/src/components/Collection/CollectionDetail/CollectionVerseCell.tsx
+++ b/src/components/Collection/CollectionDetail/CollectionVerseCell.tsx
@@ -20,7 +20,7 @@ import { selectPinnedVerseKeysSet } from '@/redux/slices/QuranReader/pinnedVerse
 import { getChapterData } from '@/utils/chapter';
 import { dateToMonthDayYearFormat } from '@/utils/datetime';
 import { logButtonClick } from '@/utils/eventLogger';
-import { isRTLLocale, toLocalizedVerseKey, toLocalizedVerseKeyRTL } from '@/utils/locale';
+import { isRTLLocale, toLocalizedVerseKeyAuto } from '@/utils/locale';
 import { getVerseNavigationUrlByVerseKey } from '@/utils/navigation';
 import { makeVerseKey } from '@/utils/verse';
 import DataContext from 'src/contexts/DataContext';
@@ -51,9 +51,7 @@ const CollectionVerseCell: React.FC<CollectionVerseCellProps> = ({
   const verseKey = makeVerseKey(chapterId, verseNumber);
   const isPinned = pinnedVerseKeysSet.has(verseKey);
   const chapterData = getChapterData(chaptersData, chapterId.toString());
-  const localizedVerseKey = isRTLLocale(lang)
-    ? toLocalizedVerseKeyRTL(verseKey, lang)
-    : toLocalizedVerseKey(verseKey, lang);
+  const localizedVerseKey = toLocalizedVerseKeyAuto(verseKey, lang);
   const chapterName = isRTLLocale(lang)
     ? chapterData?.nameArabic || chapterData?.transliteratedName
     : chapterData?.transliteratedName;

--- a/src/components/MyQuran/tabs/RecentContent/RecentContent.tsx
+++ b/src/components/MyQuran/tabs/RecentContent/RecentContent.tsx
@@ -20,12 +20,7 @@ import { TestId } from '@/tests/test-ids';
 import { getMushafId } from '@/utils/api';
 import { getChapterData } from '@/utils/chapter';
 import { logButtonClick } from '@/utils/eventLogger';
-import {
-  isRTLLocale,
-  toLocalizedDate,
-  toLocalizedVerseKey,
-  toLocalizedVerseKeyRTL,
-} from '@/utils/locale';
+import { toLocalizedDate, toLocalizedVerseKeyAuto } from '@/utils/locale';
 import { getChapterWithStartingVerseUrl } from '@/utils/navigation';
 import { getVerseAndChapterNumbersFromKey } from '@/utils/verse';
 
@@ -91,10 +86,7 @@ const RecentContent = () => {
             />
             <div className={styles.recentContentItemTitle}>
               <p>
-                {surah.transliteratedName}{' '}
-                {isRTLLocale(lang)
-                  ? toLocalizedVerseKeyRTL(verseKey, lang)
-                  : toLocalizedVerseKey(verseKey, lang)}
+                {surah.transliteratedName} {toLocalizedVerseKeyAuto(verseKey, lang)}
               </p>
               <IconContainer icon={<ArrowIcon />} />
             </div>

--- a/src/components/QuranReader/PinnedVersesBar/VerseTag.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/VerseTag.tsx
@@ -6,7 +6,7 @@ import useTranslation from 'next-translate/useTranslation';
 import styles from './VerseTag.module.scss';
 
 import CloseIcon from '@/icons/close.svg';
-import { isRTLLocale, toLocalizedVerseKey, toLocalizedVerseKeyRTL } from '@/utils/locale';
+import { toLocalizedVerseKeyAuto } from '@/utils/locale';
 
 interface VerseTagProps {
   verseKey: string;
@@ -17,9 +17,7 @@ interface VerseTagProps {
 
 const VerseTag: React.FC<VerseTagProps> = ({ verseKey, onRemove, onClick, isSelected = false }) => {
   const { t, lang } = useTranslation('quran-reader');
-  const localizedVerseKey = isRTLLocale(lang)
-    ? toLocalizedVerseKeyRTL(verseKey, lang)
-    : toLocalizedVerseKey(verseKey, lang);
+  const localizedVerseKey = toLocalizedVerseKeyAuto(verseKey, lang);
 
   const handleRemoveClick = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/QuranReader/ReadingView/StudyModeModal/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/index.tsx
@@ -44,7 +44,7 @@ import Word, { CharType } from '@/types/Word';
 import { getDefaultWordFields, getMushafId } from '@/utils/api';
 import { makeByVerseKeyUrl } from '@/utils/apiPaths';
 import { logButtonClick, logValueChange } from '@/utils/eventLogger';
-import { toLocalizedVerseKey, toLocalizedVerseKeyRTL, isRTLLocale } from '@/utils/locale';
+import { toLocalizedVerseKeyAuto } from '@/utils/locale';
 import {
   fakeNavigate,
   getVerseSelectedTafsirNavigationUrl,
@@ -398,9 +398,7 @@ const StudyModeModal: React.FC<Props> = ({
     if (versesHistory.length === 0) return null;
     const prevVerseKey = versesHistory[versesHistory.length - 1];
     const chapter = chaptersData?.[getChapterNumberFromKey(prevVerseKey)];
-    const localizedVerseKey = isRTLLocale(lang)
-      ? toLocalizedVerseKeyRTL(prevVerseKey, lang)
-      : toLocalizedVerseKey(prevVerseKey, lang);
+    const localizedVerseKey = toLocalizedVerseKeyAuto(prevVerseKey, lang);
     return {
       localizedVerseKey,
       chapterName: chapter?.transliteratedName || '',

--- a/src/components/QuranReader/TranslationView/TranslationText/Reference.tsx
+++ b/src/components/QuranReader/TranslationView/TranslationText/Reference.tsx
@@ -5,7 +5,7 @@ import styles from './TranslationText.module.scss';
 import Link from '@/dls/Link/Link';
 import EventNames from '@/utils/event-names';
 import { logButtonClick } from '@/utils/eventLogger';
-import { isRTLLocale, toLocalizedVerseKey, toLocalizedVerseKeyRTL } from '@/utils/locale';
+import { toLocalizedVerseKeyAuto } from '@/utils/locale';
 import { getChapterWithStartingVerseUrl } from '@/utils/navigation';
 
 interface Props {
@@ -18,9 +18,7 @@ const Reference = ({ reference, chapterName, lang }: Props) => {
   const localizedReference = useMemo(() => {
     if (!reference) return '';
 
-    return isRTLLocale(lang)
-      ? toLocalizedVerseKeyRTL(reference, lang)
-      : toLocalizedVerseKey(reference, lang);
+    return toLocalizedVerseKeyAuto(reference, lang);
   }, [reference, lang]);
 
   const handleClick = useCallback(() => {

--- a/src/components/Verse/SaveBookmarkModal/ReadingBookmarkSection/useReadingBookmark.test.tsx
+++ b/src/components/Verse/SaveBookmarkModal/ReadingBookmarkSection/useReadingBookmark.test.tsx
@@ -82,17 +82,17 @@ vi.mock('@/utils/chapter', () => ({
 }));
 
 const toLocalizedNumberMock = vi.fn((n: number, _lang?: string) => String(n));
-const toLocalizedVerseKeyMock = vi.fn((key: string, _lang: string) => key);
-const toLocalizedVerseKeyRTLMock = vi.fn((key: string, _lang: string) =>
-  key.split(':').reverse().join(':'),
-);
-const isRTLLocaleMock = vi.fn((lang: string) => lang === 'ar');
+const toLocalizedVerseKeyAutoMock = vi.fn((key: string, lang: string) => {
+  if (['ar', 'fa'].includes(lang)) {
+    return key.split(':').reverse().join(':');
+  }
+
+  return key;
+});
 
 vi.mock('@/utils/locale', () => ({
   toLocalizedNumber: (n: number, lang?: string) => toLocalizedNumberMock(n, lang),
-  toLocalizedVerseKey: (key: string, lang: string) => toLocalizedVerseKeyMock(key, lang),
-  toLocalizedVerseKeyRTL: (key: string, lang: string) => toLocalizedVerseKeyRTLMock(key, lang),
-  isRTLLocale: (lang: string) => isRTLLocaleMock(lang),
+  toLocalizedVerseKeyAuto: (key: string, lang: string) => toLocalizedVerseKeyAutoMock(key, lang),
 }));
 
 describe('useReadingBookmark - Logged-in User', () => {
@@ -487,7 +487,7 @@ describe('useReadingBookmark - Logged-in User', () => {
       );
 
       expect(result.current.resourceDisplayName).toBe('Al-Baqarah 255:2');
-      expect(toLocalizedVerseKeyRTLMock).toHaveBeenCalledWith('2:255', 'ar');
+      expect(toLocalizedVerseKeyAutoMock).toHaveBeenCalledWith('2:255', 'ar');
     });
 
     it('uses RTL verse key for displayReadingBookmark', () => {
@@ -508,7 +508,7 @@ describe('useReadingBookmark - Logged-in User', () => {
       );
 
       expect(result.current.displayReadingBookmark).toBe('Al-Baqarah 255:2');
-      expect(toLocalizedVerseKeyRTLMock).toHaveBeenCalledWith('2:255', 'ar');
+      expect(toLocalizedVerseKeyAutoMock).toHaveBeenCalledWith('2:255', 'ar');
     });
   });
 });

--- a/src/components/Verse/SaveBookmarkModal/ReadingBookmarkSection/useReadingBookmark.ts
+++ b/src/components/Verse/SaveBookmarkModal/ReadingBookmarkSection/useReadingBookmark.ts
@@ -36,12 +36,7 @@ import { addBookmark, deleteBookmarkById as deleteBookmark } from '@/utils/auth/
 import { GuestReadingBookmark } from '@/utils/bookmark';
 import { getChapterData } from '@/utils/chapter';
 import { logEvent } from '@/utils/eventLogger';
-import {
-  isRTLLocale,
-  toLocalizedNumber,
-  toLocalizedVerseKey,
-  toLocalizedVerseKeyRTL,
-} from '@/utils/locale';
+import { toLocalizedNumber, toLocalizedVerseKeyAuto } from '@/utils/locale';
 
 /** Debounce delay to prevent flicker when state updates */
 const STATE_TRANSITION_DELAY_MS = 300;
@@ -95,11 +90,9 @@ const useReadingBookmark = ({
   const quranReaderStyles = useSelector(selectQuranReaderStyles);
   const currentMushafId = getMushafId(quranReaderStyles.quranFont, quranReaderStyles.mushafLines)
     .mushaf as Mushaf;
-  const isRtlLocale = isRTLLocale(lang);
   const localizeVerseKey = useCallback(
-    (key: string): string =>
-      isRtlLocale ? toLocalizedVerseKeyRTL(key, lang) : toLocalizedVerseKey(key, lang),
-    [isRtlLocale, lang],
+    (key: string): string => toLocalizedVerseKeyAuto(key, lang),
+    [lang],
   );
 
   const guestReadingBookmark = useSelector(selectGuestReadingBookmark);

--- a/src/components/Verse/SaveBookmarkModal/useSaveBookmarkModal.ts
+++ b/src/components/Verse/SaveBookmarkModal/useSaveBookmarkModal.ts
@@ -21,12 +21,7 @@ import { addCollection, addCollectionBookmark } from '@/utils/auth/api';
 import { getErrorStatus } from '@/utils/auth/errors';
 import { isLoggedIn } from '@/utils/auth/login';
 import { logButtonClick, logEvent } from '@/utils/eventLogger';
-import {
-  isRTLLocale,
-  toLocalizedNumber,
-  toLocalizedVerseKey,
-  toLocalizedVerseKeyRTL,
-} from '@/utils/locale';
+import { toLocalizedNumber, toLocalizedVerseKeyAuto } from '@/utils/locale';
 import {
   getChapterWithStartingVerseUrl,
   getLoginNavigationUrl,
@@ -141,9 +136,7 @@ const useSaveBookmarkModal = ({
   // Localization
   let localizedVerseKey = '';
   if (verse) {
-    localizedVerseKey = isRTLLocale(lang)
-      ? toLocalizedVerseKeyRTL(verseKey, lang)
-      : toLocalizedVerseKey(verseKey, lang);
+    localizedVerseKey = toLocalizedVerseKeyAuto(verseKey, lang);
   }
   const localizedPageNumber = pageNumber ? toLocalizedNumber(pageNumber, lang) : '';
 

--- a/src/components/Verse/VerseLink/index.tsx
+++ b/src/components/Verse/VerseLink/index.tsx
@@ -9,7 +9,7 @@ import styles from './VerseLink.module.scss';
 import Button, { ButtonShape, ButtonSize, ButtonVariant } from '@/dls/Button/Button';
 import { selectStudyModeIsOpen } from '@/redux/slices/QuranReader/studyMode';
 import { logButtonClick } from '@/utils/eventLogger';
-import { isRTLLocale, toLocalizedVerseKey, toLocalizedVerseKeyRTL } from '@/utils/locale';
+import { toLocalizedVerseKeyAuto } from '@/utils/locale';
 import { getChapterWithStartingVerseUrl } from '@/utils/navigation';
 
 interface Props {
@@ -37,9 +37,7 @@ const VerseLink: React.FC<Props> = ({ verseKey, isTranslationView }) => {
         logButtonClick(`${isTranslationView ? 'translation_view' : 'reading_view'}_verse_link`);
       }}
     >
-      {isRTLLocale(lang)
-        ? toLocalizedVerseKeyRTL(verseKey, lang)
-        : toLocalizedVerseKey(verseKey, lang)}
+      {toLocalizedVerseKeyAuto(verseKey, lang)}
     </Button>
   );
 };

--- a/src/hooks/studyMode/useStudyModeVerseNavigation.ts
+++ b/src/hooks/studyMode/useStudyModeVerseNavigation.ts
@@ -7,7 +7,7 @@ import { useDispatch } from 'react-redux';
 import { StudyModeTabId } from '@/components/QuranReader/ReadingView/StudyModeModal/StudyModeBottomActions';
 import DataContext from '@/contexts/DataContext';
 import { setVerseKey } from '@/redux/slices/QuranReader/studyMode';
-import { isRTLLocale, toLocalizedVerseKey, toLocalizedVerseKeyRTL } from '@/utils/locale';
+import { toLocalizedVerseKeyAuto } from '@/utils/locale';
 import { fakeNavigateReplace } from '@/utils/navigation';
 import { getChapterNumberFromKey } from '@/utils/verse';
 
@@ -119,9 +119,7 @@ const useStudyModeVerseNavigation = ({
     if (versesHistory.length === 0) return null;
     const prevVerseKey = versesHistory[versesHistory.length - 1];
     const chapter = chaptersData?.[getChapterNumberFromKey(prevVerseKey)];
-    const localizedVerseKey = isRTLLocale(lang)
-      ? toLocalizedVerseKeyRTL(prevVerseKey, lang)
-      : toLocalizedVerseKey(prevVerseKey, lang);
+    const localizedVerseKey = toLocalizedVerseKeyAuto(prevVerseKey, lang);
     return {
       localizedVerseKey,
       chapterName: chapter?.transliteratedName || '',

--- a/src/utils/locale.test.ts
+++ b/src/utils/locale.test.ts
@@ -1,6 +1,11 @@
 import { it, expect } from 'vitest';
 
-import { toLocalizedNumber, toLocalizedMonthName, toLocalizedVerseKeyRTL } from './locale';
+import {
+  toLocalizedNumber,
+  toLocalizedMonthName,
+  toLocalizedVerseKeyRTL,
+  toLocalizedVerseKeyAuto,
+} from './locale';
 
 it('toLocalizedNumber works as expected', () => {
   expect(toLocalizedNumber(9, 'en', true)).toBe('09');
@@ -34,4 +39,64 @@ it('toLocalizedVerseKeyRTL works as expected', () => {
   // Both multi-digit
   expect(toLocalizedVerseKeyRTL('36:83', 'ar')).toBe('٨٣:٣٦');
   expect(toLocalizedVerseKeyRTL('36:83', 'en')).toBe('83:36');
+});
+
+it('toLocalizedVerseKeyAuto works as expected for RTL languages', () => {
+  // Arabic - should use RTL format (reversed order with Arabic numerals)
+  expect(toLocalizedVerseKeyAuto('3:1', 'ar')).toBe('١:٣');
+  expect(toLocalizedVerseKeyAuto('1:1', 'ar')).toBe('١:١');
+  expect(toLocalizedVerseKeyAuto('114:6', 'ar')).toBe('٦:١١٤');
+  expect(toLocalizedVerseKeyAuto('2:286', 'ar')).toBe('٢٨٦:٢');
+  expect(toLocalizedVerseKeyAuto('36:83', 'ar')).toBe('٨٣:٣٦');
+
+  // Persian/Farsi - should use RTL format with Persian numerals
+  expect(toLocalizedVerseKeyAuto('3:1', 'fa')).toBe('۱:۳');
+  expect(toLocalizedVerseKeyAuto('2:286', 'fa')).toBe('۲۸۶:۲');
+});
+
+it('toLocalizedVerseKeyAuto works as expected for LTR languages', () => {
+  // English - should use LTR format
+  expect(toLocalizedVerseKeyAuto('3:1', 'en')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('1:1', 'en')).toBe('1:1');
+  expect(toLocalizedVerseKeyAuto('114:6', 'en')).toBe('114:6');
+  expect(toLocalizedVerseKeyAuto('2:286', 'en')).toBe('2:286');
+  expect(toLocalizedVerseKeyAuto('36:83', 'en')).toBe('36:83');
+
+  // French - should use LTR format
+  expect(toLocalizedVerseKeyAuto('3:1', 'fr')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('2:286', 'fr')).toBe('2:286');
+
+  // Other LTR languages
+  expect(toLocalizedVerseKeyAuto('3:1', 'de')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('3:1', 'es')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('3:1', 'id')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('3:1', 'ru')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('3:1', 'tr')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('3:1', 'zh')).toBe('3:1');
+});
+
+it('toLocalizedVerseKeyAuto handles Urdu as a special case (LTR format despite being RTL)', () => {
+  // Urdu is RTL locale but should use LTR format for verse keys
+  expect(toLocalizedVerseKeyAuto('3:1', 'ur')).toBe('3:1');
+  expect(toLocalizedVerseKeyAuto('1:1', 'ur')).toBe('1:1');
+  expect(toLocalizedVerseKeyAuto('114:6', 'ur')).toBe('114:6');
+  expect(toLocalizedVerseKeyAuto('2:286', 'ur')).toBe('2:286');
+  expect(toLocalizedVerseKeyAuto('36:83', 'ur')).toBe('36:83');
+});
+
+it('toLocalizedVerseKeyAuto handles edge cases', () => {
+  // First verse of first chapter across different locales
+  expect(toLocalizedVerseKeyAuto('1:1', 'ar')).toBe('١:١'); // RTL
+  expect(toLocalizedVerseKeyAuto('1:1', 'en')).toBe('1:1'); // LTR
+  expect(toLocalizedVerseKeyAuto('1:1', 'ur')).toBe('1:1'); // Urdu special case
+
+  // Last verse of last surah
+  expect(toLocalizedVerseKeyAuto('114:6', 'ar')).toBe('٦:١١٤'); // RTL
+  expect(toLocalizedVerseKeyAuto('114:6', 'en')).toBe('114:6'); // LTR
+  expect(toLocalizedVerseKeyAuto('114:6', 'ur')).toBe('114:6'); // Urdu special case
+
+  // Longest verse in the Quran
+  expect(toLocalizedVerseKeyAuto('2:286', 'ar')).toBe('٢٨٦:٢'); // RTL
+  expect(toLocalizedVerseKeyAuto('2:286', 'en')).toBe('2:286'); // LTR
+  expect(toLocalizedVerseKeyAuto('2:286', 'ur')).toBe('2:286'); // Urdu special case
 });

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -437,7 +437,9 @@ export const toLocalizedVerseKeyRTL = (verseKey: string, lang: string): string =
  * @returns {string} The localized verse key based on locale direction.
  */
 export const toLocalizedVerseKeyAuto = (verseKey: string, lang: string): string =>
-  isRTLLocale(lang) ? toLocalizedVerseKeyRTL(verseKey, lang) : toLocalizedVerseKey(verseKey, lang);
+  isRTLLocale(lang) && lang !== Language.UR
+    ? toLocalizedVerseKeyRTL(verseKey, lang)
+    : toLocalizedVerseKey(verseKey, lang);
 
 /**
  * Get the localized value of a range e.g. "1-20"

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -429,6 +429,17 @@ export const toLocalizedVerseKeyRTL = (verseKey: string, lang: string): string =
     .join(':');
 
 /**
+ * Get the localized value of the verse key based on the locale direction.
+ * This is a wrapper function that automatically chooses between RTL and LTR localization.
+ *
+ * @param {string} verseKey - The verse key in "chapter:verse" format (e.g., "3:1").
+ * @param {string} lang - The target language for number localization.
+ * @returns {string} The localized verse key based on locale direction.
+ */
+export const toLocalizedVerseKeyAuto = (verseKey: string, lang: string): string =>
+  isRTLLocale(lang) ? toLocalizedVerseKeyRTL(verseKey, lang) : toLocalizedVerseKey(verseKey, lang);
+
+/**
  * Get the localized value of a range e.g. "1-20"
  *
  * @param {string} range

--- a/src/utils/verseKeys.ts
+++ b/src/utils/verseKeys.ts
@@ -8,12 +8,7 @@ import ChaptersData from '@/types/ChaptersData';
 import { MushafLines, QuranFont } from '@/types/QuranReader';
 import { getDefaultWordFields, getMushafId } from '@/utils/api';
 import { makeByVerseKeyUrl } from '@/utils/apiPaths';
-import {
-  isRTLLocale,
-  toLocalizedNumber,
-  toLocalizedVerseKey,
-  toLocalizedVerseKeyRTL,
-} from '@/utils/locale';
+import { toLocalizedNumber, toLocalizedVerseKeyAuto } from '@/utils/locale';
 
 /**
  * Generate the verse keys between two verse keys.
@@ -235,20 +230,15 @@ export const readableVerseRangeKeys = (
       const chapterData = getChapterData(chaptersData, from.chapter.toString());
       if (!chapterData) return null;
 
-      const localizedVerseKey = (verseKey: string) =>
-        isRTLLocale(lang)
-          ? toLocalizedVerseKeyRTL(verseKey, lang)
-          : toLocalizedVerseKey(verseKey, lang);
-
       const chapterName = chapterData.transliteratedName;
-      const titleForm = `${chapterName} ${localizedVerseKey(from.verseKey)}`;
+      const titleForm = `${chapterName} ${toLocalizedVerseKeyAuto(from.verseKey, lang)}`;
 
       if (from.chapter === to.chapter) {
         if (from.verse === to.verse) return titleForm;
         return `${titleForm}-${toLocalizedNumber(to.verse, lang)}`;
       }
 
-      return `${titleForm}-${localizedVerseKey(to.verseKey)}`;
+      return `${titleForm}-${toLocalizedVerseKeyAuto(to.verseKey, lang)}`;
     })
     .filter((title): title is string => title !== null);
 };


### PR DESCRIPTION
### Summary
- Introduced `toLocalizedVerseKeyAuto()` as a single unified function that automatically handles both RTL and LTR verse key localization
- Replaced all occurrences of the ternary pattern `isRTLLocale(lang) ? toLocalizedVerseKeyRTL(...) : toLocalizedVerseKey(...)` with the new simplified function
- Updated 11 component files to use the new unified approach, reducing code duplication and improving maintainability
- The new function excludes Urdu (ur) from RTL auto-selection logic due to its special handling requirements

Fixes: [QF-4808](https://quranfoundation.atlassian.net/browse/QF-4808)

### Technical Details
The new `toLocalizedVerseKeyAuto()` function in `src/utils/locale.ts` encapsulates the logic for selecting between RTL and LTR verse key localization based on the locale direction. This change:
- Reduces boilerplate code across multiple components
- Centralizes the locale selection logic in one place
- Maintains backward compatibility by keeping the original functions
- Follows the existing pattern where Urdu is treated as a special case

### Test plan
- [x] Verify verse keys display correctly in RTL languages (e.g., Arabic)
- [x] Verify verse keys display correctly in LTR languages (e.g., English)
- [x] Verify Urdu (ur) locale verse keys display correctly (should use LTR format)
- [x] Test all affected components:
  - Collection/CollectionDetail/CollectionVerseCell
  - MyQuran/tabs/RecentContent
  - QuranReader/PinnedVersesBar/VerseTag
  - QuranReader/ReadingView/StudyModeModal
  - QuranReader/TranslationView/TranslationText/Reference
  - Verse/SaveBookmarkModal components
  - Verse/VerseLink
  - studyMode/useStudyModeVerseNavigation
  - verseKeys utility functions
  
  
<img width="311" height="224" alt="image" src="https://github.com/user-attachments/assets/6299387b-6dca-4a0b-a7d1-74392195c659" />



[QF-4808]: https://quranfoundation.atlassian.net/browse/QF-4808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ