### PR TITLE
sentry: add @sentry/node and enable default pii with full profiling sample rate

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@sanity/client": "^5.2.1",
     "@sanity/image-url": "^1.0.2",
     "@sentry/nextjs": "^9.19.0",
+    "@sentry/node": "9.19.0",
     "@sentry/profiling-node": "9.19.0",
     "@types/crypto-js": "^4.2.2",
     "@umalqura/core": "^0.0.7",

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -13,6 +13,7 @@ const version = `quran.com-frontend-next@${process.env.NEXT_PUBLIC_APP_VERSION}`
 Sentry.init({
   enabled: SENTRY_ENABLED,
   dsn: SENTRY_ENABLED ? SENTRY_DSN : null,
+  sendDefaultPii: true,
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production


### PR DESCRIPTION
## Summary
- add `@sentry/node` as a direct dependency
- enable `sendDefaultPii: true` in server Sentry init
- set `profilesSampleRate: 1.0` in server Sentry init

## Notes
- profiling config is applied in `sentry.server.config.ts`
