### PR TITLE
fix(QF-4707): use migration marker to prevent cascading font scale remap

### DIFF
--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -117,19 +117,22 @@ const ReduxProvider = ({ children, locale }) => {
               effectiveFont,
               remoteStyles.mushafLines ?? store.getState().quranReaderStyles.mushafLines,
             );
-            // Write corrected scale + marker so remap doesn't cascade on next load
+            // Write corrected scale, then persist marker only after scale succeeds
             addOrUpdateUserPreference(
               'quranTextFontScale',
               correctedScale,
               PreferenceGroup.QURAN_READER_STYLES,
               mushaf,
-            ).catch(() => {});
-            addOrUpdateUserPreference(
-              'fontScaleRemapVersion',
-              1,
-              PreferenceGroup.QURAN_READER_STYLES,
-              mushaf,
-            ).catch(() => {});
+            )
+              .then(() =>
+                addOrUpdateUserPreference(
+                  'fontScaleRemapVersion',
+                  1,
+                  PreferenceGroup.QURAN_READER_STYLES,
+                  mushaf,
+                ),
+              )
+              .catch(() => {});
           }
         }
 

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -8,6 +8,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 import getStore from './store';
 
+import { logErrorToSentry } from '@/lib/sentry';
 import resetSettings from '@/redux/actions/reset-settings';
 import syncLocaleDependentSettings from '@/redux/actions/sync-locale-dependent-settings';
 import syncUserPreferences from '@/redux/actions/sync-user-preferences';
@@ -132,7 +133,7 @@ const ReduxProvider = ({ children, locale }) => {
                   mushaf,
                 ),
               )
-              .catch(() => {});
+              .catch((err) => logErrorToSentry(err, { transactionName: 'fontScaleRemap' }));
           }
         }
 

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -107,23 +107,29 @@ const ReduxProvider = ({ children, locale }) => {
         // Must happen pre-dispatch so the corrected value flows through once;
         // a remap inside the reducer would cascade on subsequent syncs (7→9→10).
         const remoteStyles = userPreferences[PreferenceGroup.QURAN_READER_STYLES];
-        if (remoteStyles?.quranTextFontScale != null) {
+        if (remoteStyles?.quranTextFontScale != null && !remoteStyles.fontScaleRemapVersion) {
           const effectiveFont =
             remoteStyles.quranFont ?? store.getState().quranReaderStyles.quranFont;
           if (needsFontScaleRemap(effectiveFont, remoteStyles.quranTextFontScale)) {
             const correctedScale = remapFontScale(effectiveFont, remoteStyles.quranTextFontScale);
             remoteStyles.quranTextFontScale = correctedScale;
-            // Push corrected value back to backend (fire-and-forget)
             const { mushaf } = getMushafId(
               effectiveFont,
               remoteStyles.mushafLines ?? store.getState().quranReaderStyles.mushafLines,
             );
+            // Write corrected scale + marker so remap doesn't cascade on next load
             addOrUpdateUserPreference(
               'quranTextFontScale',
               correctedScale,
               PreferenceGroup.QURAN_READER_STYLES,
               mushaf,
-            ).catch(() => {}); // fire-and-forget
+            ).catch(() => {});
+            addOrUpdateUserPreference(
+              'fontScaleRemapVersion',
+              1,
+              PreferenceGroup.QURAN_READER_STYLES,
+              mushaf,
+            ).catch(() => {});
           }
         }
 


### PR DESCRIPTION
## Summary

Cherry-pick of the migration marker fix from PR #3188 (production) onto testing, so both branches stay in sync after merge.

Closes: [QF-4707](https://quranfoundation.atlassian.net/browse/QF-4707)

---

## Problem

The remap table has chains where output values are also input values (`6→7`, but `7→9`). The runtime remap in `Provider.tsx` ran on every page load, so after writing back `7`, the next load would remap it to `9`, then `9→10` — cascading until the max.

## Solution

Write a `fontScaleRemapVersion: 1` marker to the backend alongside the corrected scale. On subsequent loads, if the marker exists, skip the remap entirely:

1. **First load:** no marker → remap `6→7`, write `scale=7` + `marker=1`
2. **Next load:** marker exists → skip remap. Scale stays `7`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Test Plan

- [x] `npx vitest run src/redux/migration-scripts/remap-font-scale.test.ts` — 95 tests pass
- [x] `npx vitest run src/redux/migrations.test.ts` — 17 tests pass
- [x] Manual: set scale 6 → reload → verify 7 → reload again → verify still 7 (not 9)

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code

[QF-4707]: https://quranfoundation.atlassian.net/browse/QF-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ