### PR TITLE
 style(reading-mode): align 3-dots menu content with tooltip

### DIFF
--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/ReadingModeWordHoverActions.module.scss
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/ReadingModeWordHoverActions.module.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-xsmall-px);
+  padding: var(--spacing-small2-px);
   border-radius: var(--spacing-xxsmall-px);
   background: var(--color-success-medium);
   box-shadow: var(--shadow-reading-word-three-dots);
@@ -22,7 +22,11 @@
   border-radius: var(--spacing-xxsmall-px);
   min-inline-size: auto;
   z-index: var(--z-index-modal);
-  direction: ltr;
+}
+
+.menuContentRtl {
+  direction: rtl;
+  text-align: end;
 }
 
 .menuItemContent {
@@ -36,4 +40,8 @@
 .menuItemChevron {
   inline-size: var(--spacing-small2-px);
   block-size: var(--spacing-small2-px);
+}
+
+.menuItemChevronRtl {
+  transform: rotate(180deg);
 }

--- a/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
+++ b/src/components/dls/QuranWord/ReadingModeWordHoverActions/WordOptionsDropdown.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import classNames from 'classnames';
 import useTranslation from 'next-translate/useTranslation';
 
 import styles from './ReadingModeWordHoverActions.module.scss';
@@ -8,6 +9,7 @@ import ReadingViewNoteAction from '@/components/Notes/modal/ReadingViewNoteActio
 import BookmarkAction from '@/components/Verse/BookmarkAction';
 import IconContainer, { IconColor, IconSize } from '@/dls/IconContainer/IconContainer';
 import PopoverMenu, { PopoverMenuAlign } from '@/dls/PopoverMenu/PopoverMenu';
+import useDirection from '@/hooks/useDirection';
 import ArrowIcon from '@/icons/arrow.svg';
 import BookIcon from '@/icons/book-open.svg';
 import OverflowMenuIcon from '@/icons/menu_more_horiz.svg';
@@ -35,10 +37,14 @@ const WordOptionsDropdown: React.FC<Props> = ({
   onRepeatVerse,
 }) => {
   const { t } = useTranslation('common');
+  const direction = useDirection();
+  const isRTL = direction === Direction.RTL;
 
   return (
     <PopoverMenu
-      contentClassName={styles.menuContent}
+      contentClassName={classNames(styles.menuContent, {
+        [styles.menuContentRtl]: isRTL,
+      })}
       dir={Direction.LTR}
       align={PopoverMenuAlign.END}
       sideOffset={DROPDOWN_SIDE_OFFSET}
@@ -68,7 +74,11 @@ const WordOptionsDropdown: React.FC<Props> = ({
       >
         <span className={styles.menuItemContent}>
           {t('more')}
-          <ArrowIcon className={styles.menuItemChevron} />
+          <ArrowIcon
+            className={classNames(styles.menuItemChevron, {
+              [styles.menuItemChevronRtl]: isRTL,
+            })}
+          />
         </span>
       </PopoverMenu.Item>
 


### PR DESCRIPTION
 ## Summary

  - Updates the Reading Mode word 3-dots dropdown to support RTL content alignment.
  -  align 3-dots menu content with tooltip

  Closes: QF-4753 (https://quranfoundation.atlassian.net/browse/QF-4753)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
    expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses one feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Environment Variables

  No new environment variables.

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations
  - [ ] Rollback requires special steps (describe below):

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  Testing steps:

  1. Switch to an RTL locale (e.g. Arabic/Urdu).
  2. Open the word 3-dots menu in Reading Mode.
  3. Verify menu content is RTL-aligned and the More chevron flips correctly.
  4. Switch to LTR locale and verify menu layout/position remains unchanged.

  ### Edge Cases Verified

  - [ ] ⏳ Loading state handled
  - [ ] ❌ Error state handled
  - [ ] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a self-review of my code (file by file)
  - [x] My code follows the project style guidelines (/.github/copilot-instructions.md)
  - [x] No any types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [ ] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (yarn test)
  - [ ] Linting passes (yarn lint)
  - [ ] Build succeeds (yarn build)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [ ] Inline comments added for complex logic

  ### Localization (if UI changes)

  - [x] All user-facing text uses next-translate
  - [x] Only English locale files modified (Lokalise handles others)
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] ARIA attributes added where needed
  - [x] Keyboard navigation works


  ## Related PRs

  - https://github.com/quran/quran.com-frontend-next/pull/3156


  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have thoroughly reviewed and validated all generated code
