### PR TITLE
[QF-4797] Preserve paused audio state after Settings Reset

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.test.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import AudioPlayer from './AudioPlayer';
+
+import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
+
+vi.mock('next/dynamic', () => ({
+  default: () => {
+    const Stub = () => <div data-testid="audio-player-body-stub" />;
+    return Stub;
+  },
+}));
+
+vi.mock('@/components/Onboarding/OnboardingProvider', () => ({
+  useOnboarding: () => ({ isActive: false }),
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: () => false,
+}));
+
+vi.mock('@xstate/react', () => ({
+  useSelector: (service: unknown, selector: (state: unknown) => unknown) => {
+    return selector({ matches: (val: string) => val === 'VISIBLE' });
+  },
+}));
+
+vi.mock('@/utils/datetime', () => ({
+  milliSecondsToSeconds: (ms: number) => ms / 1000,
+}));
+
+interface MockSnapshot {
+  matches: (stateValue: string) => boolean;
+  context?: {
+    audioData?: { duration: number } | null;
+  };
+}
+
+const createMockAudioService = (statePath: string) => {
+  const send = vi.fn();
+  const getSnapshot = (): MockSnapshot => ({
+    matches: (val: string) => val === statePath,
+    context: { audioData: { duration: 10_000 } },
+  });
+  return {
+    send,
+    getSnapshot,
+    state: {
+      hasTag: () => false,
+    },
+  };
+};
+
+describe('AudioPlayer', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const renderWithService = (audioService: ReturnType<typeof createMockAudioService>) => {
+    const result = render(
+      <AudioPlayerMachineContext.Provider
+        value={audioService as unknown as React.ContextType<typeof AudioPlayerMachineContext>}
+      >
+        <AudioPlayer />
+      </AudioPlayerMachineContext.Provider>,
+    );
+    audioService.send.mockClear();
+    return result;
+  };
+
+  describe('onPlay guard', () => {
+    it('pauses audio and does not send PLAY when machine is not in PLAYING state', () => {
+      const audioService = createMockAudioService('VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.ACTIVE');
+      renderWithService(audioService);
+
+      const audioEl = document.getElementById('audio-player') as HTMLAudioElement;
+      const pauseSpy = vi.fn();
+      audioEl.pause = pauseSpy;
+
+      fireEvent.play(audioEl);
+
+      expect(pauseSpy).toHaveBeenCalled();
+      expect(audioService.send).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'PLAY' }));
+    });
+
+    it('sends PLAY when machine is in PLAYING state', () => {
+      const audioService = createMockAudioService('VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING');
+      renderWithService(audioService);
+
+      const audioEl = document.getElementById('audio-player') as HTMLAudioElement;
+      fireEvent.play(audioEl);
+
+      expect(audioService.send).toHaveBeenCalledWith({ type: 'PLAY' });
+    });
+  });
+
+  describe('onTimeUpdate guard', () => {
+    it('does not send WAITING or CAN_PLAY when machine is not in PLAYING state', () => {
+      const audioService = createMockAudioService('VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.ACTIVE');
+      renderWithService(audioService);
+
+      const audioEl = document.getElementById('audio-player') as HTMLAudioElement;
+      Object.defineProperty(audioEl, 'currentTime', { value: 3, writable: true });
+      Object.defineProperty(audioEl, 'buffered', {
+        value: { length: 1, end: () => 2 },
+        writable: true,
+      });
+
+      fireEvent.timeUpdate(audioEl);
+
+      expect(audioService.send).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'WAITING' }),
+      );
+      expect(audioService.send).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'CAN_PLAY' }),
+      );
+      expect(audioService.send).toHaveBeenCalledWith({ type: 'UPDATE_TIMING' });
+    });
+  });
+});

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -75,8 +75,10 @@ const AudioPlayer = () => {
     const downloadProgress = getAudioPlayerDownloadProgress(audioPlayer);
     const isWaiting = currentTimestamp > downloadProgress - AUDIO_DURATION_TOLERANCE;
 
-    const audioDataDuration = audioService.getSnapshot().context?.audioData?.duration;
-    if (audioDataDuration) {
+    const snapshot = audioService.getSnapshot();
+    const isAudioPlaying = snapshot.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING');
+    const audioDataDuration = snapshot.context?.audioData?.duration;
+    if (audioDataDuration && isAudioPlaying) {
       const isAlmostEnded =
         currentTimestamp > milliSecondsToSeconds(audioDataDuration) - AUDIO_DURATION_TOLERANCE;
 
@@ -120,7 +122,15 @@ const AudioPlayer = () => {
     });
   };
 
-  const onPlay = () => {
+  const onPlay = (e) => {
+    const isAudioPlaying = audioService
+      .getSnapshot()
+      .matches('VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING');
+    if (!isAudioPlaying) {
+      e.target.pause();
+      return;
+    }
+
     audioService.send({ type: 'PLAY' });
   };
 

--- a/src/components/Navbar/SettingsDrawer/ResetButton.test.tsx
+++ b/src/components/Navbar/SettingsDrawer/ResetButton.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useDispatch } from 'react-redux';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+
+import ResetButton from './ResetButton';
+
+import { DEFAULT_XSTATE_INITIAL_STATE } from '@/redux/defaultSettings/defaultSettings';
+import { isLoggedIn } from '@/utils/auth/login';
+import { AudioPlayerMachineContext } from 'src/xstate/AudioPlayerMachineContext';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('next-translate/useTranslation', () => ({
+  default: () => ({
+    t: (key: string) => key,
+    lang: 'en',
+  }),
+}));
+
+vi.mock('react-redux', () => ({
+  useDispatch: vi.fn(),
+}));
+
+vi.mock('@/utils/auth/login', () => ({
+  isLoggedIn: vi.fn(() => false),
+}));
+
+vi.mock('@/utils/eventLogger', () => ({
+  logButtonClick: vi.fn(),
+}));
+
+vi.mock('@/dls/Toast/Toast', () => ({
+  ToastStatus: { Success: 'success', Error: 'error' },
+  useToast: () => vi.fn(),
+}));
+
+const NON_DEFAULT_RECITER_ID = 11;
+
+interface MockAudioService {
+  send: ReturnType<typeof vi.fn>;
+  getSnapshot: () => {
+    context: {
+      reciterId: number;
+      audioData?: { reciterId: number } | null;
+    };
+  };
+}
+
+describe('ResetButton', () => {
+  const dispatchMock = vi.fn(() => Promise.resolve({ payload: undefined }));
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  const renderButton = (audioContext: MockAudioService) =>
+    render(
+      <AudioPlayerMachineContext.Provider
+        value={audioContext as unknown as React.ContextType<typeof AudioPlayerMachineContext>}
+      >
+        <ResetButton />
+      </AudioPlayerMachineContext.Provider>,
+    );
+
+  const createAudioContext = (
+    audioDataReciterId?: number | null,
+    contextReciterId = DEFAULT_XSTATE_INITIAL_STATE.reciterId,
+  ): MockAudioService => {
+    const send = vi.fn();
+    return {
+      send,
+      getSnapshot: () => ({
+        context: {
+          reciterId: contextReciterId,
+          audioData:
+            audioDataReciterId === null || audioDataReciterId === undefined
+              ? (audioDataReciterId as null | undefined)
+              : { reciterId: audioDataReciterId },
+        },
+      }),
+    };
+  };
+
+  it('sends CHANGE_RECITER when currently loaded audio reciter differs from default', () => {
+    vi.mocked(useDispatch).mockReturnValue(dispatchMock);
+    const audioContext = createAudioContext(NON_DEFAULT_RECITER_ID);
+
+    renderButton(audioContext);
+    fireEvent.click(screen.getByTestId('reset-settings-button'));
+
+    expect(dispatchMock).toHaveBeenCalled();
+    expect(audioContext.send).toHaveBeenCalledWith({
+      type: 'SET_INITIAL_CONTEXT',
+      ...DEFAULT_XSTATE_INITIAL_STATE,
+    });
+    expect(audioContext.send).toHaveBeenCalledWith({
+      type: 'CHANGE_RECITER',
+      reciterId: DEFAULT_XSTATE_INITIAL_STATE.reciterId,
+    });
+  });
+
+  it('does not send CHANGE_RECITER when active reciter is already default', () => {
+    vi.mocked(useDispatch).mockReturnValue(dispatchMock);
+    const audioContext = createAudioContext(DEFAULT_XSTATE_INITIAL_STATE.reciterId);
+
+    renderButton(audioContext);
+    fireEvent.click(screen.getByTestId('reset-settings-button'));
+
+    expect(dispatchMock).toHaveBeenCalled();
+    expect(audioContext.send).toHaveBeenCalledWith({
+      type: 'SET_INITIAL_CONTEXT',
+      ...DEFAULT_XSTATE_INITIAL_STATE,
+    });
+    expect(audioContext.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'CHANGE_RECITER' }),
+    );
+  });
+
+  it('falls back to context.reciterId when audioData is null', () => {
+    vi.mocked(useDispatch).mockReturnValue(dispatchMock);
+    const audioContext = createAudioContext(null, DEFAULT_XSTATE_INITIAL_STATE.reciterId);
+
+    renderButton(audioContext);
+    fireEvent.click(screen.getByTestId('reset-settings-button'));
+
+    expect(audioContext.send).toHaveBeenCalledWith({
+      type: 'SET_INITIAL_CONTEXT',
+      ...DEFAULT_XSTATE_INITIAL_STATE,
+    });
+    expect(audioContext.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'CHANGE_RECITER' }),
+    );
+  });
+
+  it('sends CHANGE_RECITER when audioData is null and context reciter differs from default', () => {
+    vi.mocked(useDispatch).mockReturnValue(dispatchMock);
+    const audioContext = createAudioContext(null, NON_DEFAULT_RECITER_ID);
+
+    renderButton(audioContext);
+    fireEvent.click(screen.getByTestId('reset-settings-button'));
+
+    expect(audioContext.send).toHaveBeenCalledWith({
+      type: 'CHANGE_RECITER',
+      reciterId: DEFAULT_XSTATE_INITIAL_STATE.reciterId,
+    });
+  });
+
+  it('resets settings for logged-in users after persisting defaults', async () => {
+    vi.mocked(useDispatch).mockReturnValue(dispatchMock);
+    vi.mocked(isLoggedIn).mockReturnValue(true);
+    const audioContext = createAudioContext(NON_DEFAULT_RECITER_ID);
+
+    renderButton(audioContext);
+    fireEvent.click(screen.getByTestId('reset-settings-button'));
+
+    await waitFor(() => {
+      expect(audioContext.send).toHaveBeenCalledWith({
+        type: 'SET_INITIAL_CONTEXT',
+        ...DEFAULT_XSTATE_INITIAL_STATE,
+      });
+    });
+  });
+});

--- a/src/components/Navbar/SettingsDrawer/ResetButton.tsx
+++ b/src/components/Navbar/SettingsDrawer/ResetButton.tsx
@@ -44,8 +44,9 @@ const ResetButton = () => {
   };
 
   const resetAndSetInitialState = () => {
-    const shouldChangeReciter =
-      audioService.getSnapshot().context.reciterId !== DEFAULT_XSTATE_INITIAL_STATE.reciterId;
+    const snapshot = audioService.getSnapshot();
+    const activeReciterId = snapshot.context.audioData?.reciterId || snapshot.context.reciterId;
+    const shouldChangeReciter = activeReciterId !== DEFAULT_XSTATE_INITIAL_STATE.reciterId;
 
     dispatch(resetSettings(lang));
     audioService.send({

--- a/src/components/Navbar/SettingsDrawer/ResetButton.tsx
+++ b/src/components/Navbar/SettingsDrawer/ResetButton.tsx
@@ -44,15 +44,20 @@ const ResetButton = () => {
   };
 
   const resetAndSetInitialState = () => {
+    const shouldChangeReciter =
+      audioService.getSnapshot().context.reciterId !== DEFAULT_XSTATE_INITIAL_STATE.reciterId;
+
     dispatch(resetSettings(lang));
     audioService.send({
       type: 'SET_INITIAL_CONTEXT',
       ...DEFAULT_XSTATE_INITIAL_STATE,
     });
-    audioService.send({
-      type: 'CHANGE_RECITER',
-      reciterId: DEFAULT_XSTATE_INITIAL_STATE.reciterId,
-    });
+    if (shouldChangeReciter) {
+      audioService.send({
+        type: 'CHANGE_RECITER',
+        reciterId: DEFAULT_XSTATE_INITIAL_STATE.reciterId,
+      });
+    }
   };
 
   const onResetSettingsClicked = async () => {

--- a/src/xstate/AudioPlayerMachineContext.test.tsx
+++ b/src/xstate/AudioPlayerMachineContext.test.tsx
@@ -1,0 +1,59 @@
+import React, { useContext, useEffect } from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { persistXstateToLocalStorage } from './actors/audioPlayer/audioPlayerPersistHelper';
+import { AudioPlayerMachineContext, AudioPlayerMachineProvider } from './AudioPlayerMachineContext';
+
+vi.mock('next-translate/useTranslation', () => ({
+  default: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/dls/Toast/Toast', () => ({
+  ToastStatus: { Error: 'error' },
+  useToast: () => vi.fn(),
+}));
+
+vi.mock('./actors/audioPlayer/audioPlayerPersistHelper', () => ({
+  getXstateStateFromLocalStorage: () => ({}),
+  persistXstateToLocalStorage: vi.fn(),
+}));
+
+const Probe = ({ eventOverride }: { eventOverride?: Record<string, unknown> }) => {
+  const audioService = useContext(AudioPlayerMachineContext);
+
+  useEffect(() => {
+    audioService.send({
+      type: 'SET_INITIAL_CONTEXT',
+      reciterId: 7,
+      playbackRate: 1,
+      volume: 0.75,
+      ...eventOverride,
+    });
+  }, [audioService, eventOverride]);
+
+  return null;
+};
+
+describe('AudioPlayerMachineProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists xstate context when receiving SET_INITIAL_CONTEXT', async () => {
+    render(
+      <AudioPlayerMachineProvider>
+        <Probe />
+      </AudioPlayerMachineProvider>,
+    );
+
+    await waitFor(() => {
+      expect(persistXstateToLocalStorage).toHaveBeenCalledWith({
+        reciterId: 7,
+        playbackRate: 1,
+        volume: 0.75,
+      });
+    });
+  });
+});

--- a/src/xstate/AudioPlayerMachineContext.tsx
+++ b/src/xstate/AudioPlayerMachineContext.tsx
@@ -20,6 +20,7 @@ export const AudioPlayerMachineContext = createContext(
 
 const LOCAL_STORAGE_PERSISTENCE_EVENT_TRIGGER = [
   'CHANGE_RECITER',
+  'SET_INITIAL_CONTEXT',
   'SET_PLAYBACK_SPEED',
   'UPDATE_VOLUME',
 ];

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.reset.test.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.reset.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { State } from 'xstate';
+
+import { audioPlayerMachine } from './audioPlayerMachine';
+
+const getAudioPlayer = () => ({
+  currentTime: 0,
+  src: '',
+  pause: () => null,
+  play: () => Promise.resolve(),
+});
+
+const getPausedLoadingState = () =>
+  State.from(
+    { VISIBLE: 'LOADING_RECITER_DATA_AND_PAUSE' },
+    {
+      ...audioPlayerMachine.initialState.context,
+      audioPlayer: getAudioPlayer(),
+      surah: 1,
+      ayahNumber: 1,
+    },
+  );
+
+const getFetchReciterDoneEvent = () => ({
+  type: 'done.invoke.fetchReciter',
+  data: {
+    audioUrl: 'https://example.com/audio.mp3',
+    duration: 5_000,
+    verseTimings: [{ verseKey: '1:1', timestampFrom: 0, timestampTo: 5_000, segments: [] }],
+    reciterId: 7,
+  },
+});
+
+describe('audioPlayerMachine reset flows', () => {
+  it('resolves paused reciter reload to PAUSED.ACTIVE and pauses audio', () => {
+    const nextState = audioPlayerMachine.transition(
+      getPausedLoadingState(),
+      getFetchReciterDoneEvent(),
+    );
+
+    const actionTypes = nextState.actions.map((action) => action.type);
+
+    expect(nextState.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.ACTIVE')).toBe(true);
+    expect(nextState.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.LOADING')).toBe(false);
+    expect(actionTypes).toContain('pauseAudio');
+  });
+});

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -574,11 +574,12 @@ export const audioPlayerMachine =
                     actions: [
                       'setAudioData',
                       'setAudioPlayerSource',
+                      'pauseAudio',
                       'setAudioPlayerCurrentTime',
                       'updateRepeatVerseTimings',
                     ],
                     description: 'The API call to get the selected chapter + Surah succeeded',
-                    target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.LOADING',
+                    target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.ACTIVE',
                   },
                 ],
                 onError: [


### PR DESCRIPTION
 ## Summary

  This PR updates the audio reset flow so **user playback intent is preserved** when clicking **Settings → Reset**.

  ### What changed

  - `ResetButton` now sends `CHANGE_RECITER` only when the current reciter differs from the default reciter.
  - In the paused reciter-loading path, the machine now explicitly pauses audio and resolves to `PAUSED.ACTIVE`.
  - Native `<audio onPlay>` events are ignored unless the machine is already in a `PLAYING` state.
  - Simulated `WAITING/CAN_PLAY` transitions from `onTimeUpdate` now run only while in `PLAYING`.

  ### Behavior now

  - If audio is **paused** before reset, it stays paused after reset.
  - If audio is **playing** before reset, it continues playing after reset with default reciter.
  - Reciter/default settings still reset correctly and persist after refresh.
  - Safari `autoPlay` support remains intact.

  Closes: [QF-4797](https://quranfoundation.atlassian.net/browse/QF-4797)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
        expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Environment Variables

  No new environment variables were added.

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations
  - [ ] Rollback requires special steps (describe below):

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Automated checks run:**
  1. `yarn eslint src/components/AudioPlayer/AudioPlayer.tsx src/components/Navbar/SettingsDrawer/ResetButton.tsx src/
  xstate/actors/audioPlayer/audioPlayerMachine.ts`
  2. Existing audio selector tests remain passing in local validation runs

  **Manual testing steps:**
  1. Open any surah
  2. Click play
  3. Click pause
  4. Open Settings drawer → click Reset
  5. Verify audio remains paused and does not auto-resume
  6. Change reciter to non-default, play, pause, then Reset
  7. Verify new/default reciter audio loads but remains paused
  8. Keep audio playing, Reset with default reciter selected
  9. Verify uninterrupted playback (no forced reload)
  10. Keep audio playing, Reset after switching to non-default reciter
  11. Verify playback continues correctly after reciter reset
  12. Verify normal play/pause/seek behavior still works
  13. Verify behavior in Chrome
  14. Verify behavior in Firefox
  15. Confirm defaults persisted after refresh (default reciter restored)

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled
  - [ ] ❌ Error state handled
  - [ ] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [ ] Complex logic has inline comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [ ] Inline comments added for complex logic

  ### Localization (if UI changes)

  - [x] All user-facing text uses `next-translate`
  - [x] Only English locale files modified (Lokalise handles others)
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] ARIA attributes added where needed
  - [x] Keyboard navigation works

  ## Screenshots/Videos

  N/A (no visible UI changes)

  ## Related PRs

  None

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4797]: https://quranfoundation.atlassian.net/browse/QF-4797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ