### PR TITLE
[QF-4516] Fix incorrect header metadata on direct surah navigation

### DIFF
--- a/src/components/QuranReader/hooks/useSyncChapterPage.ts
+++ b/src/components/QuranReader/hooks/useSyncChapterPage.ts
@@ -2,21 +2,53 @@
 
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useStore } from 'react-redux';
 
 import DataContext from '@/contexts/DataContext';
 import useBrowserLayoutEffect from '@/hooks/useBrowserLayoutEffect';
 import useChapterIdsByUrlPath from '@/hooks/useChapterId';
-import {
-  selectLastReadVerseKey,
-  setLastReadVerse,
-} from '@/redux/slices/QuranReader/readingTracker';
+import { RootState } from '@/redux/RootState';
+import { setLastReadVerse } from '@/redux/slices/QuranReader/readingTracker';
 import { normalizeQueryParam } from '@/utils/url';
 import { VersesResponse } from 'types/ApiResponses';
 
 const getNormalizedStartingVerse = (startingVerse: string | string[]): number => {
   const parsedStartingVerse = Number(normalizeQueryParam(startingVerse));
   return Number.isNaN(parsedStartingVerse) || parsedStartingVerse < 1 ? 1 : parsedStartingVerse;
+};
+
+/**
+ * Check if we should sync the chapter from the URL for this page.
+ *
+ * We only allow this on plain chapter reader routes (`/[chapterId]`) and when
+ * the payload looks like a chapter page (first verse is verse 1).
+ * We skip verse-like params such as `20:49`.
+ *
+ * @param {object} params - Values used by the check.
+ * @param {string} params.pathname - Current Next.js pathname (for example '/[chapterId]').
+ * @param {string | undefined} params.routeChapterId - Normalized chapterId from query.
+ * @param {number | undefined} params.firstVerseNumber - Verse number of `initialData.verses[0]`.
+ * @returns {boolean} True if URL chapter sync should run.
+ */
+const shouldSyncChapterFromRoute = ({
+  pathname,
+  routeChapterId,
+  firstVerseNumber,
+}: {
+  pathname: string;
+  routeChapterId?: string;
+  firstVerseNumber?: number;
+}): boolean => {
+  const isPlainChapterReaderPath = pathname === '/[chapterId]';
+  const isVerseLikeChapterParam = routeChapterId?.includes(':');
+  const isChapterLikePayload = firstVerseNumber === 1;
+
+  return (
+    isPlainChapterReaderPath &&
+    Boolean(routeChapterId) &&
+    !isVerseLikeChapterParam &&
+    isChapterLikePayload
+  );
 };
 
 /**
@@ -33,22 +65,27 @@ const getNormalizedStartingVerse = (startingVerse: string | string[]): number =>
  * so the correct page number is displayed immediately.
  *
  * Additional route sync:
- * - On chapter routes (`/S`), we also align chapter context with the URL (and `startingVerse`
- *   when needed) without clobbering in-chapter scroll progress.
+ * - On plain chapter routes (`/[chapterId]`) only, we also align chapter context with the URL
+ *   (and `startingVerse` when needed) without clobbering in-chapter scroll progress.
  *
  * @param {VersesResponse} initialData - The initial verses data from the page
  */
 const useSyncChapterPage = (initialData: VersesResponse): void => {
   const dispatch = useDispatch();
+  const store = useStore<RootState>();
   const router = useRouter();
   const { lang } = useTranslation('common');
   const chaptersData = useContext(DataContext);
-  const lastReadVerse = useSelector(selectLastReadVerseKey, shallowEqual);
-  const hasChapterIdInRoute = Boolean(router.query.chapterId) && !router.query.verseId;
+  const firstVerse = initialData?.verses?.[0];
+  const routeChapterId = normalizeQueryParam(router.query.chapterId);
+  const hasChapterIdInRoute = shouldSyncChapterFromRoute({
+    pathname: router.pathname,
+    routeChapterId,
+    firstVerseNumber: firstVerse?.verseNumber,
+  });
   const chapterIdsByUrlPath = useChapterIdsByUrlPath(lang);
   const urlChapterId = hasChapterIdInRoute ? chapterIdsByUrlPath?.[0] : undefined;
 
-  const firstVerse = initialData?.verses?.[0];
   // Use verseKey as the dependency to detect navigation changes
   const firstVerseKey = firstVerse?.verseKey;
   const normalizedStartingVerse = getNormalizedStartingVerse(router.query.startingVerse);
@@ -69,12 +106,14 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
     );
   }, [firstVerseKey, chaptersData, dispatch, firstVerse]);
 
-  // On /S routes, ensure Redux chapter context matches URL chapter without clobbering in-chapter scroll progress.
+  // On plain chapter routes, ensure Redux chapter context matches URL chapter without
+  // clobbering in-chapter scroll progress.
   useEffect(() => {
     if (!hasChapterIdInRoute || !urlChapterId || !chaptersData) {
       return;
     }
 
+    const { lastReadVerse } = store.getState().readingTracker;
     const expectedVerseKey = `${urlChapterId}:${normalizedStartingVerse}`;
     const chapterFromVerseKey = lastReadVerse?.verseKey?.split(':')?.[0];
     if ((lastReadVerse?.chapterId || chapterFromVerseKey) === urlChapterId) {
@@ -100,11 +139,8 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
     firstVerse?.hizbNumber,
     firstVerse?.pageNumber,
     hasChapterIdInRoute,
-    lastReadVerse?.chapterId,
-    lastReadVerse?.hizb,
-    lastReadVerse?.page,
-    lastReadVerse?.verseKey,
     normalizedStartingVerse,
+    store,
     urlChapterId,
   ]);
 };

--- a/src/components/QuranReader/hooks/useSyncChapterPage.ts
+++ b/src/components/QuranReader/hooks/useSyncChapterPage.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+﻿import { useContext, useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
@@ -44,7 +44,7 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
   const { lang } = useTranslation('common');
   const chaptersData = useContext(DataContext);
   const lastReadVerse = useSelector(selectLastReadVerseKey, shallowEqual);
-  const hasChapterIdInRoute = Boolean(router.query.chapterId);
+  const hasChapterIdInRoute = Boolean(router.query.chapterId) && !router.query.verseId;
   const chapterIdsByUrlPath = useChapterIdsByUrlPath(lang);
   const urlChapterId = hasChapterIdInRoute ? chapterIdsByUrlPath?.[0] : undefined;
 

--- a/src/components/QuranReader/hooks/useSyncChapterPage.ts
+++ b/src/components/QuranReader/hooks/useSyncChapterPage.ts
@@ -1,10 +1,16 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 
-import { useDispatch } from 'react-redux';
+import { useRouter } from 'next/router';
+import useTranslation from 'next-translate/useTranslation';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import DataContext from '@/contexts/DataContext';
 import useBrowserLayoutEffect from '@/hooks/useBrowserLayoutEffect';
-import { setLastReadVerse } from '@/redux/slices/QuranReader/readingTracker';
+import useChapterIdsByUrlPath from '@/hooks/useChapterId';
+import {
+  selectLastReadVerseKey,
+  setLastReadVerse,
+} from '@/redux/slices/QuranReader/readingTracker';
 import { VersesResponse } from 'types/ApiResponses';
 
 /**
@@ -20,15 +26,38 @@ import { VersesResponse } from 'types/ApiResponses';
  * Uses useBrowserLayoutEffect to ensure state is set synchronously before paint,
  * so the correct page number is displayed immediately.
  *
+ * Additional route sync:
+ * - On chapter routes (`/S`), we also align chapter context with the URL (and `startingVerse`
+ *   when needed) without clobbering in-chapter scroll progress.
+ *
  * @param {VersesResponse} initialData - The initial verses data from the page
  */
 const useSyncChapterPage = (initialData: VersesResponse): void => {
   const dispatch = useDispatch();
+  const router = useRouter();
+  const { lang } = useTranslation('common');
   const chaptersData = useContext(DataContext);
+  const lastReadVerse = useSelector(selectLastReadVerseKey, shallowEqual);
+  const chapterIdsByUrlPath = useChapterIdsByUrlPath(lang);
+  const urlChapterId = chapterIdsByUrlPath?.[0];
+  const hasChapterIdInRoute = Boolean(router.query.chapterId);
 
   const firstVerse = initialData?.verses?.[0];
   // Use verseKey as the dependency to detect navigation changes
   const firstVerseKey = firstVerse?.verseKey;
+
+  // If a startingVerse query param is present, use it to determine the verse to sync to.
+  const normalizedStartingVerse = useMemo(() => {
+    const rawStartingVerse = router.query.startingVerse;
+    const startingVerse = Array.isArray(rawStartingVerse) ? rawStartingVerse[0] : rawStartingVerse;
+    const parsedStartingVerse = Number(startingVerse);
+
+    if (Number.isNaN(parsedStartingVerse) || parsedStartingVerse < 1) {
+      return 1;
+    }
+
+    return parsedStartingVerse;
+  }, [router.query.startingVerse]);
 
   useBrowserLayoutEffect(() => {
     if (!firstVerse) return;
@@ -45,6 +74,48 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
       }),
     );
   }, [firstVerseKey, chaptersData, dispatch, firstVerse]);
+
+  // On /S routes, ensure Redux chapter context matches URL chapter without clobbering in-chapter scroll progress.
+  useEffect(() => {
+    if (!hasChapterIdInRoute || !urlChapterId || !chaptersData) {
+      return;
+    }
+
+    const expectedVerseKey = `${urlChapterId}:${normalizedStartingVerse}`;
+    const chapterFromVerseKey = lastReadVerse?.verseKey?.split(':')?.[0];
+    const currentReduxChapterId = lastReadVerse?.chapterId || chapterFromVerseKey;
+    const isAlreadyAligned = currentReduxChapterId === urlChapterId;
+
+    if (isAlreadyAligned) {
+      return;
+    }
+
+    const shouldPreserveCurrentVerseKey = chapterFromVerseKey === urlChapterId;
+
+    dispatch(
+      setLastReadVerse({
+        lastReadVerse: {
+          verseKey: shouldPreserveCurrentVerseKey ? lastReadVerse.verseKey : expectedVerseKey,
+          chapterId: urlChapterId,
+          page: String(firstVerse?.pageNumber ?? lastReadVerse?.page ?? ''),
+          hizb: String(firstVerse?.hizbNumber ?? lastReadVerse?.hizb ?? ''),
+        },
+        chaptersData,
+      }),
+    );
+  }, [
+    chaptersData,
+    dispatch,
+    firstVerse?.hizbNumber,
+    firstVerse?.pageNumber,
+    hasChapterIdInRoute,
+    lastReadVerse?.chapterId,
+    lastReadVerse?.hizb,
+    lastReadVerse?.page,
+    lastReadVerse?.verseKey,
+    normalizedStartingVerse,
+    urlChapterId,
+  ]);
 };
 
 export default useSyncChapterPage;

--- a/src/components/QuranReader/hooks/useSyncChapterPage.ts
+++ b/src/components/QuranReader/hooks/useSyncChapterPage.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
@@ -13,6 +13,11 @@ import {
 } from '@/redux/slices/QuranReader/readingTracker';
 import { normalizeQueryParam } from '@/utils/url';
 import { VersesResponse } from 'types/ApiResponses';
+
+const getNormalizedStartingVerse = (startingVerse: string | string[]): number => {
+  const parsedStartingVerse = Number(normalizeQueryParam(startingVerse));
+  return Number.isNaN(parsedStartingVerse) || parsedStartingVerse < 1 ? 1 : parsedStartingVerse;
+};
 
 /**
  * A hook that sets the initial page state when navigating to any content type
@@ -46,17 +51,7 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
   const firstVerse = initialData?.verses?.[0];
   // Use verseKey as the dependency to detect navigation changes
   const firstVerseKey = firstVerse?.verseKey;
-
-  // If a startingVerse query param is present, use it to determine the verse to sync to.
-  const normalizedStartingVerse = useMemo(() => {
-    const parsedStartingVerse = Number(normalizeQueryParam(router.query.startingVerse));
-
-    if (Number.isNaN(parsedStartingVerse) || parsedStartingVerse < 1) {
-      return 1;
-    }
-
-    return parsedStartingVerse;
-  }, [router.query.startingVerse]);
+  const normalizedStartingVerse = getNormalizedStartingVerse(router.query.startingVerse);
 
   useBrowserLayoutEffect(() => {
     if (!firstVerse) return;
@@ -82,10 +77,7 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
 
     const expectedVerseKey = `${urlChapterId}:${normalizedStartingVerse}`;
     const chapterFromVerseKey = lastReadVerse?.verseKey?.split(':')?.[0];
-    const currentReduxChapterId = lastReadVerse?.chapterId || chapterFromVerseKey;
-    const isAlreadyAligned = currentReduxChapterId === urlChapterId;
-
-    if (isAlreadyAligned) {
+    if ((lastReadVerse?.chapterId || chapterFromVerseKey) === urlChapterId) {
       return;
     }
 

--- a/src/components/QuranReader/hooks/useSyncChapterPage.ts
+++ b/src/components/QuranReader/hooks/useSyncChapterPage.ts
@@ -11,6 +11,7 @@ import {
   selectLastReadVerseKey,
   setLastReadVerse,
 } from '@/redux/slices/QuranReader/readingTracker';
+import { normalizeQueryParam } from '@/utils/url';
 import { VersesResponse } from 'types/ApiResponses';
 
 /**
@@ -38,9 +39,9 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
   const { lang } = useTranslation('common');
   const chaptersData = useContext(DataContext);
   const lastReadVerse = useSelector(selectLastReadVerseKey, shallowEqual);
-  const chapterIdsByUrlPath = useChapterIdsByUrlPath(lang);
-  const urlChapterId = chapterIdsByUrlPath?.[0];
   const hasChapterIdInRoute = Boolean(router.query.chapterId);
+  const chapterIdsByUrlPath = useChapterIdsByUrlPath(lang);
+  const urlChapterId = hasChapterIdInRoute ? chapterIdsByUrlPath?.[0] : undefined;
 
   const firstVerse = initialData?.verses?.[0];
   // Use verseKey as the dependency to detect navigation changes
@@ -48,9 +49,7 @@ const useSyncChapterPage = (initialData: VersesResponse): void => {
 
   // If a startingVerse query param is present, use it to determine the verse to sync to.
   const normalizedStartingVerse = useMemo(() => {
-    const rawStartingVerse = router.query.startingVerse;
-    const startingVerse = Array.isArray(rawStartingVerse) ? rawStartingVerse[0] : rawStartingVerse;
-    const parsedStartingVerse = Number(startingVerse);
+    const parsedStartingVerse = Number(normalizeQueryParam(router.query.startingVerse));
 
     if (Number.isNaN(parsedStartingVerse) || parsedStartingVerse < 1) {
       return 1;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -23,6 +23,17 @@ export const getWindowOrigin = (locale: string) => {
   return '';
 };
 
+export type QueryParamValue = string | string[] | undefined;
+
+/**
+ * Normalize a query parameter to a single string value.
+ *
+ * @param {QueryParamValue} param
+ * @returns {string | undefined}
+ */
+export const normalizeQueryParam = (param: QueryParamValue): string | undefined =>
+  Array.isArray(param) ? param[0] : param;
+
 /**
  * Navigate programmatically to an external url. we will try to open
  * the url in a new tab and if it doesn't work due to pop-ups being blocked,

--- a/tests/integration/url/path.spec.ts
+++ b/tests/integration/url/path.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 import Homepage from '@/tests/POM/home-page';
+import { TestId } from '@/tests/test-ids';
 
 let homePage: Homepage;
 
@@ -15,6 +16,18 @@ test('Page /S should load Surah S', { tag: ['@url', '@smoke'] }, async ({ page }
   await expect(page.getByText('Al-Qiyamah').first()).toBeVisible();
   expect(await page.title()).toContain('Al-Qiyamah');
 });
+
+test(
+  'Page /S route change should update chapter navigation label',
+  { tag: ['@url', '@reader', '@header'] },
+  async ({ page }) => {
+    await homePage.goTo('/1');
+    await expect(page.getByTestId(TestId.CHAPTER_NAVIGATION)).toContainText('1. Al-Fatihah');
+
+    await page.goto('/16');
+    await expect(page.getByTestId(TestId.CHAPTER_NAVIGATION)).toContainText('16. An-Nahl');
+  },
+);
 
 test(
   'Page /S/V should load Ayah V of Surah S',

--- a/tests/integration/url/path.spec.ts
+++ b/tests/integration/url/path.spec.ts
@@ -18,14 +18,18 @@ test('Page /S should load Surah S', { tag: ['@url', '@smoke'] }, async ({ page }
 });
 
 test(
-  'Page /S route change should update chapter navigation label',
+  'Page /78 should show correct chapter label and header metadata',
   { tag: ['@url', '@reader', '@header'] },
-  async ({ page }) => {
-    await homePage.goTo('/1');
-    await expect(page.getByTestId(TestId.CHAPTER_NAVIGATION)).toContainText('1. Al-Fatihah');
+  async ({ page, isMobile }) => {
+    test.skip(isMobile);
 
-    await page.goto('/16');
-    await expect(page.getByTestId(TestId.CHAPTER_NAVIGATION)).toContainText('16. An-Nahl');
+    await homePage.goTo('/78');
+    await expect(page.getByTestId(TestId.CHAPTER_NAVIGATION)).toContainText('78. An-Naba');
+
+    const pageInfo = page.getByTestId(TestId.PAGE_INFO);
+    await expect(pageInfo).toContainText('Page 582');
+    await expect(pageInfo).toContainText('Juz 30');
+    await expect(pageInfo).toContainText('Hizb 59');
   },
 );
 


### PR DESCRIPTION
## Summary

Fixes an issue when directly navigating to a `/S` page from the browser address bar (i.e. without using the site's internal routing).

Previously, the header could display incorrect surah metadata (wrong page, juz, and hizb).

Closes: [QF-4516](https://quranfoundation.atlassian.net/browse/QF-4516)

## Type of Change

- [X] 🐛 Bug fix (non-breaking change)

## Scope Confirmation

- [X] This PR addresses **one** fix only  
- [ ] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [X] Can be safely reverted without data issues or migrations  
- [ ] Rollback requires special steps

## Test Plan

- [ ] Unit tests added/updated  
- [X] Integration tests added/updated  
- [X] Manual testing performed  

### Testing steps

**Direct navigation**
1. Go to `/78`  
2. Verify the header displays the correct information (Surah An-Naba, Juz 30, Hizb 59)

**Internal routing**
1. Use the site router to navigate to Surah Sad  
2. Verify the header information is correct

**Starting verse**
1. Verify that `startingVerse` is still correct

I've also verified the navigaiton drawer behavior, and the direct navigation to page with starting verse like `/80?startingVerse=20`

### Edge Cases Verified

- [ ] ⏳ Loading state handled  
- [ ] ❌ Error state handled  
- [ ] 📭 Empty state handled  
- [ ] 👤 Logged-in vs guest behavior  

## Code Quality

- [X] Self-review completed (file by file)  
- [X] Follows project style guidelines  
- [X] No `any` types used (or justified if unavoidable)  
- [X] No unused code, imports, or dead code  
- [X] Inline comments explain complex logic (“why”)  
- [X] Functions under 30 lines and single-responsibility  

## Testing & Validation

- [X] All tests pass locally (`yarn test`)  
- [X] Linting passes (`yarn lint`)  
- [ ] Build succeeds (`yarn build`)  
- [ ] Edge cases and error scenarios handled  

## Screenshots / Videos


https://github.com/user-attachments/assets/6d0a58ac-f1ca-4e77-9eeb-a7ceaf8cd264

## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR  
- [X] AI tools were used, and I have **thoroughly reviewed and validated** all generated code  

[QF-4516]: https://quranfoundation.atlassian.net/browse/QF-4516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ