### PR TITLE
fix(QF-4707): migrate default quranTextFontScale from 3 to 4

### DIFF
--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -8,13 +8,11 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 import getStore from './store';
 
-import { logErrorToSentry } from '@/lib/sentry';
 import resetSettings from '@/redux/actions/reset-settings';
 import syncLocaleDependentSettings from '@/redux/actions/sync-locale-dependent-settings';
 import syncUserPreferences from '@/redux/actions/sync-user-preferences';
-import { needsFontScaleRemap, remapFontScale } from '@/redux/migration-scripts/remap-font-scale';
-import { getMushafId } from '@/utils/api';
-import { addOrUpdateUserPreference, getUserPreferences } from '@/utils/auth/api';
+import remapRemoteFontScale from '@/redux/migration-scripts/migrate-remote-font-scale';
+import { getUserPreferences } from '@/utils/auth/api';
 import { isLoggedIn } from '@/utils/auth/login';
 import { setLocaleCookie } from '@/utils/cookies';
 import isClient from '@/utils/isClient';
@@ -104,38 +102,11 @@ const ReduxProvider = ({ children, locale }) => {
         }
         const localeForDefaults = remoteLang || initialLocaleRef.current;
 
-        // Remap stale font scale in remote preferences BEFORE syncing to Redux.
-        // Must happen pre-dispatch so the corrected value flows through once;
-        // a remap inside the reducer would cascade on subsequent syncs (7→9→10).
+        // Remap stale font scale + migrate default scale (3→4) in remote preferences
+        // BEFORE syncing to Redux. Mutates remoteStyles.quranTextFontScale in place.
         const remoteStyles = userPreferences[PreferenceGroup.QURAN_READER_STYLES];
-        if (remoteStyles?.quranTextFontScale != null && !remoteStyles.fontScaleRemapVersion) {
-          const effectiveFont =
-            remoteStyles.quranFont ?? store.getState().quranReaderStyles.quranFont;
-          if (needsFontScaleRemap(effectiveFont, remoteStyles.quranTextFontScale)) {
-            const correctedScale = remapFontScale(effectiveFont, remoteStyles.quranTextFontScale);
-            remoteStyles.quranTextFontScale = correctedScale;
-            const { mushaf } = getMushafId(
-              effectiveFont,
-              remoteStyles.mushafLines ?? store.getState().quranReaderStyles.mushafLines,
-            );
-            // Write corrected scale, then persist marker only after scale succeeds
-            addOrUpdateUserPreference(
-              'quranTextFontScale',
-              correctedScale,
-              PreferenceGroup.QURAN_READER_STYLES,
-              mushaf,
-            )
-              .then(() =>
-                addOrUpdateUserPreference(
-                  'fontScaleRemapVersion',
-                  1,
-                  PreferenceGroup.QURAN_READER_STYLES,
-                  mushaf,
-                ),
-              )
-              .catch((err) => logErrorToSentry(err, { transactionName: 'fontScaleRemap' }));
-          }
-        }
+        const { quranReaderStyles: localStyles } = store.getState();
+        remapRemoteFontScale(remoteStyles, localStyles.quranFont, localStyles.mushafLines);
 
         store.dispatch(syncUserPreferences(userPreferences, localeForDefaults));
 

--- a/src/redux/defaultSettings/defaultSettings.ts
+++ b/src/redux/defaultSettings/defaultSettings.ts
@@ -56,7 +56,7 @@ const QURAN_READER_STYLES_INITIAL_STATE: QuranReaderStyles = {
   tafsirFontScale: 3,
   reflectionFontScale: 3,
   lessonFontScale: 3,
-  quranTextFontScale: 3,
+  quranTextFontScale: 4,
   translationFontScale: 3,
   wordByWordFontScale: 3,
   qnaFontScale: 3,

--- a/src/redux/migration-scripts/migrate-default-scale.test.ts
+++ b/src/redux/migration-scripts/migrate-default-scale.test.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable react-func/max-lines-per-function */
+import { describe, it, expect } from 'vitest';
+
+import { migrateDefaultScale, needsDefaultScaleMigration } from './migrate-default-scale';
+
+import { QuranFont } from '@/types/QuranReader';
+
+const AFFECTED_FONTS = [
+  QuranFont.QPCHafs,
+  QuranFont.MadaniV1,
+  QuranFont.MadaniV2,
+  QuranFont.TajweedV4,
+  QuranFont.IndoPak,
+];
+
+const UNAFFECTED_FONTS = [QuranFont.Uthmani, QuranFont.Tajweed];
+
+describe('migrate-default-scale', () => {
+  describe('migrateDefaultScale', () => {
+    it.each(AFFECTED_FONTS.map((font) => [font]))(
+      'remaps scale 3 → 4 for affected font %s',
+      (font) => {
+        expect(migrateDefaultScale(font as QuranFont, 3)).toBe(4);
+      },
+    );
+
+    it.each(
+      AFFECTED_FONTS.flatMap((font) => [1, 2, 4, 5, 6, 7, 8, 9, 10].map((scale) => [font, scale])),
+    )('returns scale unchanged for affected font %s at scale %d', (font, scale) => {
+      expect(migrateDefaultScale(font as QuranFont, scale as number)).toBe(scale);
+    });
+
+    it.each(
+      UNAFFECTED_FONTS.flatMap((font) =>
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((scale) => [font, scale]),
+      ),
+    )('returns scale unchanged for unaffected font %s at scale %d', (font, scale) => {
+      expect(migrateDefaultScale(font as QuranFont, scale as number)).toBe(scale);
+    });
+  });
+
+  describe('needsDefaultScaleMigration', () => {
+    it.each(AFFECTED_FONTS.map((font) => [font]))(
+      'returns true for affected font %s at scale 3',
+      (font) => {
+        expect(needsDefaultScaleMigration(font as QuranFont, 3)).toBe(true);
+      },
+    );
+
+    it.each(
+      AFFECTED_FONTS.flatMap((font) => [1, 2, 4, 5, 6, 7, 8, 9, 10].map((scale) => [font, scale])),
+    )('returns false for affected font %s at scale %d', (font, scale) => {
+      expect(needsDefaultScaleMigration(font as QuranFont, scale as number)).toBe(false);
+    });
+
+    it.each(
+      UNAFFECTED_FONTS.flatMap((font) =>
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((scale) => [font, scale]),
+      ),
+    )('returns false for unaffected font %s at scale %d', (font, scale) => {
+      expect(needsDefaultScaleMigration(font as QuranFont, scale as number)).toBe(false);
+    });
+  });
+});

--- a/src/redux/migration-scripts/migrate-default-scale.ts
+++ b/src/redux/migration-scripts/migrate-default-scale.ts
@@ -1,0 +1,22 @@
+import { QuranFont } from 'types/QuranReader';
+
+/**
+ * Migrate default quranTextFontScale from 3 → 4 for the five Quran fonts
+ * that were previously defaulting to scale 3.
+ */
+
+const AFFECTED_FONTS = new Set([
+  QuranFont.QPCHafs,
+  QuranFont.MadaniV1,
+  QuranFont.MadaniV2,
+  QuranFont.TajweedV4,
+  QuranFont.IndoPak,
+]);
+
+export const migrateDefaultScale = (quranFont: QuranFont, scale: number): number => {
+  if (AFFECTED_FONTS.has(quranFont) && scale === 3) return 4;
+  return scale;
+};
+
+export const needsDefaultScaleMigration = (quranFont: QuranFont, scale: number): boolean =>
+  migrateDefaultScale(quranFont, scale) !== scale;

--- a/src/redux/migration-scripts/migrate-remote-font-scale.ts
+++ b/src/redux/migration-scripts/migrate-remote-font-scale.ts
@@ -24,13 +24,13 @@ const persistDefaultScaleMigration = (
 ) => {
   addOrUpdateUserPreference('quranTextFontScale', newScale, STYLES, mushaf)
     .then(() =>
-      Promise.all([
-        addOrUpdateUserPreference('defaultScaleMigrated', 1, STYLES, mushaf),
-        !hasRemapVersion
-          ? addOrUpdateUserPreference('fontScaleRemapVersion', 1, STYLES, mushaf)
-          : Promise.resolve(),
-      ]),
+      // Write fontScaleRemapVersion first to prevent the old remap from cascading 4→7
+      // if defaultScaleMigrated were to succeed alone in a partial-failure scenario.
+      !hasRemapVersion
+        ? addOrUpdateUserPreference('fontScaleRemapVersion', 1, STYLES, mushaf)
+        : Promise.resolve(),
     )
+    .then(() => addOrUpdateUserPreference('defaultScaleMigrated', 1, STYLES, mushaf))
     .catch((err) => logErrorToSentry(err, { transactionName: 'defaultScaleMigration' }));
 };
 

--- a/src/redux/migration-scripts/migrate-remote-font-scale.ts
+++ b/src/redux/migration-scripts/migrate-remote-font-scale.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-param-reassign */
+import { logErrorToSentry } from '@/lib/sentry';
+import {
+  needsDefaultScaleMigration,
+  migrateDefaultScale,
+} from '@/redux/migration-scripts/migrate-default-scale';
+import { needsFontScaleRemap, remapFontScale } from '@/redux/migration-scripts/remap-font-scale';
+import { getMushafId } from '@/utils/api';
+import { addOrUpdateUserPreference } from '@/utils/auth/api';
+import PreferenceGroup from 'types/auth/PreferenceGroup';
+
+const STYLES = PreferenceGroup.QURAN_READER_STYLES;
+
+const persistScaleRemap = (correctedScale: number, mushaf: string) => {
+  addOrUpdateUserPreference('quranTextFontScale', correctedScale, STYLES, mushaf)
+    .then(() => addOrUpdateUserPreference('fontScaleRemapVersion', 1, STYLES, mushaf))
+    .catch((err) => logErrorToSentry(err, { transactionName: 'fontScaleRemap' }));
+};
+
+const persistDefaultScaleMigration = (
+  newScale: number,
+  mushaf: string,
+  hasRemapVersion: boolean,
+) => {
+  addOrUpdateUserPreference('quranTextFontScale', newScale, STYLES, mushaf)
+    .then(() =>
+      Promise.all([
+        addOrUpdateUserPreference('defaultScaleMigrated', 1, STYLES, mushaf),
+        !hasRemapVersion
+          ? addOrUpdateUserPreference('fontScaleRemapVersion', 1, STYLES, mushaf)
+          : Promise.resolve(),
+      ]),
+    )
+    .catch((err) => logErrorToSentry(err, { transactionName: 'defaultScaleMigration' }));
+};
+
+/**
+ * Remap stale font scale + migrate default scale (3→4) in remote preferences
+ * BEFORE syncing to Redux. Mutates remoteStyles.quranTextFontScale in place.
+ */
+const remapRemoteFontScale = (
+  remoteStyles: Record<string, any>,
+  localQuranFont: string,
+  localMushafLines: string,
+) => {
+  if (remoteStyles?.quranTextFontScale == null) return;
+
+  const effectiveFont = remoteStyles.quranFont ?? localQuranFont;
+  const mushafLines = remoteStyles.mushafLines ?? localMushafLines;
+
+  if (!remoteStyles.fontScaleRemapVersion) {
+    if (needsFontScaleRemap(effectiveFont, remoteStyles.quranTextFontScale)) {
+      const correctedScale = remapFontScale(effectiveFont, remoteStyles.quranTextFontScale);
+      remoteStyles.quranTextFontScale = correctedScale;
+      const { mushaf } = getMushafId(effectiveFont, mushafLines);
+      persistScaleRemap(correctedScale, mushaf);
+    }
+  }
+
+  if (!remoteStyles.defaultScaleMigrated) {
+    if (needsDefaultScaleMigration(effectiveFont, remoteStyles.quranTextFontScale)) {
+      const newScale = migrateDefaultScale(effectiveFont, remoteStyles.quranTextFontScale);
+      remoteStyles.quranTextFontScale = newScale;
+      const { mushaf } = getMushafId(effectiveFont, mushafLines);
+      persistDefaultScaleMigration(newScale, mushaf, !!remoteStyles.fontScaleRemapVersion);
+    }
+  }
+};
+
+export default remapRemoteFontScale;

--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import initialState, { DEFAULT_TAFSIRS } from './defaultSettings/defaultSettings';
+import { migrateDefaultScale } from './migration-scripts/migrate-default-scale';
 import { migrateRecentReadingSessions } from './migration-scripts/migrating-recent-reading-sessions';
 import { remapFontScale } from './migration-scripts/remap-font-scale';
 import { initialSidebarIsVisible } from './slices/QuranReader/sidebarNavigation';
@@ -369,6 +370,16 @@ export default {
     quranReaderStyles: {
       ...state.quranReaderStyles,
       quranTextFontScale: remapFontScale(
+        state.quranReaderStyles.quranFont,
+        state.quranReaderStyles.quranTextFontScale,
+      ),
+    },
+  }),
+  47: (state) => ({
+    ...state,
+    quranReaderStyles: {
+      ...state.quranReaderStyles,
+      quranTextFontScale: migrateDefaultScale(
         state.quranReaderStyles.quranFont,
         state.quranReaderStyles.quranTextFontScale,
       ),

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -53,7 +53,7 @@ import getPersistedTheme from './utils/getPersistedTheme';
 
 const persistConfig = {
   key: 'root',
-  version: 46,
+  version: 47,
   storage,
   migrate: createMigrate(migrations, {
     debug: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development',


### PR DESCRIPTION
## Summary

Closes: [QF-4707](https://quranfoundation.atlassian.net/browse/QF-4707)

- Changes default `quranTextFontScale` from 3 to 4 for the five Quran fonts (QPCHafs, MadaniV1, MadaniV2, TajweedV4, IndoPak)
- Adds Redux migration slot 47 for offline/guest users
- Adds runtime migration in Provider.tsx for logged-in users with remote preferences, with `defaultScaleMigrated` marker to prevent re-migration and `fontScaleRemapVersion=1` to prevent the old remap from cascading 4→7

## Cascade prevention

When the new default-scale migration writes scale 4, it also writes `fontScaleRemapVersion: 1` (if missing) to prevent the existing remap from picking up 4 as input (4→7 in Group1 fonts).

## Test plan

- [x] `npx vitest run src/redux/migration-scripts/migrate-default-scale.test.ts` — 140 tests pass
- [x] `npx vitest run src/redux/migration-scripts/remap-font-scale.test.ts` — 95 tests pass (no regression)
- [x] `npx vitest run src/redux/migrations.test.ts` — 17 tests pass
- [x] Manual: new user gets scale 4
- [x] Manual: existing QPCHafs user at scale 3 → migrated to 4 on reload, stays 4 on subsequent reloads
- [x] Manual: existing Uthmani user at scale 3 → stays at 3

[QF-4707]: https://quranfoundation.atlassian.net/browse/QF-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ