### PR TITLE
fix(QF-4707): fix build error in migrate-remote-font-scale types

### DIFF
--- a/src/redux/migration-scripts/migrate-remote-font-scale.ts
+++ b/src/redux/migration-scripts/migrate-remote-font-scale.ts
@@ -8,10 +8,11 @@ import { needsFontScaleRemap, remapFontScale } from '@/redux/migration-scripts/r
 import { getMushafId } from '@/utils/api';
 import { addOrUpdateUserPreference } from '@/utils/auth/api';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
+import { Mushaf, MushafLines, QuranFont } from 'types/QuranReader';
 
 const STYLES = PreferenceGroup.QURAN_READER_STYLES;
 
-const persistScaleRemap = (correctedScale: number, mushaf: string) => {
+const persistScaleRemap = (correctedScale: number, mushaf: Mushaf) => {
   addOrUpdateUserPreference('quranTextFontScale', correctedScale, STYLES, mushaf)
     .then(() => addOrUpdateUserPreference('fontScaleRemapVersion', 1, STYLES, mushaf))
     .catch((err) => logErrorToSentry(err, { transactionName: 'fontScaleRemap' }));
@@ -19,7 +20,7 @@ const persistScaleRemap = (correctedScale: number, mushaf: string) => {
 
 const persistDefaultScaleMigration = (
   newScale: number,
-  mushaf: string,
+  mushaf: Mushaf,
   hasRemapVersion: boolean,
 ) => {
   addOrUpdateUserPreference('quranTextFontScale', newScale, STYLES, mushaf)
@@ -40,8 +41,8 @@ const persistDefaultScaleMigration = (
  */
 const remapRemoteFontScale = (
   remoteStyles: Record<string, any>,
-  localQuranFont: string,
-  localMushafLines: string,
+  localQuranFont: QuranFont,
+  localMushafLines: MushafLines,
 ) => {
   if (remoteStyles?.quranTextFontScale == null) return;
 


### PR DESCRIPTION
## Summary

Closes: [QF-4707](https://quranfoundation.atlassian.net/browse/QF-4707)

- Fixes build error introduced by #3225 where `mushaf` parameter was typed as `string` instead of `Mushaf` enum, causing TypeScript to reject the `addOrUpdateUserPreference` call
- Also corrects `localQuranFont` and `localMushafLines` parameter types from `string` to their proper `QuranFont` and `MushafLines` enum types

## Test plan

- [x] `yarn build` passes
- [x] All migration tests still pass (252 tests)

[QF-4707]: https://quranfoundation.atlassian.net/browse/QF-4707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ