### PR TITLE
[QF-4832] - Ensures the ayah is always peeking at the top of the study modal

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBody.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeBody.module.scss
@@ -35,6 +35,7 @@
 .tabContentContainer {
   display: block;
   overflow: visible;
+  min-block-size: clamp(460px, 75dvh, 760px);
 }
 
 // Gradient fade overlay above bottom actions


### PR DESCRIPTION
## Summary

Ensures the ayah is always peeking at the top of the study modal, regardless of the content length.

This PR is minimal and only adds a single SCSS line to fix the layout behavior.

Closes: [QF-4832](https://quranfoundation.atlassian.net/browse/QF-4832)

## Type of Change

- [X] 🐛 Bug fix (non-breaking change)

## Test Plan

- [ ] Unit tests added/updated  
- [ ] Integration tests added/updated  
- [X] Manual testing performed  

### Testing steps

1. Tested on desktop  
2. Tested on mobile view  

⚠️ Note: Direct navigation to the study modal via  `/8:9/tafsirs/en-tafsir-ibn-kathir`  does not trigger the scroll behavior in production (even when the content is long enough). This behavior remains unchanged.

## Screenshots / Videos

https://github.com/user-attachments/assets/a4f989f0-ae6e-44bf-9aec-a62e82c3efad

[QF-4832]: https://quranfoundation.atlassian.net/browse/QF-4832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ