### PR TITLE
[QF-4833] - Set global max content width to 1230px and study modal to 1310px

### DIFF
--- a/src/components/QuranReader/EndOfScrollingControls/EndOfScrollingControls.module.scss
+++ b/src/components/QuranReader/EndOfScrollingControls/EndOfScrollingControls.module.scss
@@ -33,7 +33,7 @@
   margin-inline: auto;
   max-inline-size: 100%;
   @include breakpoints.tablet {
-    max-inline-size: 80%;
+    max-inline-size: min(80%, 1230px);
   }
 }
 

--- a/src/components/QuranReader/QuranReader.module.scss
+++ b/src/components/QuranReader/QuranReader.module.scss
@@ -26,7 +26,7 @@ $virtual-scrolling-height-bandage: calc(
 
 .loading {
   text-align: center;
-  max-inline-size: 80%;
+  max-inline-size: min(80%, 1230px);
   margin-block-start: var(--spacing-medium);
   margin-block-end: var(--spacing-medium);
   margin-inline-start: auto;

--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeModal.module.scss
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeModal.module.scss
@@ -22,7 +22,7 @@ div.contentModal {
     padding-block-end: var(--spacing-medium2-px);
     max-block-size: 85vh;
     inline-size: 80%;
-    max-inline-size: 80%;
+    max-inline-size: 1310px;
     border-radius: var(--border-radius-large-px);
   }
 }

--- a/src/components/QuranReader/RevelationOrderNavigationNotice.module.scss
+++ b/src/components/QuranReader/RevelationOrderNavigationNotice.module.scss
@@ -13,7 +13,7 @@
   // Matches the Quran Reader's container width
   max-inline-size: 100%;
   @include breakpoints.tablet {
-    max-inline-size: 80%;
+    max-inline-size: min(80%, 1230px);
   }
 
   margin: var(--spacing-medium) auto;

--- a/src/components/QuranReader/TranslationView/TranslationView.module.scss
+++ b/src/components/QuranReader/TranslationView/TranslationView.module.scss
@@ -3,7 +3,7 @@
 .container {
   max-inline-size: 100%;
   @include breakpoints.tablet {
-    max-inline-size: 80%;
+    max-inline-size: min(80%, 1230px);
   }
   margin-inline-start: auto;
   margin-inline-end: auto;

--- a/src/styles/_utility.scss
+++ b/src/styles/_utility.scss
@@ -944,7 +944,7 @@ $page-container-max-width: 80rem;
 @mixin pageContainer {
   max-inline-size: $page-container-max-width;
   @include breakpoints.tablet {
-    max-inline-size: 80%;
+    max-inline-size: min(80%, 1230px);
   }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces a maximum content width of **1230px** across the website for pages that currently only use `max-inline-size: 80%` (without a fixed pixel cap).

The content continues to scale responsively, but stops growing once it reaches 1230px on large screens (e.g., 1920×1080).

The **Study Mode modal** keeps a separate max width of **1310px**.

Pages that already define their own max width (e.g., `/my-quran`, learning plans overview, etc.) are not affected.

Closes: [QF-4833](https://quranfoundation.atlassian.net/browse/QF-4833)

---

## Type of Change

* [x] ♻️ Refactoring (no functional changes)

---

## Scope Confirmation

* [x] This PR addresses **one** feature/fix only
* [ ] If multiple changes were needed, they are split into separate PRs

---

## Rollback Safety

* [x] Can be safely reverted without data issues or migrations
* [ ] Rollback requires special steps (describe below):

---

## Test Plan

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [x] Manual testing performed

### Pages Tested

* **Homepage**
* **Reader page**
  * Translation mode (juz, hizb, page)
  * With and without navigation drawer opened
  * Mushaf mode (juz, hizb, page)
  * All mushaf fonts (Indopak, Tajweed, QPC v1 & v2, etc.)
  * All Arabic font sizes (mushaf mode) and translation font sizes
    > Note: In mushaf mode, very large Arabic font sizes may cause the mushaf content to visually exceed 1230px due to scaling behavior.

* **Study modal** (translation and mushaf modes)
* `/reading-goal/progress`
* `/take-notes`
* `/about-the-quran`
* `/media`
* `/profile`

### Width-Specific Verifications

* Confirmed `/my-quran` retains its own max width.
* Confirmed `/learning-plans` retains its own max width.
* Verified a learning plan lesson page uses the new 1230px cap:
  * `/learning-plans/small-consistent-actions-path-to-paradise`
* Verified `/ramadan2026`
* Verified reading page loading skeleton
* Verified share, note, and bookmark modals

### Responsive Testing
* Verified mobile view — no layout regressions observed.

---

### Edge Cases Verified

* [x] ⏳ Loading state handled
* [ ] ❌ Error state handled
* [ ] 📭 Empty state handled
* [x] 👤 Logged-in vs guest behavior (if applicable)

---

### Code Quality

* [x] Self-review completed (file by file)
* [x] Follows project style guidelines
* [x] No `any` types used (or justified if unavoidable)
* [x] No unused code or dead imports
* [x] Complex logic documented inline where necessary
* [x] Functions remain under 30 lines and follow single responsibility

---

### Testing & Validation

* [x] All tests pass locally (`yarn test`)
* [x] Linting passes (`yarn lint`)
* [ ] Build succeeds (`yarn build`)
* [ ] Edge cases and error scenarios are handled

---

## Screenshots/Videos

| Before                                                                                                                               | After                                                                                                                                |
| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
| <img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/7547f02b-ef8f-4121-88ae-a22406cbb411" /> | <img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/09154685-f639-481c-b98d-60059128948f" /> |

---

## AI Assistance Disclosure

* [ ] AI tools were NOT used for this PR
* [x] AI tools were used, and I have thoroughly reviewed and validated all generated code


[QF-4833]: https://quranfoundation.atlassian.net/browse/QF-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ