### PR TITLE
Revert "sentry,replay: disable prod replay-on-error sampling (#3199)"

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -27,7 +27,7 @@ Sentry.init({
   dsn: SENTRY_ENABLED ? SENTRY_DSN : null,
   debug: isDev,
   tracesSampleRate: isDev ? 1 : 0.1,
-  replaysOnErrorSampleRate: isDev ? 1 : 0,
+  replaysOnErrorSampleRate: isDev ? 1 : 0.1,
   // Session replays sample rate - only capture dev sessions
   replaysSessionSampleRate: isDev ? 1.0 : 0,
   release: version,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -27,7 +27,7 @@ Sentry.init({
   dsn: SENTRY_ENABLED ? SENTRY_DSN : null,
   debug: isDev,
   tracesSampleRate: isDev ? 1 : 0.1,
-  replaysOnErrorSampleRate: isDev ? 1 : 0.1,
+  replaysOnErrorSampleRate: isDev ? 1 : 0.01,
   // Session replays sample rate - only capture dev sessions
   replaysSessionSampleRate: isDev ? 1.0 : 0,
   release: version,


### PR DESCRIPTION
This PR reverts #3199 and sets production `replaysOnErrorSampleRate` to `0.01`.