### PR TITLE
auth: call refresh endpoint via base fetcher

### DIFF
--- a/src/utils/auth/api.ts
+++ b/src/utils/auth/api.ts
@@ -252,8 +252,13 @@ export const getUserProfile = async (): Promise<UserProfile> =>
 export const getUserFeatureFlags = async (): Promise<Record<string, boolean>> =>
   privateFetcher(makeUserFeatureFlagsUrl());
 
-export const refreshToken = async (): Promise<RefreshToken> =>
-  privateFetcher(makeRefreshTokenUrl());
+export const refreshToken = async (): Promise<RefreshToken> => {
+  // IMPORTANT: do NOT use privateFetcher here, otherwise refresh-fetch will deadlock on the
+  // in-flight refresh promise (privateFetcher waits for itself).
+  const result = await withCredentialsFetcher<RefreshToken>(makeRefreshTokenUrl());
+  throwIfResponseContainsError(result, 'Token refresh failed');
+  return result;
+};
 
 // Track token refresh progress to allow UI / logic to defer actions while refreshing
 let tokenRefreshInProgress = false;


### PR DESCRIPTION
## Summary
- route refresh token calls through `withCredentialsFetcher` instead of `privateFetcher`
- avoid circular refresh flow where refresh-fetch can end up waiting on its own in-flight refresh
- document the deadlock risk inline in `refreshToken`

## Critical bug context
In `src/utils/auth/api.ts` the refresh endpoint used to be called like this:

```ts
export const refreshToken = async (): Promise<RefreshToken> =>
  privateFetcher(makeRefreshTokenUrl());
```

But `privateFetcher` is `configureRefreshFetch(...)`, and its `refreshToken:` callback is `refreshTokenWithFlag`, which calls `refreshToken()`.

This creates a circular wait:
- request fails and `privateFetcher` starts refresh (`refreshingTokenPromise`)
- during that refresh, it calls `refreshTokenWithFlag`
- `refreshTokenWithFlag` calls `refreshToken()`
- `refreshToken()` calls `privateFetcher(...)` again
- `privateFetcher` sees refresh in progress and waits for that same promise
- that promise cannot complete until `refreshToken()` returns

The refresh-token network call must not use the refresh-wrapped fetcher. It must use the underlying fetch function (`withCredentialsFetcher`).

Applied fix:

```ts
export const refreshToken = async (): Promise<RefreshToken> => {
  // IMPORTANT: do NOT use privateFetcher here, otherwise refresh-fetch will deadlock on the
  // in-flight refresh promise (privateFetcher waits for itself).
  const result = await withCredentialsFetcher<RefreshToken>(makeRefreshTokenUrl());
  throwIfResponseContainsError(result, 'Token refresh failed');
  return result;
};
```

## Why this matters
If backend returns any 401-ish expired condition, refresh can hang or fail repeatedly, surfacing as repeated "token expired" failures.

## Verification
- confirmed in committed code that `refreshToken` no longer uses `privateFetcher(makeRefreshTokenUrl())`
- `git grep` against committed `HEAD` returns no `privateFetcher(makeRefreshTokenUrl())`
- pre-commit checks passed during amend (ai link check + lint-staged)
