### PR TITLE
Fix Modals Closing Animation

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/index.tsx
@@ -506,7 +506,7 @@ const StudyModeModal: React.FC<Props> = ({
     </div>
   );
 
-  if (!isOpen || !chaptersData) return null;
+  if (!chaptersData) return null;
 
   const handleRetry = () => {
     logButtonClick('study_mode_retry', { verseKey });

--- a/src/components/QuranReader/StudyModeContainer.tsx
+++ b/src/components/QuranReader/StudyModeContainer.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import dynamic from 'next/dynamic';
 import { useDispatch, useSelector } from 'react-redux';
 
+import type { StudyModeTabId } from '@/components/QuranReader/ReadingView/StudyModeModal/StudyModeBottomActions';
 import { clearAllHighlights } from '@/redux/slices/QuranReader/readingViewVerse';
 import {
   closeStudyMode,
@@ -15,10 +16,16 @@ import {
 
 const StudyModeModal = dynamic(() => import('./ReadingView/StudyModeModal'), { ssr: false });
 
+type LastOpenState = {
+  verseKey: string | null;
+  activeTab: StudyModeTabId | null;
+  highlightedWordLocation: string | null;
+};
+
 /**
  * Global container for the Study Mode modal.
- * This component subscribes to the Redux studyMode state and renders
- * the modal when it's open. It handles closing the modal and resetting
+ * This component subscribes to the Redux studyMode state and keeps
+ * the modal mounted to allow close animations. It handles closing the modal and resetting
  * highlight state.
  *
  * Mount this component once in the QuranReaderView so the modal is
@@ -33,24 +40,49 @@ const StudyModeContainer: React.FC = () => {
   const verseKey = useSelector(selectStudyModeVerseKey);
   const activeTab = useSelector(selectStudyModeActiveTab);
   const highlightedWordLocation = useSelector(selectStudyModeHighlightedWordLocation);
+  const lastOpenStateRef = useRef<LastOpenState>({
+    verseKey: null,
+    activeTab: null,
+    highlightedWordLocation: null,
+  });
 
   const handleClose = useCallback(() => {
     dispatch(closeStudyMode());
     dispatch(clearAllHighlights());
   }, [dispatch]);
 
+  useEffect(() => {
+    if (isOpen && verseKey) {
+      lastOpenStateRef.current = {
+        verseKey,
+        activeTab,
+        highlightedWordLocation,
+      };
+    }
+  }, [isOpen, verseKey, activeTab, highlightedWordLocation]);
+
   // Don't render the client-side modal when in SSR mode (SSR container handles it)
-  if (!isOpen || !verseKey || isSsrMode) {
-    return null;
-  }
+  if (isSsrMode) return null;
+
+  const {
+    verseKey: lastVerseKey,
+    activeTab: lastActiveTab,
+    highlightedWordLocation: lastHighlight,
+  } = lastOpenStateRef.current;
+
+  const effectiveVerseKey = isOpen ? verseKey : lastVerseKey;
+  const effectiveActiveTab = isOpen ? activeTab : lastActiveTab;
+  const effectiveHighlightedWordLocation = isOpen ? highlightedWordLocation : lastHighlight;
+
+  if (!effectiveVerseKey) return null;
 
   return (
     <StudyModeModal
       isOpen={isOpen}
       onClose={handleClose}
-      verseKey={verseKey}
-      initialActiveTab={activeTab}
-      highlightedWordLocation={highlightedWordLocation ?? undefined}
+      verseKey={effectiveVerseKey}
+      initialActiveTab={effectiveActiveTab ?? undefined}
+      highlightedWordLocation={effectiveHighlightedWordLocation ?? undefined}
     />
   );
 };

--- a/src/components/QuranReader/VerseActionModalContainer/AdvancedCopyModal.tsx
+++ b/src/components/QuranReader/VerseActionModalContainer/AdvancedCopyModal.tsx
@@ -15,6 +15,7 @@ import ArrowIcon from '@/icons/arrow.svg';
 import Verse from '@/types/Verse';
 
 interface AdvancedCopyModalProps {
+  isOpen: boolean;
   verse: Verse;
   wasOpenedFromStudyMode: boolean;
   onClose: () => void;
@@ -22,6 +23,7 @@ interface AdvancedCopyModalProps {
 }
 
 const AdvancedCopyModal: React.FC<AdvancedCopyModalProps> = ({
+  isOpen,
   verse,
   wasOpenedFromStudyMode,
   onClose,
@@ -49,7 +51,7 @@ const AdvancedCopyModal: React.FC<AdvancedCopyModalProps> = ({
 
   return (
     <ContentModal
-      isOpen
+      isOpen={isOpen}
       header={header}
       hasCloseButton
       onClose={onClose}

--- a/src/components/QuranReader/VerseActionModalContainer/BookmarkModal.tsx
+++ b/src/components/QuranReader/VerseActionModalContainer/BookmarkModal.tsx
@@ -6,6 +6,7 @@ import SaveBookmarkModal, {
 import Verse from '@/types/Verse';
 
 interface BookmarkModalProps {
+  isOpen: boolean;
   verse: Verse;
   wasOpenedFromStudyMode: boolean;
   onClose: () => void;
@@ -13,13 +14,14 @@ interface BookmarkModalProps {
 }
 
 const BookmarkModal: React.FC<BookmarkModalProps> = ({
+  isOpen,
   verse,
   wasOpenedFromStudyMode,
   onClose,
   onBack,
 }) => (
   <SaveBookmarkModal
-    isOpen
+    isOpen={isOpen}
     type={SaveBookmarkType.AYAH}
     verse={verse}
     onClose={onClose}

--- a/src/components/QuranReader/VerseActionModalContainer/FeedbackModal.tsx
+++ b/src/components/QuranReader/VerseActionModalContainer/FeedbackModal.tsx
@@ -12,6 +12,7 @@ import IconContainer, { IconSize } from '@/dls/IconContainer/IconContainer';
 import ArrowIcon from '@/icons/arrow.svg';
 
 interface FeedbackModalProps {
+  isOpen: boolean;
   verseKey: string;
   wasOpenedFromStudyMode: boolean;
   onClose: () => void;
@@ -19,6 +20,7 @@ interface FeedbackModalProps {
 }
 
 const FeedbackModal: React.FC<FeedbackModalProps> = ({
+  isOpen,
   verseKey,
   wasOpenedFromStudyMode,
   onClose,
@@ -46,7 +48,7 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
 
   return (
     <ContentModal
-      isOpen
+      isOpen={isOpen}
       header={header}
       hasCloseButton
       onClose={onClose}

--- a/src/components/QuranReader/VerseActionModalContainer/NotesModals.tsx
+++ b/src/components/QuranReader/VerseActionModalContainer/NotesModals.tsx
@@ -7,6 +7,7 @@ import { VerseActionModalType as ModalType } from '@/redux/slices/QuranReader/ve
 import { Note } from '@/types/auth/Note';
 
 interface NotesModalsProps {
+  isOpen: boolean;
   modalType: ModalType;
   verseKey: string;
   notesCount: number;
@@ -22,6 +23,7 @@ interface NotesModalsProps {
 }
 
 const NotesModals: React.FC<NotesModalsProps> = ({
+  isOpen,
   modalType,
   verseKey,
   notesCount,
@@ -51,7 +53,7 @@ const NotesModals: React.FC<NotesModalsProps> = ({
   return (
     <>
       <AddNoteModal
-        isModalOpen={modalType === ModalType.ADD_NOTE}
+        isModalOpen={isOpen && modalType === ModalType.ADD_NOTE}
         onModalClose={onClose}
         onMyNotes={getOnMyNotesHandler()}
         notesCount={notesCount}
@@ -59,7 +61,7 @@ const NotesModals: React.FC<NotesModalsProps> = ({
         onBack={getBackHandler()}
       />
       <MyNotesModal
-        isOpen={modalType === ModalType.MY_NOTES}
+        isOpen={isOpen && modalType === ModalType.MY_NOTES}
         onClose={onClose}
         notesCount={notesCount}
         onAddNote={onOpenAddNote}
@@ -68,7 +70,7 @@ const NotesModals: React.FC<NotesModalsProps> = ({
       />
       <EditNoteModal
         note={editingNote}
-        isModalOpen={modalType === ModalType.EDIT_NOTE}
+        isModalOpen={isOpen && modalType === ModalType.EDIT_NOTE}
         onModalClose={onClose}
         onMyNotes={onOpenMyNotes}
         onBack={onOpenMyNotes}

--- a/src/components/QuranReader/VerseActionModalContainer/index.tsx
+++ b/src/components/QuranReader/VerseActionModalContainer/index.tsx
@@ -89,8 +89,6 @@ const VerseActionModalContainer: React.FC = () => {
     previousModalType: null,
   });
 
-  const lastNotesCountRef = useRef<number>(0);
-
   const { data: notesCount } = useBatchedCountRangeNotes(isOpen && verseKey ? verseKey : null);
 
   const getRestoredVerse = useCallback(
@@ -191,12 +189,6 @@ const VerseActionModalContainer: React.FC = () => {
     previousModalType,
   ]);
 
-  useEffect(() => {
-    if (isOpen && typeof notesCount === 'number') {
-      lastNotesCountRef.current = notesCount;
-    }
-  }, [isOpen, notesCount]);
-
   const handleBackToStudyMode = useCallback(() => {
     dispatch(closeVerseActionModal());
 
@@ -260,7 +252,6 @@ const VerseActionModalContainer: React.FC = () => {
 
   if (!effectiveState.verseKey || !effectiveState.modalType) return null;
 
-  const count = isOpen ? notesCount ?? lastNotesCountRef.current : lastNotesCountRef.current;
   const isNotesModal =
     effectiveState.modalType === VerseActionModalType.ADD_NOTE ||
     effectiveState.modalType === VerseActionModalType.MY_NOTES ||
@@ -272,7 +263,7 @@ const VerseActionModalContainer: React.FC = () => {
         isOpen={isOpen}
         modalType={effectiveState.modalType}
         verseKey={effectiveState.verseKey}
-        notesCount={count}
+        notesCount={notesCount}
         editingNote={effectiveState.editingNote}
         wasOpenedFromStudyMode={effectiveState.wasOpenedFromStudyMode}
         previousModalType={effectiveState.previousModalType}

--- a/src/components/QuranReader/VerseActionModalContainer/index.tsx
+++ b/src/components/QuranReader/VerseActionModalContainer/index.tsx
@@ -33,9 +33,13 @@ import {
   selectVerseActionModalWasOpenedFromStudyMode,
   setEditingNote,
   setModalType,
+  type StudyModeRestoreState,
   VerseActionModalType,
 } from '@/redux/slices/QuranReader/verseActionModal';
-import { Note } from '@/types/auth/Note';
+import type { Note } from '@/types/auth/Note';
+import Language from '@/types/Language';
+import type { QiraatReader } from '@/types/Qiraat';
+import type Verse from '@/types/Verse';
 import { logEvent } from '@/utils/eventLogger';
 import {
   consumePendingBookmarkModalRestore,
@@ -43,11 +47,22 @@ import {
 } from '@/utils/pendingBookmarkModalRestore';
 import { getVerseAndChapterNumbersFromKey } from '@/utils/verse';
 
+type LastOpenState = {
+  modalType: VerseActionModalType | null;
+  verseKey: string | null;
+  verse: Verse | null;
+  editingNote: Note | null;
+  isTranslationView: boolean;
+  wasOpenedFromStudyMode: boolean;
+  studyModeRestoreState: StudyModeRestoreState | null;
+  readerBioReader: QiraatReader | null;
+  previousModalType: VerseActionModalType | null;
+};
+
 const VerseActionModalContainer: React.FC = () => {
   const dispatch = useDispatch();
   const router = useRouter();
   const hasClosedStudyModeRef = useRef(false);
-  // Use a reactive source of truth so restores can happen even if auth state flips after mount.
   const { isLoggedIn: isUserLoggedIn } = useIsLoggedIn();
 
   const isOpen = useSelector(selectVerseActionModalIsOpen);
@@ -62,13 +77,27 @@ const VerseActionModalContainer: React.FC = () => {
   const previousModalType = useSelector(selectVerseActionModalPreviousModalType);
   const isStudyModeOpen = useSelector(selectStudyModeIsOpen);
 
+  const lastOpenStateRef = useRef<LastOpenState>({
+    modalType: null,
+    verseKey: null,
+    verse: null,
+    editingNote: null,
+    isTranslationView: false,
+    wasOpenedFromStudyMode: false,
+    studyModeRestoreState: null,
+    readerBioReader: null,
+    previousModalType: null,
+  });
+
+  const lastNotesCountRef = useRef<number>(0);
+
   const { data: notesCount } = useBatchedCountRangeNotes(isOpen && verseKey ? verseKey : null);
 
   const getRestoredVerse = useCallback(
     async (pendingVerseKey: string) => {
       try {
         const [chapterId, verseNumber] = getVerseAndChapterNumbersFromKey(pendingVerseKey);
-        const response = await getChapterVerses(chapterId, router.locale || 'en', {
+        const response = await getChapterVerses(chapterId, router.locale || Language.EN, {
           page: verseNumber,
           perPage: 1,
         });
@@ -133,6 +162,41 @@ const VerseActionModalContainer: React.FC = () => {
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen || !verseKey || !modalType) {
+      return;
+    }
+
+    lastOpenStateRef.current = {
+      modalType,
+      verseKey,
+      verse,
+      editingNote,
+      isTranslationView,
+      wasOpenedFromStudyMode,
+      studyModeRestoreState,
+      readerBioReader,
+      previousModalType,
+    };
+  }, [
+    isOpen,
+    modalType,
+    verseKey,
+    verse,
+    editingNote,
+    isTranslationView,
+    wasOpenedFromStudyMode,
+    studyModeRestoreState,
+    readerBioReader,
+    previousModalType,
+  ]);
+
+  useEffect(() => {
+    if (isOpen && typeof notesCount === 'number') {
+      lastNotesCountRef.current = notesCount;
+    }
+  }, [isOpen, notesCount]);
+
   const handleBackToStudyMode = useCallback(() => {
     dispatch(closeVerseActionModal());
 
@@ -180,25 +244,38 @@ const VerseActionModalContainer: React.FC = () => {
     handleClose();
   }, [isTranslationView, handleClose]);
 
-  if (!isOpen || !verseKey) {
-    return null;
-  }
+  const effectiveState: LastOpenState = isOpen
+    ? {
+        modalType,
+        verseKey,
+        verse,
+        editingNote,
+        isTranslationView,
+        wasOpenedFromStudyMode,
+        studyModeRestoreState,
+        readerBioReader,
+        previousModalType,
+      }
+    : lastOpenStateRef.current;
 
-  const count = notesCount ?? 0;
+  if (!effectiveState.verseKey || !effectiveState.modalType) return null;
+
+  const count = isOpen ? notesCount ?? lastNotesCountRef.current : lastNotesCountRef.current;
   const isNotesModal =
-    modalType === VerseActionModalType.ADD_NOTE ||
-    modalType === VerseActionModalType.MY_NOTES ||
-    modalType === VerseActionModalType.EDIT_NOTE;
+    effectiveState.modalType === VerseActionModalType.ADD_NOTE ||
+    effectiveState.modalType === VerseActionModalType.MY_NOTES ||
+    effectiveState.modalType === VerseActionModalType.EDIT_NOTE;
 
   if (isNotesModal) {
     return (
       <NotesModals
-        modalType={modalType}
-        verseKey={verseKey}
+        isOpen={isOpen}
+        modalType={effectiveState.modalType}
+        verseKey={effectiveState.verseKey}
         notesCount={count}
-        editingNote={editingNote}
-        wasOpenedFromStudyMode={wasOpenedFromStudyMode}
-        previousModalType={previousModalType}
+        editingNote={effectiveState.editingNote}
+        wasOpenedFromStudyMode={effectiveState.wasOpenedFromStudyMode}
+        previousModalType={effectiveState.previousModalType}
         onClose={handleClose}
         onBack={handleBackToStudyMode}
         onBackToBookmark={handleBackToBookmark}
@@ -212,47 +289,53 @@ const VerseActionModalContainer: React.FC = () => {
     );
   }
 
-  if (modalType === VerseActionModalType.TRANSLATION_FEEDBACK) {
+  if (effectiveState.modalType === VerseActionModalType.TRANSLATION_FEEDBACK) {
     return (
       <FeedbackModal
-        verseKey={verseKey}
-        wasOpenedFromStudyMode={wasOpenedFromStudyMode}
+        isOpen={isOpen}
+        verseKey={effectiveState.verseKey}
+        wasOpenedFromStudyMode={effectiveState.wasOpenedFromStudyMode}
         onClose={handleFeedbackClose}
         onBack={handleBackToStudyMode}
       />
     );
   }
 
-  if (modalType === VerseActionModalType.SAVE_BOOKMARK && verse) {
+  if (effectiveState.modalType === VerseActionModalType.SAVE_BOOKMARK && effectiveState.verse) {
     return (
       <BookmarkModal
-        verse={verse}
-        wasOpenedFromStudyMode={wasOpenedFromStudyMode}
+        isOpen={isOpen}
+        verse={effectiveState.verse}
+        wasOpenedFromStudyMode={effectiveState.wasOpenedFromStudyMode}
         onClose={handleClose}
         onBack={handleBackToStudyMode}
       />
     );
   }
 
-  if (modalType === VerseActionModalType.ADVANCED_COPY && verse) {
+  if (effectiveState.modalType === VerseActionModalType.ADVANCED_COPY && effectiveState.verse) {
     return (
       <AdvancedCopyModal
-        verse={verse}
-        wasOpenedFromStudyMode={wasOpenedFromStudyMode}
+        isOpen={isOpen}
+        verse={effectiveState.verse}
+        wasOpenedFromStudyMode={effectiveState.wasOpenedFromStudyMode}
         onClose={handleAdvancedCopyClose}
         onBack={handleBackToStudyMode}
       />
     );
   }
 
-  if (modalType === VerseActionModalType.READER_BIO && readerBioReader) {
+  if (
+    effectiveState.modalType === VerseActionModalType.READER_BIO &&
+    effectiveState.readerBioReader
+  ) {
     return (
       <ReaderBioModal
-        reader={readerBioReader}
+        reader={effectiveState.readerBioReader}
         isOpen={isOpen}
         onClose={handleClose}
         onBack={handleBackToStudyMode}
-        wasOpenedFromStudyMode={wasOpenedFromStudyMode}
+        wasOpenedFromStudyMode={effectiveState.wasOpenedFromStudyMode}
       />
     );
   }


### PR DESCRIPTION
## Summary

Fixed a bug where Study Mode and Verse Action modals would close instantly without playing their exit animations. The issue occurred because modals were being unmounted immediately when their `isOpen` state changed to `false`, cutting off any CSS animations.

**Changes:**
- Keep modals mounted with their last known state while playing close animations
- Preserve modal state (verse data, active tabs, editing notes) after close is triggered
- Pass `isOpen` prop down to all child modal components to control visibility

**Files modified:**
- `src/components/QuranReader/ReadingView/StudyModeModal/index.tsx` - Removed early return that unmounted modal
- `src/components/QuranReader/StudyModeContainer.tsx` - Added state preservation logic
- `src/components/QuranReader/VerseActionModalContainer/index.tsx` - Added state preservation for all action modals
- `src/components/QuranReader/VerseActionModalContainer/AdvancedCopyModal.tsx` - Added `isOpen` prop
- `src/components/QuranReader/VerseActionModalContainer/BookmarkModal.tsx` - Added `isOpen` prop
- `src/components/QuranReader/VerseActionModalContainer/FeedbackModal.tsx` - Added `isOpen` prop
- `src/components/QuranReader/VerseActionModalContainer/NotesModals.tsx` - Added `isOpen` prop

###  Testing Plan

#### Study Mode Modal

1. **Open Study Mode**
   - Navigate to any verse in the Quran reader
   - Tap on a verse to open Study Mode
   - Verify the modal opens with animation

2. **Close Study Mode**
   - Tap the close button (X) or tap outside the modal
   - **Expected:** Modal should fade out smoothly with animation
   - **Previously:** Modal would disappear instantly

3. **Switch tabs and close**
   - Open Study Mode
   - Switch between different tabs (e.g., Tafsir, Translations)
   - Close the modal
   - **Expected:** Animation plays correctly regardless of active tab

4. **Word highlighting and close**
   - Open Study Mode
   - Tap on a word to highlight it
   - Close the modal
   - **Expected:** Animation plays, highlights are cleared properly

#### Verse Action Modals

5. **Advanced Copy Modal**
   - Long-press on a verse or tap verse action menu
   - Select "Advanced Copy"
   - Close the modal (back button or X)
   - **Expected:** Smooth close animation

7. **Translation Feedback Modal**
   - Open feedback modal
   - Close the modal
   - **Expected:** Smooth close animation

8. **Notes Modals (Add, Edit, My Notes)**
   - Open "Add Note" modal
   - Close it
   - **Expected:** Smooth close animation

   - Open "My Notes" modal
   - Navigate to "Edit Note"
   - Close the edit modal
   - **Expected:** Each modal close animates smoothly

9. **Reader Bio Modal**
   - Open a reader's bio from translation info
   - Close the modal
   - **Expected:** Smooth close animation

#### Study Mode Integration

10. **Study Mode → Verse Action Modal**
    - Open Study Mode on a verse
    - Tap a verse action (e.g., bookmark, note)
    - Close the action modal (back to Study Mode)
    - **Expected:** Action modal closes with animation, Study Mode remains open

11. **Close Study Mode after navigation**
    - Open Study Mode
    - Navigate to an action modal
    - Return to Study Mode
    - Close Study Mode
    - **Expected:** Study Mode closes with smooth animation

#### Edge Cases

12. **Rapid open/close**
    - Open and close the modal quickly multiple times
    - **Expected:** No flickering, animations complete cleanly each time

13. **State preservation**
    - Open Study Mode and make changes (select tab, highlight word)
    - Close the modal
    - Reopen Study Mode on same verse
    - **Expected:** Previous state is cleared, fresh state on reopen

14. **Different screen sizes**
    - Test on mobile and desktop viewport sizes
    - **Expected:** Animations work consistently across all sizes

