### PR TITLE
[QF-4727] Fix PinnedVersesBar mobile light mode background and border styling

### DIFF
--- a/src/components/QuranReader/PinnedVersesBar/PinnedVersesBar.module.scss
+++ b/src/components/QuranReader/PinnedVersesBar/PinnedVersesBar.module.scss
@@ -1,4 +1,5 @@
 @use 'src/styles/breakpoints';
+@use 'src/styles/theme';
 
 .container {
   display: flex;
@@ -7,6 +8,13 @@
   background: var(--color-background-elevated);
   border: var(--spacing-micro-px) solid var(--color-separators-new);
   transition: margin-inline-start var(--transition-regular), inline-size var(--transition-regular);
+
+  @include breakpoints.smallerThanTablet {
+    @include theme.light {
+      background: var(--color-background-alternative-faded);
+      border-color: var(--color-separators-ayah-level);
+    }
+  }
 }
 
 .withSidebarNavigation {


### PR DESCRIPTION
## Summary
                                                                                                                         
  Override `PinnedVersesBar` background and border color on mobile viewports in light mode only.
  Previously the bar used `--color-background-elevated` and `--color-separators-new` across all                          
  breakpoints and themes. On mobile + light mode it now uses
  `--color-background-alternative-faded` and `--color-separators-ayah-level` 
to match the intended design. Dark, sepia, and desktop are unaffected.

  Closes: [QF-4727](https://quranfoundation.atlassian.net/browse/QF-4727)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [x] Manual testing performed

  **Testing steps:**

  1. Open the app at a mobile viewport (< 768 px) in **light mode** → verify the `PinnedVersesBar`
     shows `#f8f9fa` background and `#ebeef0` border.
  2. Switch to **dark mode** on the same mobile viewport → verify the bar reverts to the default
     elevated background and `separators-new` border.
  3. Switch to **sepia mode** on mobile → same as step 2, no override applied.
  4. Resize to a **desktop viewport (≥ 768 px)** in light mode → verify no visual change from
     before this PR.

  ### Edge Cases Verified

  - [ ] ⏳ Loading state handled
  - [ ] ❌ Error state handled
  - [ ] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  _N/A — pure styling change with no state logic._

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [x] Linting passes (`yarn lint`)
  - [x] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming

  ### Localization (if UI changes)

  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used

  ## Reviewer Notes

  Only `PinnedVersesBar.module.scss` is touched. The fix is two SCSS lines nested inside
  `breakpoints.smallerThanTablet > theme.light` so the override is strictly scoped and cannot
  bleed into other themes or breakpoints.

  ## AI Assistance Disclosure

  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4727]: https://quranfoundation.atlassian.net/browse/QF-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ