### PR TITLE
 [QF-4805] Add Share button to CourseDetails header 

### DIFF
--- a/src/components/Course/Buttons/RepeatLearningPlan/index.tsx
+++ b/src/components/Course/Buttons/RepeatLearningPlan/index.tsx
@@ -6,6 +6,7 @@ import useTranslation from 'next-translate/useTranslation';
 import styles from './RepeatLearningPlan.module.scss';
 
 import Button, { ButtonSize } from '@/dls/Button/Button';
+import useIsMobile from '@/hooks/useIsMobile';
 import { Course } from '@/types/auth/Course';
 import { logButtonClick } from '@/utils/eventLogger';
 import { getLessonNavigationUrl } from '@/utils/navigation';
@@ -17,6 +18,7 @@ type Props = {
 const RepeatLearningPlan: React.FC<Props> = ({ course }) => {
   const { t } = useTranslation('learn');
   const router = useRouter();
+  const isMobile = useIsMobile();
   const { id, slug, lessons } = course;
 
   const onRepeatClicked = () => {
@@ -27,7 +29,11 @@ const RepeatLearningPlan: React.FC<Props> = ({ course }) => {
   };
 
   return (
-    <Button size={ButtonSize.Small} className={styles.repeatButton} onClick={onRepeatClicked}>
+    <Button
+      size={isMobile ? ButtonSize.Small : ButtonSize.Medium}
+      className={styles.repeatButton}
+      onClick={onRepeatClicked}
+    >
       {t('repeat-learning-plan')}
     </Button>
   );

--- a/src/components/Course/Buttons/ShareCourse/ShareCourse.module.scss
+++ b/src/components/Course/Buttons/ShareCourse/ShareCourse.module.scss
@@ -1,0 +1,55 @@
+@use 'src/styles/breakpoints';
+
+.shareButton {
+  background-color: var(--color-background-alternative-faint-new);
+  color: var(--color-text-default-new);
+  border-color: var(--color-background-alternative-faint-new);
+
+  svg {
+    color: var(--color-text-default-new);
+  }
+
+  &:hover {
+    background-color: var(--color-background-alternative-faint-new);
+    color: var(--color-text-default-new);
+    opacity: var(--opacity-85);
+  }
+}
+
+.shareIcon {
+  display: flex;
+  align-items: center;
+  inline-size: var(--spacing-medium2-px);
+  block-size: var(--spacing-medium2-px);
+
+  @include breakpoints.smallerThanTablet {
+    inline-size: calc(var(--spacing-small-plus-px) * 2);
+    block-size: calc(var(--spacing-small-plus-px) * 2);
+  }
+
+  svg {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+}
+
+.closeButton {
+  position: absolute;
+  inset-block-start: var(--spacing-medium);
+  inset-inline-end: var(--spacing-medium);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-default);
+  inline-size: var(--spacing-medium3-px);
+  block-size: var(--spacing-medium3-px);
+
+  svg {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+}

--- a/src/components/Course/Buttons/ShareCourse/index.tsx
+++ b/src/components/Course/Buttons/ShareCourse/index.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+
+import useTranslation from 'next-translate/useTranslation';
+
+import styles from './ShareCourse.module.scss';
+
+import Button, { ButtonSize } from '@/dls/Button/Button';
+import { ModalSize } from '@/dls/Modal/Content';
+import Modal from '@/dls/Modal/Modal';
+import ShareButtons from '@/dls/ShareButtons';
+import useIsMobile from '@/hooks/useIsMobile';
+import CloseIcon from '@/icons/close.svg';
+import ShareIcon from '@/icons/share.svg';
+import { Course } from '@/types/auth/Course';
+import { logButtonClick } from '@/utils/eventLogger';
+import { getCourseNavigationUrl } from '@/utils/navigation';
+import { getBasePath } from '@/utils/url';
+
+type Props = { course: Course };
+
+const ShareCourse: React.FC<Props> = ({ course }) => {
+  const { t } = useTranslation('common');
+  const [isOpen, setIsOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  const shareUrl = `${getBasePath()}${getCourseNavigationUrl(course.slug)}`;
+
+  const onShareClicked = () => {
+    logButtonClick('share_course_clicked', { courseId: course.id });
+    setIsOpen(true);
+  };
+
+  return (
+    <>
+      <Button
+        size={isMobile ? ButtonSize.Small : ButtonSize.Medium}
+        className={styles.shareButton}
+        prefix={
+          <span className={styles.shareIcon}>
+            <ShareIcon />
+          </span>
+        }
+        onClick={onShareClicked}
+      >
+        {t('share')}
+      </Button>
+      <Modal isOpen={isOpen} onClickOutside={() => setIsOpen(false)} size={ModalSize.MEDIUM}>
+        <Modal.Body>
+          <button
+            className={styles.closeButton}
+            onClick={() => setIsOpen(false)}
+            type="button"
+            aria-label="Close"
+          >
+            <CloseIcon />
+          </button>
+          <Modal.Title>{course.title}</Modal.Title>
+          <ShareButtons
+            url={shareUrl}
+            title={course.title}
+            analyticsContext="share_course"
+            hideVideoGeneration
+          />
+        </Modal.Body>
+      </Modal>
+    </>
+  );
+};
+
+export default ShareCourse;

--- a/src/components/Course/Buttons/StartOrContinueLearning/index.tsx
+++ b/src/components/Course/Buttons/StartOrContinueLearning/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 
-import Button from '@/dls/Button/Button';
+import Button, { ButtonSize } from '@/dls/Button/Button';
 import { Course } from '@/types/auth/Course';
 import { logButtonClick } from '@/utils/eventLogger';
 import { getLessonNavigationUrl } from '@/utils/navigation';
@@ -11,9 +11,10 @@ import { getLessonNavigationUrl } from '@/utils/navigation';
 type Props = {
   course: Course;
   isHeaderButton?: boolean;
+  size?: ButtonSize;
 };
 
-const StartOrContinueLearning: React.FC<Props> = ({ course, isHeaderButton = true }) => {
+const StartOrContinueLearning: React.FC<Props> = ({ course, isHeaderButton = true, size }) => {
   const { t } = useTranslation('learn');
   const { lessons, continueFromLesson, id, slug } = course;
   /**
@@ -32,7 +33,11 @@ const StartOrContinueLearning: React.FC<Props> = ({ course, isHeaderButton = tru
     router.push(getLessonNavigationUrl(slug, redirectToLessonSlug));
   };
 
-  return <Button onClick={onContinueLearningClicked}>{t('continue-learning')}</Button>;
+  return (
+    <Button size={size} onClick={onContinueLearningClicked}>
+      {t('continue-learning')}
+    </Button>
+  );
 };
 
 export default StartOrContinueLearning;

--- a/src/components/Course/CourseDetails/CourseDetails.module.scss
+++ b/src/components/Course/CourseDetails/CourseDetails.module.scss
@@ -13,20 +13,17 @@
 .headerContainer {
   padding-block-end: var(--spacing-small);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--spacing-small-px);
   inline-size: 100%;
   order: 1;
 
   @include breakpoints.smallerThanTablet {
     order: 2;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: var(--spacing-small-px);
   }
 
   &.completedHeader {
-    flex-direction: column;
     align-items: flex-start;
     padding-block-end: 0;
 
@@ -52,6 +49,7 @@
 .titleRow {
   display: flex;
   align-items: center;
+  align-self: flex-start;
 }
 
 .titleRow .completedPill {
@@ -74,6 +72,32 @@
     align-self: flex-end;
     margin-block-start: 0;
     margin-block-end: var(--spacing-medium2-px);
+  }
+}
+
+.actionsRow {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small-px);
+  align-self: flex-end;
+}
+
+.completedActionsRow,
+.actionsRow {
+  @include breakpoints.smallerThanMobileM {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  button {
+    padding-inline: var(--spacing-xsmall-px);
+    border-radius: var(--border-radius-small-px);
+    font-weight: var(--font-weight-semibold);
+    white-space: nowrap;
+
+    @include breakpoints.smallerThanTablet {
+      font-size: var(--font-size-small);
+    }
   }
 }
 

--- a/src/components/Course/CourseDetails/StatusHeader/index.tsx
+++ b/src/components/Course/CourseDetails/StatusHeader/index.tsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 
 import StartOrContinueLearning from '@/components/Course/Buttons/StartOrContinueLearning';
-import Button from '@/dls/Button/Button';
+import Button, { ButtonSize } from '@/dls/Button/Button';
 import { useToast, ToastStatus } from '@/dls/Toast/Toast';
+import useIsMobile from '@/hooks/useIsMobile';
 import { Course } from '@/types/auth/Course';
 import EnrollmentMethod from '@/types/auth/EnrollmentMethod';
 import { getUserType, isLoggedIn } from '@/utils/auth/login';
@@ -25,6 +26,8 @@ type Props = {
 
 const StatusHeader: React.FC<Props> = ({ course, isCTA = false }) => {
   const { id, isUserEnrolled, slug, lessons, allowGuestAccess } = course;
+  const isMobile = useIsMobile();
+  const buttonSize = isMobile ? ButtonSize.Small : ButtonSize.Medium;
   const router = useRouter();
   const { t } = useTranslation('learn');
   const toast = useToast();
@@ -73,6 +76,7 @@ const StatusHeader: React.FC<Props> = ({ course, isCTA = false }) => {
   const renderStartHereButton = () => {
     return (
       <Button
+        size={buttonSize}
         isDisabled={isEnrolling}
         isLoading={isEnrolling}
         onClick={onStartHereClicked}
@@ -90,7 +94,7 @@ const StatusHeader: React.FC<Props> = ({ course, isCTA = false }) => {
   }
 
   if (isUserEnrolled) {
-    return <StartOrContinueLearning course={course} />;
+    return <StartOrContinueLearning course={course} size={buttonSize} />;
   }
 
   return renderStartHereButton();

--- a/src/components/Course/CourseDetails/index.tsx
+++ b/src/components/Course/CourseDetails/index.tsx
@@ -8,6 +8,7 @@ import styles from './CourseDetails.module.scss';
 import EditorsDetails from './Tabs/MainDetails/DetailSection/EditorsDetails';
 
 import RepeatLearningPlan from '@/components/Course/Buttons/RepeatLearningPlan';
+import ShareCourse from '@/components/Course/Buttons/ShareCourse';
 import StartOrContinueLearning from '@/components/Course/Buttons/StartOrContinueLearning';
 import ContentContainer from '@/components/Course/ContentContainer';
 import StatusHeader from '@/components/Course/CourseDetails/StatusHeader';
@@ -98,13 +99,17 @@ const CourseDetails: React.FC<Props> = ({ course }) => {
           </div>
           {isCompleted ? (
             <div className={styles.completedActionsRow}>
+              <ShareCourse course={course} />
               <RepeatLearningPlan course={course} />
               {course?.userHasFeedback === false && (
                 <CourseFeedback course={course} source={FeedbackSource.CoursePage} />
               )}
             </div>
           ) : (
-            <StatusHeader course={course} />
+            <div className={styles.actionsRow}>
+              <ShareCourse course={course} />
+              <StatusHeader course={course} />
+            </div>
           )}
         </div>
 

--- a/src/components/Course/CourseFeedback/index.tsx
+++ b/src/components/Course/CourseFeedback/index.tsx
@@ -6,6 +6,7 @@ import useTranslation from 'next-translate/useTranslation';
 import CourseFeedbackModal from './CourseFeedbackModal';
 
 import Button, { ButtonSize, ButtonType } from '@/dls/Button/Button';
+import useIsMobile from '@/hooks/useIsMobile';
 import { Course } from '@/types/auth/Course';
 import { getUserType, isLoggedIn } from '@/utils/auth/login';
 import { logButtonClick } from '@/utils/eventLogger';
@@ -26,6 +27,7 @@ const CourseFeedback: React.FC<Props> = ({ source, course, shouldOpenModal = fal
   const { t } = useTranslation('learn');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const router = useRouter();
+  const isMobile = useIsMobile();
   const userIsLoggedIn = isLoggedIn();
   const userType = getUserType(userIsLoggedIn);
 
@@ -55,7 +57,11 @@ const CourseFeedback: React.FC<Props> = ({ source, course, shouldOpenModal = fal
 
   return (
     <>
-      <Button size={ButtonSize.Small} type={ButtonType.Primary} onClick={onAddFeedbackClicked}>
+      <Button
+        size={isMobile ? ButtonSize.Small : ButtonSize.Medium}
+        type={ButtonType.Primary}
+        onClick={onAddFeedbackClicked}
+      >
         {t('feedback.add-feedback')}
       </Button>
       <CourseFeedbackModal


### PR DESCRIPTION
 ## Summary                                                                                                                                         

  Adds a **Share** button to the CourseDetails page header, visible in all enrollment states (guest, not enrolled, enrolled/continuing, completed). 
The button opens a modal with Facebook, X, WhatsApp, and Copy URL sharing options. 

  Closes: [QF-4805](https://quranfoundation.atlassian.net/browse/QF-4805)

  ## Type of Change

  - [x] ✨ New feature (non-breaking change which adds functionality)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Environment Variables

  N/A

  ## Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

  1. Navigate to any course page as a **guest** → confirm Share button appears first, before
     Start Here
  2. Navigate as a **logged-in, not-enrolled** user → same as guest
  3. Navigate as an **enrolled** user → confirm Share appears before Continue Learning
  4. Navigate as a **completed** user → confirm Share appears before Repeat (and Feedback if
     no feedback yet)
  5. Click Share → modal opens with Facebook, X, WhatsApp, and Copy URL options
  6. Click Copy URL → clipboard contains the correct course URL
     (`<base_url>/learning-plans/<slug>`)
  7. Click Facebook / X / WhatsApp → external share windows open correctly
  8. Check browser console / analytics for `share_course_clicked` event on button click
  9. Resize to **< 375px** → confirm buttons wrap to a new line instead of being clipped
  10. Resize to **≥ 375px** → confirm all buttons stay on one row, text does not wrap
  11. Verify **dark / sepia** themes render Share and Repeat buttons correctly (same
      background/color as each other)
  12. Verify **RTL** layout — Share icon flips correctly, modal closes on outside click

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled (Start Here shows spinner via `isLoading` prop)
  - [x] ❌ Error state handled (enroll failure shows toast)
  - [ ] 📭 Empty state handled
  - [x] 👤 Logged-in vs guest behavior — guest without `allowGuestAccess` is redirected to
        login; guest with `allowGuestAccess` goes directly to first lesson

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the project style guidelines
  - [x] No `any` types used
  - [x] No unused code, imports, or dead code included
  - [x] Complex logic has comments explaining "why"
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [ ] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Localization (if UI changes)

  - [x] All user-facing text uses `next-translate` — Share button uses existing
        `common:share` key; no new locale keys added
  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used
  - [x] Close button has `aria-label="Close"`
  - [x] Keyboard navigation works (modal closes on outside click)

  ## AI Assistance Disclosure

  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated
        code

[QF-4805]: https://quranfoundation.atlassian.net/browse/QF-4805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ