### PR TITLE
[QF-4702] Fix LearningPlanBanner mobile image stretching

### DIFF
--- a/src/components/QuranReader/LearningPlanBanner/LearningPlanBanner.module.scss
+++ b/src/components/QuranReader/LearningPlanBanner/LearningPlanBanner.module.scss
@@ -41,23 +41,14 @@
   @include breakpoints.smallerThanTablet {
     inline-size: 100vw;
     margin-inline: calc(50% - 50vw);
-    aspect-ratio: 9 / 3;
   }
 }
 
 .imageWrap {
   img {
     inline-size: 100%;
-    block-size: 100%;
+    block-size: auto;
     max-inline-size: 1230px;
-  }
-
-  @include breakpoints.smallerThanTablet {
-    inline-size: 100%;
-    block-size: 100%;
-    img {
-      object-fit: cover;
-    }
   }
 }
 


### PR DESCRIPTION
## Summary               
                                                                                                                                    
  Fix `LearningPlanBanner` mobile image stretching by removing the forced `aspect-ratio: 9 / 3` container and `block-size: 100%` / `object-fit: cover` overrides. 
The image now renders at its natural aspect ratio (1230×307), edge-to-edge on mobile — consistent with how `CourseDetails` handles its top image.
                                                                                                                                                       
  Closes: [QF-4702](https://quranfoundation.atlassian.net/browse/QF-4702)

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Safety

  - [x] Can be safely reverted without data issues or migrations

  ## Test Plan

  - [x] Manual testing performed

  **Testing steps:**

  1. Open any Quran reader page that shows the Learning Plan banner
  2. Resize to a mobile viewport (< 768px) or use DevTools device emulation
  3. Verify the banner image renders at its natural aspect ratio without stretching or cropping
  4. Verify the image remains full-width (edge-to-edge) on mobile
  5. Verify the desktop layout is unchanged

  ### Edge Cases Verified

  - [x] ⏳ Loading state handled
  - [x] ❌ Error state handled
  - [x] 📭 Empty state handled

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No unused code, imports, or dead code included

  ### Testing & Validation

  - [x] Linting passes (`yarn lint`)
  - [x] Build succeeds (`yarn build`)

  ### Localization (if UI changes)

  - [x] RTL layout verified

  ### Accessibility (if UI changes)

  - [x] Semantic HTML elements used

  ## Screenshots/Videos

  | Before | After |
  | ------ | ----- |
  | <img width="394" height="843" alt="image" src="https://github.com/user-attachments/assets/7ba9086b-69ea-4191-918d-706831980239" /> | <img width="394" height="844" alt="image" src="https://github.com/user-attachments/assets/68abd089-efd5-4f5c-873f-8d35ee22f0a6" /> |

  ## Reviewer Notes

  Only 3 CSS property changes in a single SCSS module file 

  ## AI Assistance Disclosure

  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4702]: https://quranfoundation.atlassian.net/browse/QF-4702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ