### PR TITLE
fix: localize learning plan verse widgets by lesson language

### DIFF
--- a/src/components/Course/LessonHtmlContent/VerseChunkWidget.tsx
+++ b/src/components/Course/LessonHtmlContent/VerseChunkWidget.tsx
@@ -10,6 +10,7 @@ import type { VerseReference } from '@/utils/lessonContentParser';
 type Props = {
   reference: VerseReference;
   fallbackHtml: string;
+  language?: string;
 };
 
 const parseRange = (value: string, allowDescending: boolean): WordTrimRange | undefined => {
@@ -80,8 +81,8 @@ const parseTrim = (
   };
 };
 
-const VerseChunkWidget: React.FC<Props> = ({ reference, fallbackHtml }) => {
-  const { data, isValidating } = useVerseWidgetData(reference);
+const VerseChunkWidget: React.FC<Props> = ({ reference, fallbackHtml, language }) => {
+  const { data, isValidating } = useVerseWidgetData(reference, language);
   const isRange = Boolean(reference.to && reference.to > reference.from);
 
   if (isValidating && !data) return <Skeleton className={styles.widgetSkeleton} />;

--- a/src/components/Course/LessonHtmlContent/index.tsx
+++ b/src/components/Course/LessonHtmlContent/index.tsx
@@ -16,6 +16,7 @@ import parseLessonQuizFromHtml from '@/utils/lessonQuizParser';
 type Props = {
   content: string;
   language: string;
+  widgetLanguage?: string;
   lessonSlug: string;
   courseSlug: string;
 };
@@ -32,7 +33,7 @@ const FLASHCARD_VARIANT_CONFIG: Record<FlashCardVariant, { subtitleKey: string }
   },
 };
 
-const renderChunks = (chunks: ContentChunk[], keyPrefix = '') =>
+const renderChunks = (chunks: ContentChunk[], widgetLanguage: string, keyPrefix = '') =>
   chunks.map((chunk) =>
     chunk.type === 'html' ? (
       <HtmlContent key={`${keyPrefix}${chunk.key}`} html={chunk.content} />
@@ -41,12 +42,13 @@ const renderChunks = (chunks: ContentChunk[], keyPrefix = '') =>
         key={`${keyPrefix}${chunk.key}`}
         reference={chunk.reference}
         fallbackHtml={chunk.originalHtml}
+        language={widgetLanguage}
       />
     ),
   );
 
-const renderHtml = (html: string, keyPrefix = '') =>
-  renderChunks(parseContentChunks(html), keyPrefix);
+const renderHtml = (html: string, widgetLanguage: string, keyPrefix = '') =>
+  renderChunks(parseContentChunks(html), widgetLanguage, keyPrefix);
 
 const toggleInSet = (set: Set<string>, item: string) => {
   const nextSet = new Set(set);
@@ -55,10 +57,12 @@ const toggleInSet = (set: Set<string>, item: string) => {
   return nextSet;
 };
 
-const LessonHtmlContent: React.FC<Props> = ({ content, language, lessonSlug, courseSlug }) => {
+const LessonHtmlContent: React.FC<Props> = (props) => {
+  const { content, language, widgetLanguage, lessonSlug, courseSlug } = props;
   const { t } = useTranslation('learn');
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set());
   const [masteredCards, setMasteredCards] = useState<Set<string>>(new Set());
+  const widgetLang = widgetLanguage || language;
 
   const isInteractiveLearningPlan =
     courseSlug === '30-transformative-days-with-surah-al-mulk-learn-reflect-memorize';
@@ -81,10 +85,6 @@ const LessonHtmlContent: React.FC<Props> = ({ content, language, lessonSlug, cou
     [contentToRender, shouldUseInteractiveFeatures],
   );
 
-  if (!shouldUseInteractiveFeatures) {
-    return <HtmlContent html={content} />;
-  }
-
   if (flashcardData) {
     const { subtitleKey } = FLASHCARD_VARIANT_CONFIG[flashcardData.variant];
     const isListVariant = flashcardData.variant === FlashCardVariant.List;
@@ -95,7 +95,7 @@ const LessonHtmlContent: React.FC<Props> = ({ content, language, lessonSlug, cou
 
     return (
       <div className={styles.container}>
-        {flashcardData.beforeHtml && renderHtml(flashcardData.beforeHtml, 'before-')}
+        {flashcardData.beforeHtml && renderHtml(flashcardData.beforeHtml, widgetLang, 'before-')}
         <div className={styles.flashcardSection}>
           <div className={styles.flashcardHeader}>
             <div className={styles.flashcardHeaderText}>
@@ -137,7 +137,7 @@ const LessonHtmlContent: React.FC<Props> = ({ content, language, lessonSlug, cou
             <NonListFlashCardComponent key={contentToRender} cards={flashcardData.flashcards} />
           )}
         </div>
-        {flashcardData.afterHtml && renderHtml(flashcardData.afterHtml, 'after-')}
+        {flashcardData.afterHtml && renderHtml(flashcardData.afterHtml, widgetLang, 'after-')}
         {quizNode}
       </div>
     );
@@ -156,7 +156,7 @@ const LessonHtmlContent: React.FC<Props> = ({ content, language, lessonSlug, cou
 
   return (
     <div className={styles.container}>
-      {renderChunks(chunks)}
+      {renderChunks(chunks, widgetLang)}
       {quizNode}
     </div>
   );

--- a/src/components/Course/LessonView/index.tsx
+++ b/src/components/Course/LessonView/index.tsx
@@ -29,6 +29,7 @@ const LessonView: React.FC<Props> = ({ lesson, courseSlug, lessonSlugOrId }) => 
   const { title, content, day } = lesson;
   const { t, lang } = useTranslation('learn');
   const [isCourseMaterialModalOpen, setCourseMaterialModalOpen] = useState(false);
+  const widgetLanguage = lesson.course.widgetLanguage || lesson.course.language;
 
   const onBackButtonClicked = () => {
     logButtonClick('back_to_course', { lessonSlugOrId, courseSlug });
@@ -106,6 +107,7 @@ const LessonView: React.FC<Props> = ({ lesson, courseSlug, lessonSlugOrId }) => 
                   key={lesson.id}
                   content={content}
                   language={lesson.course.language}
+                  widgetLanguage={widgetLanguage}
                   lessonSlug={lesson.slug}
                   courseSlug={courseSlug}
                 />

--- a/src/hooks/useVerseWidgetData.ts
+++ b/src/hooks/useVerseWidgetData.ts
@@ -1,13 +1,14 @@
 import { useSelector } from 'react-redux';
 import useSWR from 'swr';
 
+import i18nConfig from '../../i18n.json';
+
 import type { AyahWidgetData } from '@/components/AyahWidget/getAyahWidgetData';
+import { getTranslationsInitialState } from '@/redux/defaultSettings/util';
 import { selectTheme } from '@/redux/slices/theme';
 import ThemeType from '@/redux/types/ThemeType';
 import type { VerseReference } from '@/utils/lessonContentParser';
 import { fetcher } from 'src/api';
-
-const CLEAR_QURAN_TRANSLATION_ID = 131;
 
 const resolveTheme = (type: string): string => {
   if (type !== ThemeType.Auto) return type;
@@ -17,14 +18,17 @@ const resolveTheme = (type: string): string => {
     : ThemeType.Light;
 };
 
-const useVerseWidgetData = (reference: VerseReference) => {
+const useVerseWidgetData = (reference: VerseReference, language = 'en') => {
   const theme = useSelector(selectTheme);
+  const safeLanguage = i18nConfig.locales.includes(language) ? language : 'en';
+  const translationIds = getTranslationsInitialState(safeLanguage).selectedTranslations;
 
   const params = new URLSearchParams({
     chapter: String(reference.chapter),
     from: String(reference.from),
-    translations: String(CLEAR_QURAN_TRANSLATION_ID),
+    translations: translationIds.join(','),
     theme: resolveTheme(theme.type),
+    locale: safeLanguage,
   });
 
   if (reference.to) params.set('to', String(reference.to));

--- a/src/pages/api/ayah-widget.ts
+++ b/src/pages/api/ayah-widget.ts
@@ -7,26 +7,28 @@ import {
 } from '@/components/AyahWidget/getAyahWidgetData';
 import ThemeType from '@/redux/types/ThemeType';
 import type ThemeTypeVariant from '@/redux/types/ThemeTypeVariant';
+import { normalizeQueryParam } from '@/utils/url';
 
 type ApiResponse = AyahWidgetData | { error: string };
 
-const parseTranslationIds = (translations: string | string[] | undefined): number[] => {
-  if (!translations) return [131]; // Default to Clear Quran
-  return String(translations)
+const parseTranslationIds = (translations: string | undefined): number[] => {
+  if (translations === undefined) return [131];
+  return translations
     .split(',')
     .map((id) => Number(id.trim()))
-    .filter((id) => Number.isFinite(id));
+    .filter((id) => Number.isInteger(id) && id > 0);
 };
 
-const parseTheme = (theme: string | string[] | undefined): ThemeTypeVariant => {
+const parseTheme = (theme: string | undefined): ThemeTypeVariant => {
   if (theme === ThemeType.Dark || theme === ThemeType.Sepia) return theme as ThemeTypeVariant;
   return ThemeType.Light;
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ApiResponse>) {
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
-  const { chapter, from, to, translations, theme } = req.query;
-
+  const { chapter, from, to } = req.query;
+  const translations = normalizeQueryParam(req.query.translations);
+  const theme = normalizeQueryParam(req.query.theme);
   const chapterNum = Number(chapter);
   const fromNum = Number(from);
 
@@ -40,7 +42,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       rangeEnd: to ? Number(to) : undefined,
       translationIds: parseTranslationIds(translations),
       theme: parseTheme(theme),
-      locale: 'en',
+      locale: normalizeQueryParam(req.query.locale) || 'en',
       lp: true,
       mergeVerses: true,
       showTafsirs: false,

--- a/types/auth/Course.ts
+++ b/types/auth/Course.ts
@@ -33,6 +33,7 @@ export type Course = {
   authors: { author: CourseAuthor }[];
   editors: { editor: CourseEditor }[];
   language: string; // language code
+  widgetLanguage?: string; // optional verse widget language override
   description: string;
   metaDescription?: string;
   image: string;


### PR DESCRIPTION
## Summary
This PR makes learning plan verse widgets language-aware based on the learning plan language 

## Changes
- Render verse widgets for LP lesson HTML in all languages (not English-only).
- Add optional `course.widgetLanguage` override, fallback to `course.language`.
- Pass widget language through `LessonView -> LessonHtmlContent -> VerseChunkWidget -> useVerseWidgetData`.
- Resolve default translation IDs from locale defaults and send `locale` to `ayah-widget` API.
- Normalize API query params and tighten translation ID parsing.