### PR TITLE
fix: parse lp flashcards when paragraph dir is missing

### DIFF
--- a/src/utils/flashcardParser.test.ts
+++ b/src/utils/flashcardParser.test.ts
@@ -76,6 +76,13 @@ describe('flashcardParser', () => {
       expect(result?.afterHtml).toBe('<p>Practice this line slowly.</p>');
     });
 
+    it('keeps strong note paragraphs after flashcards in afterHtml', () => {
+      const html = `${makeSection()}<p><strong>Tip:</strong> Practice this line slowly.</p>`;
+      const result = parseFlashcardsFromHtml(html);
+      expect(result?.flashcards).toHaveLength(1);
+      expect(result?.afterHtml).toBe('<p><strong>Tip:</strong> Practice this line slowly.</p>');
+    });
+
     it('splits before trailing blockquote sections', () => {
       const html = `${makeSection()}<blockquote><a href="https://quran.com/2/1">2:1</a><p>Verse widget</p></blockquote>`;
       const result = parseFlashcardsFromHtml(html);

--- a/src/utils/flashcardParser.test.ts
+++ b/src/utils/flashcardParser.test.ts
@@ -5,12 +5,15 @@ import parseFlashcardsFromHtml from './flashcardParser';
 import { FlashCardVariant } from '@/components/Course/FlashCards/types';
 
 const WORD_HTML = `<p dir="rtl"><strong>ٱلَّذِى</strong>(<em>alladhī</em>) - The One Who</p>`;
+const WORD_HTML_NO_DIR = `<p><strong>ٱلَّذِى</strong>(<em>alladhī</em>) - The One Who</p>`;
 const WORD_HTML_NO_TRANSLITERATION = `<p dir="rtl"><strong>خَلَقَ</strong> - created</p>`;
 const WORD_HTML_EM_DASH = `<p dir="rtl"><strong>رَحْمَة</strong>(<em>raḥmah</em>) — mercy</p>`;
 const WORD_HTML_NBSP = `<p dir="rtl"><strong>ٱلَّذِى</strong>(<em>alladhī</em>)&nbsp;-&nbsp;The One Who</p>`;
 
 const makeSection = (headingAttrs = '', title = 'Word-by-word breakdown') =>
   `<h3${headingAttrs}>${title}</h3>${WORD_HTML}`;
+const makeSectionWithoutDir = (headingAttrs = '', title = 'Word-by-word breakdown') =>
+  `<h3${headingAttrs}>${title}</h3>${WORD_HTML_NO_DIR}`;
 const makeSectionWithoutTransliteration = (headingAttrs = '', title = 'Word-by-word breakdown') =>
   `<h3${headingAttrs}>${title}</h3>${WORD_HTML_NO_TRANSLITERATION}`;
 const makeSectionWithEmDash = (headingAttrs = '', title = 'Word-by-word breakdown') =>
@@ -83,6 +86,14 @@ describe('flashcardParser', () => {
 
     it('parses arabic, transliteration and translation', () => {
       const result = parseFlashcardsFromHtml(makeSection());
+      const card = result?.flashcards[0];
+      expect(card?.arabic).toBe('ٱلَّذِى');
+      expect(card?.transliteration).toBe('alladhī');
+      expect(card?.translation).toBe('The One Who');
+    });
+
+    it('parses word rows even when paragraph dir is missing', () => {
+      const result = parseFlashcardsFromHtml(makeSectionWithoutDir());
       const card = result?.flashcards[0];
       expect(card?.arabic).toBe('ٱلَّذِى');
       expect(card?.transliteration).toBe('alladhī');

--- a/src/utils/flashcardParser.ts
+++ b/src/utils/flashcardParser.ts
@@ -27,32 +27,37 @@ export default function parseFlashcardsFromHtml(html: string): {
 
   const afterHeadingContent = html.slice(headingEndIndex);
   const nextSectionMatch = afterHeadingContent.match(
-    /<h[1-6][^>]*>|<hr\b[^>]*\/?>|<blockquote\b[^>]*>|<ul\b[^>]*>|<ol\b[^>]*>|<div\b[^>]*>|<p[^>]*>(?!\s*<strong\b)/i,
+    /<h[1-6][^>]*>|<hr\b[^>]*\/?>|<blockquote\b[^>]*>|<ul\b[^>]*>|<ol\b[^>]*>|<div\b[^>]*>/i,
   );
   const splitAt = nextSectionMatch?.index ?? afterHeadingContent.length;
   const wordByWordHtml = afterHeadingContent.slice(0, splitAt);
-  const afterHtml = afterHeadingContent.slice(splitAt);
+  const htmlAfterSection = afterHeadingContent.slice(splitAt);
+  const { flashcards, remainingHtml } = extractFlashcardsFromSection(wordByWordHtml);
+  const afterHtml = `${remainingHtml}${htmlAfterSection}`;
 
-  const flashcards = extractFlashcardsFromSection(wordByWordHtml);
   if (flashcards.length === 0) return null;
 
   return { beforeHtml, flashcards, afterHtml, variant, headingText };
 }
 
-function extractFlashcardsFromSection(html: string): FlashCardData[] {
+function extractFlashcardsFromSection(html: string): {
+  flashcards: FlashCardData[];
+  remainingHtml: string;
+} {
   const flashcards: FlashCardData[] = [];
-  const paragraphRegex = /<p[^>]*>([\s\S]*?)<\/p>/gi;
-  let match: RegExpExecArray | null;
+  let remainingHtml = html;
 
-  // eslint-disable-next-line no-cond-assign
-  while ((match = paragraphRegex.exec(html)) !== null) {
+  // Parse only contiguous paragraph rows right after the heading.
+  for (;;) {
+    const match = remainingHtml.match(/^\s*<p[^>]*>([\s\S]*?)<\/p>/i);
+    if (!match) break;
     const cardData = parseWordParagraph(match[1]);
-    if (cardData) {
-      flashcards.push({ ...cardData, id: `flashcard-${flashcards.length}` });
-    }
+    if (!cardData) break;
+    flashcards.push({ ...cardData, id: `flashcard-${flashcards.length}` });
+    remainingHtml = remainingHtml.slice(match[0].length);
   }
 
-  return flashcards;
+  return { flashcards, remainingHtml };
 }
 
 function parseWordParagraph(html: string): Omit<FlashCardData, 'id'> | null {
@@ -61,7 +66,7 @@ function parseWordParagraph(html: string): Omit<FlashCardData, 'id'> | null {
   if (!arabicMatch) return null;
 
   const arabic = stripHtmlTags(arabicMatch[1]).trim();
-  if (!arabic) return null;
+  if (!arabic || !/[\u0600-\u06FF]/.test(arabic)) return null;
 
   const transliterationMatch = normalizedHtml.match(/<em[^>]*>(.*?)<\/em>/i);
   const transliteration = transliterationMatch ? stripHtmlTags(transliterationMatch[1]).trim() : '';
@@ -69,6 +74,8 @@ function parseWordParagraph(html: string): Omit<FlashCardData, 'id'> | null {
   const translationMatch =
     normalizedHtml.match(/\)\s*[-–—]\s*([\s\S]+?)$/) ||
     normalizedHtml.match(/\s[-–—]\s*([\s\S]+?)$/);
+  if (!transliterationMatch && !translationMatch) return null;
+
   let translation = '';
   if (translationMatch) {
     translation = stripHtmlTags(translationMatch[1])

--- a/src/utils/flashcardParser.ts
+++ b/src/utils/flashcardParser.ts
@@ -27,7 +27,7 @@ export default function parseFlashcardsFromHtml(html: string): {
 
   const afterHeadingContent = html.slice(headingEndIndex);
   const nextSectionMatch = afterHeadingContent.match(
-    /<h[1-6][^>]*>|<hr\b[^>]*\/?>|<blockquote\b[^>]*>|<ul\b[^>]*>|<ol\b[^>]*>|<div\b[^>]*>|<p(?![^>]*\bdir=["'](?:rtl|ltr)["'])[^>]*>/i,
+    /<h[1-6][^>]*>|<hr\b[^>]*\/?>|<blockquote\b[^>]*>|<ul\b[^>]*>|<ol\b[^>]*>|<div\b[^>]*>|<p[^>]*>(?!\s*<strong\b)/i,
   );
   const splitAt = nextSectionMatch?.index ?? afterHeadingContent.length;
   const wordByWordHtml = afterHeadingContent.slice(0, splitAt);
@@ -41,7 +41,7 @@ export default function parseFlashcardsFromHtml(html: string): {
 
 function extractFlashcardsFromSection(html: string): FlashCardData[] {
   const flashcards: FlashCardData[] = [];
-  const paragraphRegex = /<p[^>]*dir=["'](?:rtl|ltr)["'][^>]*>([\s\S]*?)<\/p>/gi;
+  const paragraphRegex = /<p[^>]*>([\s\S]*?)<\/p>/gi;
   let match: RegExpExecArray | null;
 
   // eslint-disable-next-line no-cond-assign


### PR DESCRIPTION
## Summary
Fix flashcard rendering for learning plan lessons where word-by-word rows use `<p>` without `dir` attributes (seen on testing data).

## Changes
- Updated `flashcardParser` to parse word rows from generic `<p>` tags, not only `dir="rtl|ltr"`.
- Adjusted section split logic to keep stopping at non-word paragraphs.
- Added a regression test for word-by-word rows without `dir`.

## Why
Production and testing lesson HTML can differ. This makes flashcard parsing robust across both formats.