### PR TITLE
fix(QF-4707): cap mobile Quran font size selector by viewport

### DIFF
--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.module.scss
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.module.scss
@@ -8,7 +8,20 @@
 
 .fontSizeSection {
   padding-block-start: var(--spacing-small-px);
+  padding-block-end: var(--spacing-small-px);
+}
+
+.fontScaleNoteRow {
+  padding-block-start: 0;
   padding-block-end: var(--spacing-medium3-px);
+}
+
+.fontScaleNote {
+  color: var(--color-text-faded-new);
+  font-size: var(--font-size-xsmall);
+  line-height: 1.4;
+  margin: 0;
+  padding-inline: var(--spacing-small-plus-px);
 }
 
 .counter {

--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
@@ -14,6 +14,7 @@ import Checkbox from '@/dls/Forms/Checkbox/Checkbox';
 import Select from '@/dls/Forms/Select';
 import Switch from '@/dls/Switch/Switch';
 import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
+import useIsMobile, { MobileSizeVariant } from '@/hooks/useIsMobile';
 import { getQuranReaderStylesInitialState } from '@/redux/defaultSettings/util';
 import { resetLoadedFontFaces } from '@/redux/slices/QuranReader/font-faces';
 import {
@@ -31,9 +32,14 @@ import { MushafLines, QuranFont } from '@/types/QuranReader';
 import { logEvent, logValueChange } from '@/utils/eventLogger';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
 
+const MOBILE_FONT_SCALE_CAP = 4;
+const SMALL_MOBILE_FONT_SCALE_CAP = 3;
+
 const QuranFontSection = () => {
   const { t, lang } = useTranslation('common');
   const dispatch = useDispatch();
+  const isMobile = useIsMobile();
+  const isSmallMobile = useIsMobile(MobileSizeVariant.SMALL);
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
   const {
     actions: { onSettingsChange },
@@ -188,6 +194,7 @@ const QuranFontSection = () => {
   };
 
   const onFontScaleIncreaseClicked = () => {
+    if (quranTextFontScale >= maxSelectableQuranScale) return;
     const value = quranTextFontScale + 1;
     logEvent('quran_font_size_increased');
     logValueChange('font_scale', quranTextFontScale, value);
@@ -210,6 +217,14 @@ const QuranFontSection = () => {
       PreferenceGroup.QURAN_READER_STYLES,
     );
   };
+
+  let maxSelectableQuranScale = MAXIMUM_QURAN_FONT_STEP;
+  if (isMobile) {
+    maxSelectableQuranScale = MOBILE_FONT_SCALE_CAP;
+  }
+  if (isSmallMobile) {
+    maxSelectableQuranScale = SMALL_MOBILE_FONT_SCALE_CAP;
+  }
 
   return (
     <Section id="quran-font-section" hideSeparator>
@@ -275,7 +290,7 @@ const QuranFontSection = () => {
           count={quranTextFontScale}
           onDecrement={quranTextFontScale === MINIMUM_FONT_STEP ? null : onFontScaleDecreaseClicked}
           onIncrement={
-            quranTextFontScale === MAXIMUM_QURAN_FONT_STEP ? null : onFontScaleIncreaseClicked
+            quranTextFontScale >= maxSelectableQuranScale ? null : onFontScaleIncreaseClicked
           }
           className={styles.counter}
         />

--- a/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
+++ b/src/components/Navbar/SettingsDrawer/QuranFontSection.tsx
@@ -14,7 +14,7 @@ import Checkbox from '@/dls/Forms/Checkbox/Checkbox';
 import Select from '@/dls/Forms/Select';
 import Switch from '@/dls/Switch/Switch';
 import usePersistPreferenceGroup from '@/hooks/auth/usePersistPreferenceGroup';
-import useIsMobile, { MobileSizeVariant } from '@/hooks/useIsMobile';
+import useIsMobile from '@/hooks/useIsMobile';
 import { getQuranReaderStylesInitialState } from '@/redux/defaultSettings/util';
 import { resetLoadedFontFaces } from '@/redux/slices/QuranReader/font-faces';
 import {
@@ -30,16 +30,13 @@ import {
 import { TestId } from '@/tests/test-ids';
 import { MushafLines, QuranFont } from '@/types/QuranReader';
 import { logEvent, logValueChange } from '@/utils/eventLogger';
+import { MOBILE_FONT_SCALE_CAP } from '@/utils/quran-font-scale';
 import PreferenceGroup from 'types/auth/PreferenceGroup';
-
-const MOBILE_FONT_SCALE_CAP = 4;
-const SMALL_MOBILE_FONT_SCALE_CAP = 3;
 
 const QuranFontSection = () => {
   const { t, lang } = useTranslation('common');
   const dispatch = useDispatch();
   const isMobile = useIsMobile();
-  const isSmallMobile = useIsMobile(MobileSizeVariant.SMALL);
   const quranReaderStyles = useSelector(selectQuranReaderStyles, shallowEqual);
   const {
     actions: { onSettingsChange },
@@ -218,13 +215,7 @@ const QuranFontSection = () => {
     );
   };
 
-  let maxSelectableQuranScale = MAXIMUM_QURAN_FONT_STEP;
-  if (isMobile) {
-    maxSelectableQuranScale = MOBILE_FONT_SCALE_CAP;
-  }
-  if (isSmallMobile) {
-    maxSelectableQuranScale = SMALL_MOBILE_FONT_SCALE_CAP;
-  }
+  const maxSelectableQuranScale = isMobile ? MOBILE_FONT_SCALE_CAP : MAXIMUM_QURAN_FONT_STEP;
 
   return (
     <Section id="quran-font-section" hideSeparator>
@@ -295,6 +286,13 @@ const QuranFontSection = () => {
           className={styles.counter}
         />
       </Section.Row>
+      {isMobile && (
+        <Section.Row className={styles.fontScaleNoteRow}>
+          <p className={styles.fontScaleNote}>
+            {`On this screen size, the maximum Quran font size is ${maxSelectableQuranScale} to preserve Mushaf line alignment.`}
+          </p>
+        </Section.Row>
+      )}
       <ReciterSection />
     </Section>
   );

--- a/src/redux/Provider.tsx
+++ b/src/redux/Provider.tsx
@@ -11,6 +11,9 @@ import getStore from './store';
 import resetSettings from '@/redux/actions/reset-settings';
 import syncLocaleDependentSettings from '@/redux/actions/sync-locale-dependent-settings';
 import syncUserPreferences from '@/redux/actions/sync-user-preferences';
+import useSyncQuranScaleWithViewport, {
+  syncQuranScaleWithViewport,
+} from '@/redux/hooks/useSyncQuranScaleWithViewport';
 import remapRemoteFontScale from '@/redux/migration-scripts/migrate-remote-font-scale';
 import { getUserPreferences } from '@/utils/auth/api';
 import { isLoggedIn } from '@/utils/auth/login';
@@ -68,6 +71,8 @@ const ReduxProvider = ({ children, locale }) => {
   const initialLocaleRef = useRef(locale);
   const audioService = useContext(AudioPlayerMachineContext);
 
+  useSyncQuranScaleWithViewport(store);
+
   /**
    * Before the Gate lifts, we want to get the user preferences
    * then store in Redux so that they can be used.
@@ -124,6 +129,7 @@ const ReduxProvider = ({ children, locale }) => {
         // eslint-disable-next-line no-empty
       } catch (error) {}
     }
+    syncQuranScaleWithViewport(store);
   };
 
   return (

--- a/src/redux/hooks/useSyncQuranScaleWithViewport.ts
+++ b/src/redux/hooks/useSyncQuranScaleWithViewport.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+import type { RootState } from '@/redux/RootState';
+import { setQuranTextFontScale } from '@/redux/slices/QuranReader/styles';
+import isClient from '@/utils/isClient';
+import { clampQuranScaleForViewport } from '@/utils/quran-font-scale';
+
+type QuranScaleStore = {
+  getState: () => RootState;
+  dispatch: (action: ReturnType<typeof setQuranTextFontScale>) => void;
+  subscribe: (listener: () => void) => () => void;
+};
+
+export const syncQuranScaleWithViewport = (store: QuranScaleStore): void => {
+  if (!isClient) return;
+  const viewportWidth = document.documentElement.clientWidth;
+  const currentScale = store.getState().quranReaderStyles.quranTextFontScale;
+  const nextScale = clampQuranScaleForViewport(currentScale, viewportWidth);
+  if (currentScale !== nextScale) {
+    store.dispatch(setQuranTextFontScale(nextScale));
+  }
+};
+
+const useSyncQuranScaleWithViewport = (store: QuranScaleStore): void => {
+  useEffect(() => {
+    if (!isClient) return undefined;
+
+    const sync = () => {
+      syncQuranScaleWithViewport(store);
+    };
+
+    sync();
+    const unsubscribe = store.subscribe(sync);
+    window.addEventListener('resize', sync);
+
+    return () => {
+      unsubscribe();
+      window.removeEventListener('resize', sync);
+    };
+  }, [store]);
+};
+
+export default useSyncQuranScaleWithViewport;

--- a/src/redux/slices/QuranReader/styles.ts
+++ b/src/redux/slices/QuranReader/styles.ts
@@ -34,6 +34,10 @@ export const quranReaderStylesSlice = createSlice({
       ...state,
       quranTextFontScale: state.quranTextFontScale + 1,
     }),
+    setQuranTextFontScale: (state, action: PayloadAction<number>) => ({
+      ...state,
+      quranTextFontScale: action.payload,
+    }),
     decreaseQuranTextFontScale: (state) => ({
       ...state,
       quranTextFontScale: state.quranTextFontScale - 1,
@@ -164,6 +168,7 @@ export const {
   setQuranFont,
   increaseQuranTextFontScale,
   decreaseQuranTextFontScale,
+  setQuranTextFontScale,
   increaseTranslationFontScale,
   decreaseTranslationFontScale,
   increaseWordByWordFontScale,

--- a/src/utils/quran-font-scale.test.ts
+++ b/src/utils/quran-font-scale.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MOBILE_FONT_SCALE_CAP,
+  clampQuranScaleForViewport,
+  getMaxQuranScaleForViewport,
+} from './quran-font-scale';
+
+describe('quran-font-scale', () => {
+  describe('getMaxQuranScaleForViewport', () => {
+    it('returns mobile cap for widths < 768', () => {
+      expect(getMaxQuranScaleForViewport(320)).toBe(MOBILE_FONT_SCALE_CAP);
+      expect(getMaxQuranScaleForViewport(375)).toBe(MOBILE_FONT_SCALE_CAP);
+      expect(getMaxQuranScaleForViewport(390)).toBe(MOBILE_FONT_SCALE_CAP);
+      expect(getMaxQuranScaleForViewport(767)).toBe(MOBILE_FONT_SCALE_CAP);
+    });
+
+    it('returns desktop max for widths >= 768', () => {
+      expect(getMaxQuranScaleForViewport(768)).toBe(10);
+      expect(getMaxQuranScaleForViewport(1200)).toBe(10);
+    });
+  });
+
+  describe('clampQuranScaleForViewport', () => {
+    it('clamps values above the mobile cap', () => {
+      expect(clampQuranScaleForViewport(10, 320)).toBe(MOBILE_FONT_SCALE_CAP);
+      expect(clampQuranScaleForViewport(10, 500)).toBe(MOBILE_FONT_SCALE_CAP);
+    });
+
+    it('preserves values at or below the viewport cap', () => {
+      expect(clampQuranScaleForViewport(3, 320)).toBe(3);
+      expect(clampQuranScaleForViewport(3, 500)).toBe(3);
+      expect(clampQuranScaleForViewport(8, 1024)).toBe(8);
+    });
+  });
+});

--- a/src/utils/quran-font-scale.ts
+++ b/src/utils/quran-font-scale.ts
@@ -1,0 +1,12 @@
+const MOBILE_WIDTH = 768;
+const DESKTOP_FONT_SCALE_CAP = 10;
+
+export const MOBILE_FONT_SCALE_CAP = 3;
+
+export const getMaxQuranScaleForViewport = (viewportWidth: number): number => {
+  if (viewportWidth < MOBILE_WIDTH) return MOBILE_FONT_SCALE_CAP;
+  return DESKTOP_FONT_SCALE_CAP;
+};
+
+export const clampQuranScaleForViewport = (scale: number, viewportWidth: number): number =>
+  Math.min(scale, getMaxQuranScaleForViewport(viewportWidth));


### PR DESCRIPTION
## Summary

Closes: [QF-4707](https://quranfoundation.atlassian.net/browse/QF-4707)

- Enforce a stable mobile Quran font size cap of `3` on all mobile widths (`<768px`) to prevent mushaf line misalignment.
- Apply the same cap in both:
  - Settings selector behavior (increment disabled at max)
  - Runtime viewport sync (clamps oversized persisted values)
- Cover both guest and logged-in paths:
  - Guest/local persisted Redux values
  - Logged-in remote preferences after sync
- Extract viewport sync logic into a dedicated Redux hook for cleaner `Provider` code.

## Test Plan

- [x] `npx eslint src/redux/Provider.tsx src/redux/hooks/useSyncQuranScaleWithViewport.ts src/components/Navbar/SettingsDrawer/QuranFontSection.tsx src/redux/slices/QuranReader/styles.ts src/utils/quran-font-scale.ts src/utils/quran-font-scale.test.ts`
- [x] `npx vitest run src/utils/quran-font-scale.test.ts src/redux/migration-scripts/remap-font-scale.test.ts src/redux/migration-scripts/migrate-default-scale.test.ts src/redux/migrations.test.ts`
- [x] Manual QA:
  - [x] On mobile widths `<768px`, Quran font scale does not increase above `3`.
  - [x] On tablet/desktop widths `>=768px`, behavior remains unchanged (up to `10`).

[QF-4707]: https://quranfoundation.atlassian.net/browse/QF-4707
