### PR TITLE
[QF-4710] Align Pinned Modals With Study Mode Back Behavior

### DIFF
--- a/src/components/QuranReader/PinnedVerses/LoadFromCollectionModal/index.tsx
+++ b/src/components/QuranReader/PinnedVerses/LoadFromCollectionModal/index.tsx
@@ -27,9 +27,14 @@ import { Collection } from 'types/Collection';
 interface LoadFromCollectionModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onBack?: () => void;
 }
 
-const LoadFromCollectionModal: React.FC<LoadFromCollectionModalProps> = ({ isOpen, onClose }) => {
+const LoadFromCollectionModal: React.FC<LoadFromCollectionModalProps> = ({
+  isOpen,
+  onClose,
+  onBack,
+}) => {
   const { t } = useTranslation('quran-reader');
   const dispatch = useDispatch();
   const toast = useToast();
@@ -95,7 +100,11 @@ const LoadFromCollectionModal: React.FC<LoadFromCollectionModalProps> = ({ isOpe
     >
       <Modal.Body>
         <div className={styles.container}>
-          <SaveBookmarkModalHeader title={t('load-from-collection')} onClose={onClose} />
+          <SaveBookmarkModalHeader
+            title={t('load-from-collection')}
+            onClose={onClose}
+            onBack={onBack}
+          />
           <CollectionsList
             collections={sortedCollections}
             isDataReady={!isLoadingCollections}

--- a/src/components/QuranReader/PinnedVerses/SavePinnedToCollectionModal/index.tsx
+++ b/src/components/QuranReader/PinnedVerses/SavePinnedToCollectionModal/index.tsx
@@ -14,11 +14,13 @@ import Modal from '@/dls/Modal/Modal';
 interface SavePinnedToCollectionModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onBack?: () => void;
 }
 
 const SavePinnedToCollectionModal: React.FC<SavePinnedToCollectionModalProps> = ({
   isOpen,
   onClose,
+  onBack,
 }) => {
   const { t } = useTranslation('common');
 
@@ -58,7 +60,11 @@ const SavePinnedToCollectionModal: React.FC<SavePinnedToCollectionModalProps> = 
           />
         ) : (
           <div className={styles.container}>
-            <SaveBookmarkModalHeader title={t('save-to-collection')} onClose={onClose} />
+            <SaveBookmarkModalHeader
+              title={t('save-to-collection')}
+              onClose={onClose}
+              onBack={onBack}
+            />
             <CollectionsList
               collections={collectionItems}
               isDataReady={!isLoading}

--- a/src/components/QuranReader/PinnedVersesBar/index.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/index.tsx
@@ -1,22 +1,23 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext } from 'react';
 
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
-import LoadFromCollectionModal from '../PinnedVerses/LoadFromCollectionModal';
-import SavePinnedToCollectionModal from '../PinnedVerses/SavePinnedToCollectionModal';
 import copyPinnedVerses from '../PinnedVerses/utils/copyPinnedVerses';
 
 import styles from './PinnedVersesBar.module.scss';
 import PinnedVersesContent from './PinnedVersesContent';
 
-import AddNoteModal from '@/components/Notes/modal/AddNoteModal';
 import DataContext from '@/contexts/DataContext';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
 import usePinnedVerseSync from '@/hooks/usePinnedVerseSync';
 import { selectPinnedVerses, selectPinnedVerseKeys } from '@/redux/slices/QuranReader/pinnedVerses';
+import {
+  openPinnedVersesModal,
+  PinnedVersesModalType,
+} from '@/redux/slices/QuranReader/pinnedVersesModal';
 import { selectIsSidebarNavigationVisible } from '@/redux/slices/QuranReader/sidebarNavigation';
 import { openStudyMode } from '@/redux/slices/QuranReader/studyMode';
 import { selectSelectedTranslations } from '@/redux/slices/QuranReader/translations';
@@ -38,10 +39,6 @@ const PinnedVersesBar: React.FC = () => {
   const isSidebarNavigationVisible = useSelector(selectIsSidebarNavigationVisible);
 
   const { unpinVerseWithSync, clearPinnedWithSync } = usePinnedVerseSync();
-  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
-  const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
-  const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
-
   const handleCompareClick = useCallback(() => {
     logButtonClick('pinned_bar_compare');
     if (pinnedVerseKeys.length > 0) {
@@ -56,8 +53,8 @@ const PinnedVersesBar: React.FC = () => {
       router.push(getLoginNavigationUrl(router.asPath));
       return;
     }
-    setIsLoadModalOpen(true);
-  }, [router]);
+    dispatch(openPinnedVersesModal({ modalType: PinnedVersesModalType.LOAD_FROM_COLLECTION }));
+  }, [dispatch, router]);
 
   const handleCopy = useCallback(async () => {
     logButtonClick('pinned_menu_copy');
@@ -107,8 +104,8 @@ const PinnedVersesBar: React.FC = () => {
       router.push(getLoginNavigationUrl(router.asPath));
       return;
     }
-    setIsSaveModalOpen(true);
-  }, [router]);
+    dispatch(openPinnedVersesModal({ modalType: PinnedVersesModalType.SAVE_TO_COLLECTION }));
+  }, [dispatch, router]);
 
   const handleAddNote = useCallback(() => {
     logButtonClick('pinned_menu_add_note');
@@ -117,8 +114,8 @@ const PinnedVersesBar: React.FC = () => {
       return;
     }
 
-    setIsNoteModalOpen(true);
-  }, [router]);
+    dispatch(openPinnedVersesModal({ modalType: PinnedVersesModalType.ADD_NOTE }));
+  }, [dispatch, router]);
 
   if (pinnedVerses.length === 0) return null;
 
@@ -143,26 +140,6 @@ const PinnedVersesBar: React.FC = () => {
           onAddNote={handleAddNote}
         />
       </div>
-
-      {isLoggedIn() && (
-        <>
-          <SavePinnedToCollectionModal
-            isOpen={isSaveModalOpen}
-            onClose={() => setIsSaveModalOpen(false)}
-          />
-          <LoadFromCollectionModal
-            isOpen={isLoadModalOpen}
-            onClose={() => setIsLoadModalOpen(false)}
-          />
-          <AddNoteModal
-            showRanges
-            isModalOpen={isNoteModalOpen}
-            onModalClose={() => setIsNoteModalOpen(false)}
-            onMyNotes={() => setIsNoteModalOpen(false)}
-            verseKeys={pinnedVerseKeys}
-          />
-        </>
-      )}
     </>
   );
 };

--- a/src/components/QuranReader/PinnedVersesBar/index.tsx
+++ b/src/components/QuranReader/PinnedVersesBar/index.tsx
@@ -120,27 +120,25 @@ const PinnedVersesBar: React.FC = () => {
   if (pinnedVerses.length === 0) return null;
 
   return (
-    <>
-      <div
-        className={classNames(styles.container, {
-          [styles.withSidebarNavigation]: isSidebarNavigationVisible,
-        })}
-      >
-        <PinnedVersesContent
-          pinnedVerses={pinnedVerses}
-          selectedVerseKey={null}
-          showCompareButton
-          onVerseTagClick={handleVerseTagClick}
-          onRemoveVerse={handleRemoveVerse}
-          onCompareClick={handleCompareClick}
-          onClear={handleClear}
-          onSaveToCollection={handleSaveToCollection}
-          onLoadFromCollection={handleLoadFromCollection}
-          onCopy={handleCopy}
-          onAddNote={handleAddNote}
-        />
-      </div>
-    </>
+    <div
+      className={classNames(styles.container, {
+        [styles.withSidebarNavigation]: isSidebarNavigationVisible,
+      })}
+    >
+      <PinnedVersesContent
+        pinnedVerses={pinnedVerses}
+        selectedVerseKey={null}
+        showCompareButton
+        onVerseTagClick={handleVerseTagClick}
+        onRemoveVerse={handleRemoveVerse}
+        onCompareClick={handleCompareClick}
+        onClear={handleClear}
+        onSaveToCollection={handleSaveToCollection}
+        onLoadFromCollection={handleLoadFromCollection}
+        onCopy={handleCopy}
+        onAddNote={handleAddNote}
+      />
+    </div>
   );
 };
 

--- a/src/components/QuranReader/PinnedVersesModalContainer/index.tsx
+++ b/src/components/QuranReader/PinnedVersesModalContainer/index.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+
+import AddNoteModal from '@/components/Notes/modal/AddNoteModal';
+import LoadFromCollectionModal from '@/components/QuranReader/PinnedVerses/LoadFromCollectionModal';
+import SavePinnedToCollectionModal from '@/components/QuranReader/PinnedVerses/SavePinnedToCollectionModal';
+import { selectPinnedVerseKeys } from '@/redux/slices/QuranReader/pinnedVerses';
+import {
+  closePinnedVersesModal,
+  PinnedVersesModalType,
+  selectPinnedVersesModalIsOpen,
+  selectPinnedVersesModalStudyModeRestoreState,
+  selectPinnedVersesModalType,
+  selectPinnedVersesModalWasOpenedFromStudyMode,
+} from '@/redux/slices/QuranReader/pinnedVersesModal';
+import {
+  closeStudyMode,
+  openStudyMode,
+  selectStudyModeIsOpen,
+} from '@/redux/slices/QuranReader/studyMode';
+
+const PinnedVersesModalContainer: React.FC = () => {
+  const dispatch = useDispatch();
+  const hasClosedStudyModeRef = useRef(false);
+
+  const isOpen = useSelector(selectPinnedVersesModalIsOpen);
+  const modalType = useSelector(selectPinnedVersesModalType);
+  const wasOpenedFromStudyMode = useSelector(selectPinnedVersesModalWasOpenedFromStudyMode);
+  const studyModeRestoreState = useSelector(selectPinnedVersesModalStudyModeRestoreState);
+  const isStudyModeOpen = useSelector(selectStudyModeIsOpen);
+  const pinnedVerseKeys = useSelector(selectPinnedVerseKeys, shallowEqual);
+
+  useEffect(() => {
+    if (isOpen && wasOpenedFromStudyMode && !hasClosedStudyModeRef.current) {
+      hasClosedStudyModeRef.current = true;
+      if (!studyModeRestoreState?.isSsrMode && isStudyModeOpen) {
+        dispatch(closeStudyMode());
+      }
+    }
+  }, [dispatch, isOpen, isStudyModeOpen, studyModeRestoreState, wasOpenedFromStudyMode]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      hasClosedStudyModeRef.current = false;
+    }
+  }, [isOpen]);
+
+  const handleBackToStudyMode = useCallback(() => {
+    dispatch(closePinnedVersesModal());
+
+    if (studyModeRestoreState?.isSsrMode) {
+      return;
+    }
+
+    if (studyModeRestoreState) {
+      dispatch(
+        openStudyMode({
+          verseKey: studyModeRestoreState.verseKey,
+          activeTab: studyModeRestoreState.activeTab,
+          highlightedWordLocation: studyModeRestoreState.highlightedWordLocation,
+          showPinnedSection: studyModeRestoreState.showPinnedSection,
+        }),
+      );
+    }
+  }, [dispatch, studyModeRestoreState]);
+
+  const handleClose = useCallback(() => {
+    if (wasOpenedFromStudyMode) {
+      handleBackToStudyMode();
+    } else {
+      dispatch(closePinnedVersesModal());
+    }
+  }, [dispatch, handleBackToStudyMode, wasOpenedFromStudyMode]);
+
+  if (!isOpen || !modalType) {
+    return null;
+  }
+
+  const shouldShowBack = wasOpenedFromStudyMode;
+
+  if (modalType === PinnedVersesModalType.SAVE_TO_COLLECTION) {
+    return (
+      <SavePinnedToCollectionModal
+        isOpen={isOpen}
+        onClose={handleClose}
+        onBack={shouldShowBack ? handleBackToStudyMode : undefined}
+      />
+    );
+  }
+
+  if (modalType === PinnedVersesModalType.LOAD_FROM_COLLECTION) {
+    return (
+      <LoadFromCollectionModal
+        isOpen={isOpen}
+        onClose={handleClose}
+        onBack={shouldShowBack ? handleBackToStudyMode : undefined}
+      />
+    );
+  }
+
+  if (modalType === PinnedVersesModalType.ADD_NOTE) {
+    return (
+      <AddNoteModal
+        showRanges
+        isModalOpen={isOpen}
+        onModalClose={handleClose}
+        onMyNotes={handleClose}
+        onBack={shouldShowBack ? handleBackToStudyMode : undefined}
+        verseKeys={pinnedVerseKeys}
+      />
+    );
+  }
+
+  return null;
+};
+
+export default PinnedVersesModalContainer;

--- a/src/components/QuranReader/QuranReaderView.tsx
+++ b/src/components/QuranReader/QuranReaderView.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 
 import useSyncReadingProgress from './hooks/useSyncReadingProgress';
+import PinnedVersesModalContainer from './PinnedVersesModalContainer';
 import StudyModeContainer from './StudyModeContainer';
 import TranslationView from './TranslationView';
 import VerseActionModalContainer from './VerseActionModalContainer';
@@ -47,6 +48,7 @@ const QuranReaderView: React.FC<Props> = ({
         />
         <StudyModeContainer />
         <VerseActionModalContainer />
+        <PinnedVersesModalContainer />
       </>
     );
   }
@@ -61,6 +63,7 @@ const QuranReaderView: React.FC<Props> = ({
       />
       <StudyModeContainer />
       <VerseActionModalContainer />
+      <PinnedVersesModalContainer />
     </>
   );
 };

--- a/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/index.tsx
@@ -105,23 +105,21 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
   }
 
   return (
-    <>
-      <div className={styles.pinnedSection}>
-        <PinnedVersesContent
-          pinnedVerses={pinnedVerses}
-          selectedVerseKey={currentStudyModeVerseKey}
-          showCompareButton={false}
-          noPadding
-          onVerseTagClick={handleVerseTagClick}
-          onRemoveVerse={handleRemoveVerse}
-          onClear={handleClear}
-          onSaveToCollection={handleSaveToCollection}
-          onLoadFromCollection={handleLoadFromCollection}
-          onCopy={handleCopy}
-          onAddNote={handleAddNote}
-        />
-      </div>
-    </>
+    <div className={styles.pinnedSection}>
+      <PinnedVersesContent
+        pinnedVerses={pinnedVerses}
+        selectedVerseKey={currentStudyModeVerseKey}
+        showCompareButton={false}
+        noPadding
+        onVerseTagClick={handleVerseTagClick}
+        onRemoveVerse={handleRemoveVerse}
+        onClear={handleClear}
+        onSaveToCollection={handleSaveToCollection}
+        onLoadFromCollection={handleLoadFromCollection}
+        onCopy={handleCopy}
+        onAddNote={handleAddNote}
+      />
+    </div>
   );
 };
 

--- a/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/index.tsx
@@ -1,24 +1,30 @@
-import React, { useContext, useState } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
-import { shallowEqual, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import styles from './PinnedVersesSection.module.scss';
 import usePinnedVerseHandlers from './usePinnedVerseHandlers';
 
-import AddNoteModal from '@/components/Notes/modal/AddNoteModal';
-import LoadFromCollectionModal from '@/components/QuranReader/PinnedVerses/LoadFromCollectionModal';
-import SavePinnedToCollectionModal from '@/components/QuranReader/PinnedVerses/SavePinnedToCollectionModal';
 import PinnedVersesContent from '@/components/QuranReader/PinnedVersesBar/PinnedVersesContent';
 import DataContext from '@/contexts/DataContext';
 import { useToast } from '@/dls/Toast/Toast';
 import usePinnedVerseSync from '@/hooks/usePinnedVerseSync';
 import { selectPinnedVerses } from '@/redux/slices/QuranReader/pinnedVerses';
-import { selectStudyModeVerseKey } from '@/redux/slices/QuranReader/studyMode';
+import {
+  openPinnedVersesModal,
+  PinnedVersesModalType,
+} from '@/redux/slices/QuranReader/pinnedVersesModal';
+import {
+  selectStudyModeActiveTab,
+  selectStudyModeHighlightedWordLocation,
+  selectStudyModeIsSsrMode,
+  selectStudyModeShowPinnedSection,
+  selectStudyModeVerseKey,
+} from '@/redux/slices/QuranReader/studyMode';
 import { selectSelectedTranslations } from '@/redux/slices/QuranReader/translations';
 import { areArraysEqual } from '@/utils/array';
-import { isLoggedIn } from '@/utils/auth/login';
 import ChaptersData from 'types/ChaptersData';
 
 interface PinnedVersesSectionProps {
@@ -28,17 +34,49 @@ interface PinnedVersesSectionProps {
 const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }) => {
   const { t, lang } = useTranslation('quran-reader');
   const router = useRouter();
+  const dispatch = useDispatch();
   const toast = useToast();
   const chaptersData = useContext(DataContext) as ChaptersData;
 
   const pinnedVerses = useSelector(selectPinnedVerses, shallowEqual);
   const currentStudyModeVerseKey = useSelector(selectStudyModeVerseKey);
+  const studyModeActiveTab = useSelector(selectStudyModeActiveTab);
+  const studyModeHighlightedWordLocation = useSelector(selectStudyModeHighlightedWordLocation);
+  const studyModeIsSsrMode = useSelector(selectStudyModeIsSsrMode);
+  const studyModeShowPinnedSection = useSelector(selectStudyModeShowPinnedSection);
   const selectedTranslations = useSelector(selectSelectedTranslations, areArraysEqual) as number[];
 
-  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
-  const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
-  const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
   const { unpinVerseWithSync, clearPinnedWithSync } = usePinnedVerseSync();
+
+  const studyModeRestoreState = useMemo(() => {
+    if (!currentStudyModeVerseKey) return null;
+    return {
+      verseKey: currentStudyModeVerseKey,
+      activeTab: studyModeActiveTab,
+      highlightedWordLocation: studyModeHighlightedWordLocation,
+      isSsrMode: studyModeIsSsrMode,
+      showPinnedSection: studyModeShowPinnedSection,
+    };
+  }, [
+    currentStudyModeVerseKey,
+    studyModeActiveTab,
+    studyModeHighlightedWordLocation,
+    studyModeIsSsrMode,
+    studyModeShowPinnedSection,
+  ]);
+
+  const openPinnedModal = useCallback(
+    (modalType: PinnedVersesModalType) => {
+      dispatch(
+        openPinnedVersesModal({
+          modalType,
+          wasOpenedFromStudyMode: Boolean(studyModeRestoreState),
+          studyModeRestoreState: studyModeRestoreState ?? undefined,
+        }),
+      );
+    },
+    [dispatch, studyModeRestoreState],
+  );
 
   const {
     handleVerseTagClick,
@@ -56,9 +94,7 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
     lang,
     chaptersData,
     selectedTranslations,
-    setIsSaveModalOpen,
-    setIsLoadModalOpen,
-    setIsNoteModalOpen,
+    openPinnedModal,
     unpinVerseWithSync,
     clearPinnedWithSync,
     onGoToVerse,
@@ -67,12 +103,6 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
   if (pinnedVerses.length === 0) {
     return null;
   }
-
-  const pinnedVerseKeys = pinnedVerses.map((v) => v.verseKey);
-
-  const handleNoteModalClose = () => {
-    setIsNoteModalOpen(false);
-  };
 
   return (
     <>
@@ -91,26 +121,6 @@ const PinnedVersesSection: React.FC<PinnedVersesSectionProps> = ({ onGoToVerse }
           onAddNote={handleAddNote}
         />
       </div>
-
-      {isLoggedIn() && (
-        <>
-          <SavePinnedToCollectionModal
-            isOpen={isSaveModalOpen}
-            onClose={() => setIsSaveModalOpen(false)}
-          />
-          <LoadFromCollectionModal
-            isOpen={isLoadModalOpen}
-            onClose={() => setIsLoadModalOpen(false)}
-          />
-          <AddNoteModal
-            showRanges
-            isModalOpen={isNoteModalOpen}
-            onModalClose={handleNoteModalClose}
-            onMyNotes={handleNoteModalClose}
-            verseKeys={pinnedVerseKeys}
-          />
-        </>
-      )}
     </>
   );
 };

--- a/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/usePinnedVerseHandlers.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/PinnedVersesSection/usePinnedVerseHandlers.ts
@@ -6,6 +6,7 @@ import useTranslation from 'next-translate/useTranslation';
 import copyPinnedVerses from '@/components/QuranReader/PinnedVerses/utils/copyPinnedVerses';
 import { ToastStatus, useToast } from '@/dls/Toast/Toast';
 import { PinnedVerse } from '@/redux/slices/QuranReader/pinnedVerses';
+import { PinnedVersesModalType } from '@/redux/slices/QuranReader/pinnedVersesModal';
 import { isLoggedIn } from '@/utils/auth/login';
 import { logButtonClick } from '@/utils/eventLogger';
 import { getLoginNavigationUrl } from '@/utils/navigation';
@@ -19,9 +20,7 @@ interface UsePinnedVerseHandlersProps {
   lang: string;
   chaptersData: ChaptersData;
   selectedTranslations: number[];
-  setIsSaveModalOpen: (isOpen: boolean) => void;
-  setIsLoadModalOpen: (isOpen: boolean) => void;
-  setIsNoteModalOpen: (isOpen: boolean) => void;
+  openPinnedModal: (modalType: PinnedVersesModalType) => void;
   unpinVerseWithSync: (verseKey: string) => Promise<void>;
   clearPinnedWithSync: () => Promise<void>;
   onGoToVerse: (chapterId: string, verseNumber: string) => void;
@@ -35,9 +34,7 @@ const usePinnedVerseHandlers = ({
   lang,
   chaptersData,
   selectedTranslations,
-  setIsSaveModalOpen,
-  setIsLoadModalOpen,
-  setIsNoteModalOpen,
+  openPinnedModal,
   unpinVerseWithSync,
   clearPinnedWithSync,
   onGoToVerse,
@@ -79,8 +76,8 @@ const usePinnedVerseHandlers = ({
       router.push(getLoginNavigationUrl(router.asPath));
       return;
     }
-    setIsSaveModalOpen(true);
-  }, [router, setIsSaveModalOpen]);
+    openPinnedModal(PinnedVersesModalType.SAVE_TO_COLLECTION);
+  }, [openPinnedModal, router]);
 
   const handleLoadFromCollection = useCallback(() => {
     logButtonClick('study_mode_load_from_collection');
@@ -88,8 +85,8 @@ const usePinnedVerseHandlers = ({
       router.push(getLoginNavigationUrl(router.asPath));
       return;
     }
-    setIsLoadModalOpen(true);
-  }, [router, setIsLoadModalOpen]);
+    openPinnedModal(PinnedVersesModalType.LOAD_FROM_COLLECTION);
+  }, [openPinnedModal, router]);
 
   const handleAddNote = useCallback(() => {
     logButtonClick('study_mode_add_note');
@@ -97,8 +94,8 @@ const usePinnedVerseHandlers = ({
       router.push(getLoginNavigationUrl(router.asPath));
       return;
     }
-    setIsNoteModalOpen(true);
-  }, [router, setIsNoteModalOpen]);
+    openPinnedModal(PinnedVersesModalType.ADD_NOTE);
+  }, [openPinnedModal, router]);
 
   const handleCopy = useCallback(async () => {
     logButtonClick('study_mode_copy_pinned');

--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeSsrContainerView.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeSsrContainerView.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { StudyModeTabId } from './StudyModeBottomActions';
 import StudyModeSsrModalContent from './StudyModeSsrModalContent';
 
+import PinnedVersesModalContainer from '@/components/QuranReader/PinnedVersesModalContainer';
 import VerseActionModalContainer from '@/components/QuranReader/VerseActionModalContainer';
 import { AyahHadithsResponse } from '@/types/Hadith';
 import AyahQuestionsResponse from '@/types/QuestionsAndAnswers/AyahQuestionsResponse';
@@ -54,6 +55,7 @@ const StudyModeSsrContainerView: React.FC<StudyModeSsrContainerViewProps> = (pro
     <>
       <StudyModeSsrModalContent {...props} />
       <VerseActionModalContainer />
+      <PinnedVersesModalContainer />
     </>
   );
 };

--- a/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeSsrContainerView.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/StudyModeSsrContainerView.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { StudyModeTabId } from './StudyModeBottomActions';
 import StudyModeSsrModalContent from './StudyModeSsrModalContent';
 
-import PinnedVersesModalContainer from '@/components/QuranReader/PinnedVersesModalContainer';
 import VerseActionModalContainer from '@/components/QuranReader/VerseActionModalContainer';
 import { AyahHadithsResponse } from '@/types/Hadith';
 import AyahQuestionsResponse from '@/types/QuestionsAndAnswers/AyahQuestionsResponse';
@@ -55,7 +54,6 @@ const StudyModeSsrContainerView: React.FC<StudyModeSsrContainerViewProps> = (pro
     <>
       <StudyModeSsrModalContent {...props} />
       <VerseActionModalContainer />
-      <PinnedVersesModalContainer />
     </>
   );
 };

--- a/src/redux/slices/QuranReader/pinnedVersesModal.ts
+++ b/src/redux/slices/QuranReader/pinnedVersesModal.ts
@@ -1,0 +1,65 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { StudyModeTabId } from '@/components/QuranReader/ReadingView/StudyModeModal/StudyModeBottomActions';
+import { RootState } from '@/redux/RootState';
+import SliceName from '@/redux/types/SliceName';
+
+export enum PinnedVersesModalType {
+  SAVE_TO_COLLECTION = 'saveToCollection',
+  LOAD_FROM_COLLECTION = 'loadFromCollection',
+  ADD_NOTE = 'addNote',
+}
+
+export type PinnedVersesStudyModeRestoreState = {
+  verseKey: string;
+  activeTab: StudyModeTabId | null;
+  highlightedWordLocation: string | null;
+  isSsrMode?: boolean;
+  showPinnedSection?: boolean;
+};
+
+export type PinnedVersesModalState = {
+  isOpen: boolean;
+  modalType: PinnedVersesModalType | null;
+  wasOpenedFromStudyMode: boolean;
+  studyModeRestoreState: PinnedVersesStudyModeRestoreState | null;
+};
+
+export const initialState: PinnedVersesModalState = {
+  isOpen: false,
+  modalType: null,
+  wasOpenedFromStudyMode: false,
+  studyModeRestoreState: null,
+};
+
+export type OpenPinnedVersesModalPayload = {
+  modalType: PinnedVersesModalType;
+  wasOpenedFromStudyMode?: boolean;
+  studyModeRestoreState?: PinnedVersesStudyModeRestoreState;
+};
+
+const pinnedVersesModal = createSlice({
+  name: SliceName.PINNED_VERSES_MODAL,
+  initialState,
+  reducers: {
+    openPinnedVersesModal: (state, { payload }: PayloadAction<OpenPinnedVersesModalPayload>) => ({
+      ...initialState,
+      isOpen: true,
+      modalType: payload.modalType,
+      wasOpenedFromStudyMode: payload.wasOpenedFromStudyMode ?? false,
+      studyModeRestoreState: payload.studyModeRestoreState ?? null,
+    }),
+    closePinnedVersesModal: () => initialState,
+  },
+});
+
+export const selectPinnedVersesModalIsOpen = (state: RootState) => state.pinnedVersesModal.isOpen;
+export const selectPinnedVersesModalType = (state: RootState) => state.pinnedVersesModal.modalType;
+export const selectPinnedVersesModalWasOpenedFromStudyMode = (state: RootState) =>
+  state.pinnedVersesModal.wasOpenedFromStudyMode;
+export const selectPinnedVersesModalStudyModeRestoreState = (state: RootState) =>
+  state.pinnedVersesModal.studyModeRestoreState;
+
+export const { openPinnedVersesModal, closePinnedVersesModal } = pinnedVersesModal.actions;
+
+export default pinnedVersesModal.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -34,6 +34,7 @@ import contextMenu from './slices/QuranReader/contextMenu';
 import fontFaces from './slices/QuranReader/font-faces';
 import notes from './slices/QuranReader/notes';
 import pinnedVerses from './slices/QuranReader/pinnedVerses';
+import pinnedVersesModal from './slices/QuranReader/pinnedVersesModal';
 import readingPreferences from './slices/QuranReader/readingPreferences';
 import readingTracker from './slices/QuranReader/readingTracker';
 import readingViewVerse from './slices/QuranReader/readingViewVerse';
@@ -117,6 +118,7 @@ export const rootReducer = combineReducers({
   studyMode,
   verseActionModal,
   pinnedVerses,
+  pinnedVersesModal,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/redux/types/SliceName.ts
+++ b/src/redux/types/SliceName.ts
@@ -35,6 +35,7 @@ enum SliceName {
   VERSE_ACTION_MODAL = 'verseActionModal',
   AYAH_WIDGET = 'ayahWidget',
   PINNED_VERSES = 'pinnedVerses',
+  PINNED_VERSES_MODAL = 'pinnedVersesModal',
 }
 
 export default SliceName;


### PR DESCRIPTION


## Summary

Unifies pinned-verses modals with the Study Mode modal flow so they close the parent modal, render as a standalone modal, and restore Study Mode via the header back action when opened from it.

Closes: [QF-4710](https://quranfoundation.atlassian.net/browse/QF-4710)

---

## Problems & Root Causes

### 1. Pinned modals overlapped Study Mode and lacked back navigation

**Problem:** When opening Save/Load/Add Note for pinned verses from Study Mode, the modal appeared on top of Study Mode without closing it, and there was no back header to return to the originating Study Mode state.

**Root Cause:** Pinned-verses modals were controlled by local component state inside the pinned section, so they bypassed the centralized modal behavior used by other verse actions. As a result, Study Mode never closed and there was no restore/back handling.

---

## Solution Approach

### 1. Centralized pinned-verses modal state + container

Introduced a dedicated Redux slice and a global container to mirror the existing verse-action modal behavior. The container closes Study Mode on open (when launched from it), and restores it on back/close with the saved verse/tab/word state.

### 2. Consistent entry points + back headers

Updated pinned-verses actions (bar + Study Mode section) to dispatch the new modal actions and pass Study Mode restore state. Added optional back header wiring to the Save/Load pinned modals so the UI matches other Study Mode-launched modals.

---

## Type of Change

- [x] ?? Bug fix (non-breaking change which fixes an issue)
- [ ] ? New feature (non-breaking change which adds functionality)
- [ ] ?? Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ?? Documentation update
- [ ] ?? Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [ ] If multiple changes were needed, they are split into separate PRs

## Test Plan
- [x] Manual testing performed

**Testing steps:**

1. **Pinned modals from Study Mode**
   - Open Study Mode for any verse.
   - Open pinned verses section and click **Save to Collection**, **Load from Collection**, and **Add Note**.
   - Verify Study Mode closes and the modal opens as standalone.
   - Click the back header and confirm Study Mode restores to the previous verse/tab/word state.

2. **Pinned modals from page-level pinned bar**
   - Open the pinned bar in the reader header.
   - Open **Save to Collection**, **Load from Collection**, and **Add Note**.
   - Verify the modal opens normally and closes without reopening Study Mode.

### Edge Cases Verified

- [x] Empty state handled
- [x] Loading state handled
- [x] Error state handled
- [x] RTL layout verified (if UI changes)
- [x] Logged-in vs guest behavior (if auth-related)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No `any` types used (or justified if unavoidable)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [x] All tests pass locally (`yarn test`)
- [x] Linting passes (`yarn lint`)
- [x] Build succeeds (`yarn build`)

### Localization (if UI changes)

- [x] All user-facing text uses `next-translate`
- [x] RTL layout verified

## AI Assistance Disclosure
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code


[QF-4710]: https://quranfoundation.atlassian.net/browse/QF-4710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ