### PR TITLE
fix(audio): harden word playback cleanup and resolve Sentry issue #1971

### DIFF
--- a/src/components/dls/QuranWord/playFromWord.ts
+++ b/src/components/dls/QuranWord/playFromWord.ts
@@ -25,14 +25,15 @@ const playAndSeekAfterLoad = (word: Word, audioService: AudioService): (() => vo
   audioService.send({ type: 'PLAY_AYAH', surah: wordSurah, ayahNumber: verseNumber });
 
   let unsubscribed = false;
+  let subscription: ReturnType<AudioService['subscribe']> | null = null;
   const cleanup = () => {
-    if (!unsubscribed) {
-      subscription.unsubscribe();
-      unsubscribed = true;
-      activeCleanup = null;
-    }
+    if (unsubscribed) return;
+    unsubscribed = true;
+    subscription?.unsubscribe();
+    subscription = null;
+    if (activeCleanup === cleanup) activeCleanup = null;
   };
-  const subscription = audioService.subscribe((state) => {
+  subscription = audioService.subscribe((state) => {
     if (unsubscribed) return;
     if (
       state.matches('VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING') &&
@@ -44,7 +45,10 @@ const playAndSeekAfterLoad = (word: Word, audioService: AudioService): (() => vo
       cleanup();
     }
   });
-
+  if (unsubscribed) {
+    subscription.unsubscribe();
+    subscription = null;
+  }
   return cleanup;
 };
 


### PR DESCRIPTION

  ## Summary

 Stability polish for word-audio playback that resolves Sentry issue `#1971`.

  Issue:
  A runtime `ReferenceError` could happen in `playFromWord` during audio state transitions.

  Root cause:
  `cleanup()` could run before `subscription` was initialized (temporal dead zone) when `audioService.subscribe(...)` emitted synchronously.

  Approach:
  We now initialize `subscription` safely before use, make cleanup idempotent, and guard post-subscribe cleanup to handle synchronous callbacks cleanly.

fixes: Sentry issue `#1971`

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
        expected)
  - [ ] 📝 Documentation update
  - [ ] ♻️ Refactoring (no functional changes)

  ## Scope Confirmation

  - [x] This PR addresses **one** feature/fix only
  - [x] If multiple changes were needed, they are split into separate PRs

  ## Rollback Safety

  - [x] Can be safely reverted without data issues or migrations
  - [ ] Rollback requires special steps (describe below):

  ## Test Plan

  - [ ] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  **Testing steps:**

 1. Open a chapter page (e.g. `/51` or `/75`) and play word audio.
  2. Pause/play and seek while audio is transitioning.
  3. Confirm no `ReferenceError` in console and no new Sentry events for issue `#1971` on the new release.
 
  ### Edge Cases Verified

  - [x] ❌ Error state handled
  - [x] ⏳ Loading state handled
  - [ ] 📭 Empty state handled
  - [ ] 👤 Logged-in vs guest behavior (if applicable)

  ## Pre-Review Checklist

  ### Code Quality

  - [x] I have performed a **self-review** of my code (file by file)
  - [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
  - [x] No `any` types used (or justified if unavoidable)
  - [x] No unused code, imports, or dead code included
  - [x] Functions are under 30 lines and follow single responsibility

  ### Testing & Validation

  - [ ] All tests pass locally (`yarn test`)
  - [x] Linting passes (`yarn lint`)
  - [ ] Build succeeds (`yarn build`)
  - [x] Edge cases and error scenarios are handled

  ### Documentation

  - [x] Code is self-documenting with clear naming
  - [ ] README updated (if adding features or setup changes)
  - [ ] Inline comments added for complex logic

  ## Reviewer Notes

  Single-file, low-risk fix in:
  `src/components/dls/QuranWord/playFromWord.ts`

  ## AI Assistance Disclosure

  - [ ] AI tools were NOT used for this PR
  - [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code