### PR TITLE
feat: add Quran.AI to footer Our Projects and widen group to prevent text wrap

### DIFF
--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -94,6 +94,12 @@
   }
 }
 
+.ourProjectsGroup {
+  @include breakpoints.tablet {
+    inline-size: 28%;
+  }
+}
+
 .groupTitle {
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-large);

--- a/src/components/dls/Footer/Links.tsx
+++ b/src/components/dls/Footer/Links.tsx
@@ -30,6 +30,7 @@ const Links = () => {
     },
     {
       title: t('our-projects'),
+      className: styles.ourProjectsGroup,
       links: [
         { text: 'Quran.com', url: 'https://quran.com', isExternal: true },
         {
@@ -43,6 +44,7 @@ const Links = () => {
           isExternal: true,
         },
         { text: 'QuranReflect.com', url: 'https://quranreflect.com', isExternal: true },
+        { text: 'Quran.AI', url: 'https://quran.ai', isExternal: true },
         { text: 'Sunnah.com', url: 'https://sunnah.com', isExternal: true },
         { text: 'Nuqayah.com', url: 'https://nuqayah.com', isExternal: true },
         { text: 'Legacy.Quran.com', url: 'https://legacy.quran.com', isExternal: true },
@@ -76,7 +78,7 @@ const Links = () => {
   return (
     <div className={styles.groupListContainer}>
       {linksGroup.map((group) => (
-        <div className={styles.group} key={group.title}>
+        <div className={classNames(styles.group, group.className)} key={group.title}>
           <div className={styles.groupTitle}>{group.title}</div>
           {group.links.map((link) => (
             <div


### PR DESCRIPTION
## Summary

Adds Quran.AI as a new project link in the footer "Our Projects" section and widens the group's `inline-size` from 26% to 28% so that "Quran For Android" no longer wraps to a second line.

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [ ] Manual testing performed

**Testing steps:**

1. Navigate to any page and scroll to the footer
2. Verify "Quran.AI" appears between "QuranReflect.com" and "Sunnah.com" in the "Our Projects" column
3. Click the link and verify it opens https://quran.ai in a new tab
4. On tablet+ viewports, verify "Quran For Android" does not wrap to a second line in the "Our Projects" group

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the project style guidelines
- [x] No unused code, imports, or dead code included

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code