### PR TITLE
close ayah actions popover when repeat audio is triggered

### DIFF
--- a/src/components/Verse/OverflowVerseActionsMenu.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenu.tsx
@@ -93,7 +93,10 @@ const OverflowVerseActionsMenu: React.FC<Props> = ({
         <OverflowVerseActionsMenuBody
           verse={verse}
           isTranslationView={isTranslationView}
-          onActionTriggered={onActionTriggered}
+          onActionTriggered={() => {
+            setIsMenuOpen(false);
+            onActionTriggered?.();
+          }}
           isInsideStudyMode={isInsideStudyMode}
         />
       </PopoverMenu>

--- a/src/components/Verse/OverflowVerseActionsMenuBody/index.tsx
+++ b/src/components/Verse/OverflowVerseActionsMenuBody/index.tsx
@@ -48,7 +48,7 @@ const OverflowVerseActionsMenuBody: React.FC<Props> = ({
         <WordByWordVerseAction verse={verse} onActionTriggered={onActionTriggered} />
       )}
       {!isStudyModeOpen && (
-        <VerseActionRepeatAudio isTranslationView={isTranslationView} verseKey={verse.verseKey} />
+        <VerseActionRepeatAudio isTranslationView={isTranslationView} verseKey={verse.verseKey} onActionTriggered={onActionTriggered} />
       )}
       <TranslationFeedbackAction
         verse={verse}

--- a/src/components/Verse/VerseActionRepeatAudio.tsx
+++ b/src/components/Verse/VerseActionRepeatAudio.tsx
@@ -14,8 +14,9 @@ import { getChapterNumberFromKey } from '@/utils/verse';
 type VerseActionRepeatAudioProps = {
   verseKey: string;
   isTranslationView: boolean;
+  onActionTriggered?: () => void;
 };
-const VerseActionRepeatAudio = ({ verseKey, isTranslationView }: VerseActionRepeatAudioProps) => {
+const VerseActionRepeatAudio = ({ verseKey, isTranslationView, onActionTriggered }: VerseActionRepeatAudioProps) => {
   const { t } = useTranslation('common');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const chapterId = getChapterNumberFromKey(verseKey);
@@ -27,6 +28,7 @@ const VerseActionRepeatAudio = ({ verseKey, isTranslationView }: VerseActionRepe
       logButtonClick('reading_view_verse_actions_menu_repeat');
     }
     setIsModalOpen(true);
+    onActionTriggered?.();
   };
 
   return (


### PR DESCRIPTION
when you tap repeat audio in the ayah actions popover, the popover stays open behind the modal. this fixes that.

the `VerseActionRepeatAudio` component was missing the `onActionTriggered` prop that every other action component already receives and calls to close the popover. wired it up the same way.

fixes #1826