### PR TITLE
fix: center tick icon inside Checkbox indicator

### DIFF
--- a/src/components/dls/Forms/Checkbox/Checkbox.module.scss
+++ b/src/components/dls/Forms/Checkbox/Checkbox.module.scss
@@ -49,6 +49,9 @@
 }
 
 .indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: var(--color-primary-medium);
   border-radius: var(--border-radius-default);
   inline-size: 100%;


### PR DESCRIPTION
## Summary

The tick icon inside the `Checkbox` component was not centered. The `.indicator` element was missing `display: flex` with alignment properties, causing the tick SVG to follow inline baseline alignment rather than being visually centered within the checkbox.

Closes: N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactoring (no functional changes)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only
- [x] If multiple changes were needed, they are split into separate PRs

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. Open Storybook → `dls/Checkbox` → `DefaultCheckbox`, set `checked: true` — tick is centered
2. On quran.com, open Settings → Translations — tick is centered on selected translations
3. Verify checked, indeterminate and disabled states all render correctly

### Edge Cases Verified

- [x] ⏳ Loading state handled
- [x] ❌ Error state handled
- [x] 📭 Empty state handled
- [x] 👤 Logged-in vs guest behavior (if applicable)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] My code follows the [project style guidelines](/.github/copilot-instructions.md)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [x] Linting passes (`yarn lint`)

### Localization (if UI changes)

- [x] RTL layout verified

### Accessibility (if UI changes)

- [x] Keyboard navigation works

## Screenshots/Videos

| Before | After |
| ------ | ----- |
| ![Before](https://raw.githubusercontent.com/Mir-Zairan/quran.com-frontend-next/production/.github/screenshots/before.png) | ![After](https://raw.githubusercontent.com/Mir-Zairan/quran.com-frontend-next/production/.github/screenshots/after.png) |

## AI Assistance Disclosure

- [ ] AI tools were NOT used for this PR
- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code