### PR TITLE
fix: use Kitab for Arabic Ramadan page and search results

### DIFF
--- a/src/components/Search/SearchResults/SearchResultItem/SearchResultText.module.scss
+++ b/src/components/Search/SearchResults/SearchResultItem/SearchResultText.module.scss
@@ -1,5 +1,7 @@
+@use 'src/styles/utility';
+
 .arabic {
-  font-family: UthmanicHafs;
+  @include utility.kitabFontLang;
   direction: rtl;
   inline-size: 100%;
   display: block;

--- a/src/components/Search/SearchResults/SearchResultItem/SearchResultText.module.scss
+++ b/src/components/Search/SearchResults/SearchResultItem/SearchResultText.module.scss
@@ -1,7 +1,5 @@
-@use 'src/styles/utility';
-
 .arabic {
-  @include utility.kitabFontLang;
+  font-family: UthmanicHafs !important;
   direction: rtl;
   inline-size: 100%;
   display: block;
@@ -12,6 +10,7 @@
   line-height: 150%;
   flex-grow: 1;
   em {
+    font-family: inherit !important;
     font-weight: var(--font-weight-bold);
     color: var(--color-highlight-dark);
   }

--- a/src/pages/about-the-quran/AboutTheQuranArabic.module.scss
+++ b/src/pages/about-the-quran/AboutTheQuranArabic.module.scss
@@ -1,4 +1,7 @@
+@use 'src/styles/utility';
+
 .arabicContainer {
+  @include utility.kitabFontHtmlLang;
   text-align: start;
 
   ol {

--- a/src/pages/what-is-ramadan/WhatIsRamadanArabic.module.scss
+++ b/src/pages/what-is-ramadan/WhatIsRamadanArabic.module.scss
@@ -1,4 +1,7 @@
+@use 'src/styles/utility';
+
 .arabicContainer {
+  @include utility.kitabFontHtmlLang;
   text-align: start;
 
   ol {


### PR DESCRIPTION
## Summary
- restore UthmanicHafs for Arabic search result rows
- ensure highlighted matches in Arabic search results inherit UthmanicHafs
- apply the Kitab utility to the Arabic What Is Ramadan page
- apply the Kitab utility to the Arabic About the Quran page
