### PR TITLE
fix: don't link hyphen-only numeric ranges as verse references

### DIFF
--- a/src/utils/string.test.ts
+++ b/src/utils/string.test.ts
@@ -385,11 +385,14 @@ describe('Test formatVerseReferencesToLinks', () => {
     expect(formatVerseReferencesToLinks(input)).toEqual(expected);
   });
 
-  // Additional test cases that match current behavior
-  it('should convert partial verse references', () => {
+  it('should not convert partial or hyphen-only references', () => {
     const input = 'See 1: and :1 and 1-1';
-    const expected = 'See 1: and :1 and <a href="/1-1" target="_blank">1-1</a>';
-    expect(formatVerseReferencesToLinks(input)).toEqual(expected);
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
+  });
+
+  it('should not convert a hyphen-only numeric range inside parentheses', () => {
+    const input = 'See Surah As-Saffat, verses (7-10) for context';
+    expect(formatVerseReferencesToLinks(input)).toEqual(input);
   });
 
   it('should convert dates that look like verse references', () => {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -186,6 +186,8 @@ export const cleanTranscript = (text: string): string => {
 /**
  * Converts verse references in text to clickable links.
  * Example: "1:1" or "1:1-2" or "1:1-2:3" will be converted to HTML anchor tags.
+ * The chapter:verse separator must be ":"; a bare hyphen-only range like
+ * "7-10" is ambiguous and is left as plain text.
  *
  * @param {string} text - The text containing verse references
  * @returns {string} The text with verse references converted to links
@@ -193,7 +195,7 @@ export const cleanTranscript = (text: string): string => {
 export const formatVerseReferencesToLinks = (text: string): string => {
   if (!text) return '';
   return text.replace(
-    /(\d{1,3}[:-]\d{1,3}(?:-\d{1,3}(?::\d{1,3})?)?)(?![^<]*<\/a>)/g,
+    /(\d{1,3}:\d{1,3}(?:-\d{1,3}(?::\d{1,3})?)?)(?![^<]*<\/a>)/g,
     (match) => `<a href="${`/${match}`}" target="_blank">${match}</a>`,
   );
 };


### PR DESCRIPTION
## Summary

Closes: #3267

The verse-reference regex used by `formatVerseReferencesToLinks` (called from
`FootnoteText`) accepted either `:` or `-` as the chapter:verse separator. As
a result, an isolated range like `(7-10)` inside a translation footnote was
rewritten to `/7-10` and routed to Surah 7 — even when the surrounding text
referenced a different Surah (the original report was Hindi Surah Al-Mulk 67:5
referencing As-Saffat 37:7-10).

Tightens the regex to require `:` between chapter and verse so only
conventional references become links: `1:1`, `1:1-3`, `1:1-2:3`. Bare
hyphen-separated numbers are left as plain text.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Test Plan

- [x] Updated the existing "partial verse references" test to expect no link
      for `1-1`.
- [x] Added a regression test for the reported case
      (`See Surah As-Saffat, verses (7-10) for context`).
- [x] `yarn test` — 935 / 935 tests pass.
- [x] `yarn lint` on the two changed files — clean.

**Manual reproduction (before fix):**

1. Open Surah Al-Mulk 67:5 with the Hindi translation by Maulana Azizul Haque al-Umari enabled.
2. Open the footnote for the word "शैतानों".
3. Click the `(7-10)` hyperlink — currently routes to `/7-10` (Surah 7).

After the fix, the `(7-10)` text remains plain (not linked), so the footnote
no longer misroutes.

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations