### PR TITLE
fix: add missing @/styles path alias to storybook's webpack

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -33,7 +33,7 @@ module.exports = {
     ];
 
     // @/ root alias doesn't work in storybook, so we have to write the aliases manually
-    const otherAliases = ["components", "utils", "redux", "hooks", "contexts"];
+    const otherAliases = ["components", "utils", "redux", "hooks", "contexts", "styles"];
 
     // Add support for module aliases (same aliases in tsconfig.json)
     config.resolve.alias = {


### PR DESCRIPTION
## summary

storybook's webpack alias list in `.storybook/main.js` was missing `@/styles`. scss modules using `@use '@/styles/...'` (e.g. `dls/Button`) failed with `SassError: Can't find stylesheet to import`, breaking the storybook preview build.

added `'styles'` to the `otherAliases` array. now matches how next.js resolves the alias via tsconfig paths.

## type of change

- [x] bug fix