### PR TITLE
fix(developers): remove dead Quran.com API project card

### DIFF
--- a/locales/en/developers.json
+++ b/locales/en/developers.json
@@ -39,11 +39,6 @@
         "name": "Quran Android",
         "stack": "Kotlin and Java"
       },
-      "q-api": {
-        "description": "Ruby on Rails backend that powers Quran data, search, and translations.",
-        "name": "Quran.com API",
-        "stack": "Rails, PostgreSQL"
-      },
       "q-audio": {
         "description": "Audio streaming platform and companion mobile apps for recitations.",
         "name": "Quranic Audio",

--- a/src/pages/developers/index.tsx
+++ b/src/pages/developers/index.tsx
@@ -23,7 +23,6 @@ const DevelopersPage: NextPage = () => {
   const { t, lang } = useTranslation('developers');
   const projects = [
     { key: 'q-next', href: 'https://github.com/quran/quran.com-frontend-next' },
-    { key: 'q-api', href: 'https://github.com/quran/quran.com-api' },
     { key: 'q-android', href: 'https://github.com/quran/quran_android' },
     { key: 'q-ios', href: 'https://github.com/quran/quran-ios' },
     { key: 'q-audio', href: 'https://github.com/quran/audio.quran.com' },


### PR DESCRIPTION
## Summary

The **Quran.com API** card in the Developers page → "Our projects" grid links to `https://github.com/quran/quran.com-api`, which now returns a **404** — the public Rails backend repository is no longer available.

Since Quran data, search, and translations are now served by the **Quran Foundation API** (`https://api-docs.quran.foundation`) — which this same page already links to via the API Documentation section — this PR removes the stale, broken project card rather than pointing it at a non-equivalent target.

## Changes

- Remove the `q-api` entry from the `projects` array in `src/pages/developers/index.tsx`.
- Remove the now-orphaned `projects.items.q-api` strings from `locales/en/developers.json` (source locale). Translated locales are managed via Lokalise and will sync automatically.

## Test plan

- [ ] Visit `/developers` and scroll to the "Our projects" section.
- [ ] Confirm the broken "Quran.com API" card no longer appears.
- [ ] Confirm the remaining cards (Frontend, Android, iOS, Quranic Audio) render and link correctly.

Closes #3235