### PR TITLE
fix(quran-reader): reset scroll when navigating from end-of-surah card

### DIFF
--- a/src/components/QuranReader/EndOfSurahSection/ReadMoreCard/ChapterLink.tsx
+++ b/src/components/QuranReader/EndOfSurahSection/ReadMoreCard/ChapterLink.tsx
@@ -45,9 +45,17 @@ const ChapterLink: React.FC<ChapterLinkProps> = ({
   const hasSummary = wordCount > MIN_SUMMARY_WORDS;
   const isLongSummary = hasSummary && wordCount > LONG_SUMMARY_THRESHOLD;
 
-  const handleClick = () => {
+  const handleClick = (event: React.MouseEvent) => {
     const eventName = isNext ? 'end_of_surah_next_chapter' : 'end_of_surah_previous_chapter';
     logButtonClick(eventName, { chapterNumber });
+    // Skip the scroll reset for modified/non-primary clicks (e.g. Cmd/Ctrl/Shift-click
+    // to open in a new tab), since the current tab isn't navigating away and should
+    // keep its reading position.
+    const isModifiedClick =
+      event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0;
+    if (isModifiedClick) {
+      return;
+    }
     // Reset scroll so the newly opened surah starts from the top instead of
     // staying at the bottom where the end-of-surah card was clicked.
     onScrollToTop();

--- a/src/components/QuranReader/EndOfSurahSection/ReadMoreCard/ChapterLink.tsx
+++ b/src/components/QuranReader/EndOfSurahSection/ReadMoreCard/ChapterLink.tsx
@@ -22,6 +22,7 @@ interface ChapterLinkProps {
   shouldShowArabicName: boolean;
   badgeLabel: string;
   ariaLabel: string;
+  onScrollToTop: () => void;
 }
 
 const ChapterLink: React.FC<ChapterLinkProps> = ({
@@ -33,6 +34,7 @@ const ChapterLink: React.FC<ChapterLinkProps> = ({
   shouldShowArabicName,
   badgeLabel,
   ariaLabel,
+  onScrollToTop,
 }) => {
   const badgeStyle = isNext ? styles.nextBadge : styles.prevBadge;
   const chapterTitle = `${chapterNumber}. ${chapter.transliteratedName}`;
@@ -46,6 +48,9 @@ const ChapterLink: React.FC<ChapterLinkProps> = ({
   const handleClick = () => {
     const eventName = isNext ? 'end_of_surah_next_chapter' : 'end_of_surah_previous_chapter';
     logButtonClick(eventName, { chapterNumber });
+    // Reset scroll so the newly opened surah starts from the top instead of
+    // staying at the bottom where the end-of-surah card was clicked.
+    onScrollToTop();
   };
 
   return (

--- a/src/components/QuranReader/EndOfSurahSection/ReadMoreCard/index.tsx
+++ b/src/components/QuranReader/EndOfSurahSection/ReadMoreCard/index.tsx
@@ -118,6 +118,7 @@ const ReadMoreCard: React.FC<ReadMoreCardProps> = ({
               surahName: nextChapter!.transliteratedName,
               surahNumber: nextDisplayNumber,
             })}
+            onScrollToTop={onScrollToTop}
           />
         )}
 
@@ -134,6 +135,7 @@ const ReadMoreCard: React.FC<ReadMoreCardProps> = ({
               surahName: prevChapter!.transliteratedName,
               surahNumber: prevDisplayNumber,
             })}
+            onScrollToTop={onScrollToTop}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

When a reader reaches the end of a surah, the **"Read more"** card offers links to the next/previous surah. Clicking one of these links opens the new surah but leaves the window **scrolled to the bottom** (where the card sits) instead of resetting to the top of the new surah's content.

The card already has an `onScrollToTop` callback — but it was only wired to the **"beginning of surah"** replay button and was never passed down to the chapter links. This PR threads that same callback to `ChapterLink` and invokes it on click, so navigation resets the scroll position. This mirrors the scroll-reset pattern already used elsewhere in the reader (e.g. `TafsirBody`).

## Changes

- `ChapterLink` now accepts an `onScrollToTop` prop and calls it in its click handler (alongside the existing analytics logging).
- `ReadMoreCard` passes its existing `onScrollToTop` callback to both `ChapterLink` instances (next + previous).

## Test plan

- [ ] Open a surah and scroll to the very bottom to reveal the "Read more" card.
- [ ] Click the **Next** surah link → the new surah should open scrolled to the **top**.
- [ ] Click the **Previous** surah link → same expectation.
- [ ] Confirm the existing "beginning of surah" replay button still scrolls to the top within the current surah.

Closes #3150