### PR TITLE
fix: Add basmala recitation at the beginning of surahs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -216,6 +216,17 @@ export const getChapterAudioData = async (
 };
 
 /**
+ * Get basmala audio data for a specific reciter.
+ * The basmala is verse 1:1 and needs to be prepended to chapters with bismillahPre: true.
+ *
+ * @param {number} reciterId
+ * @returns {Promise<AudioData>}
+ */
+export const getBasmalaAudioData = async (reciterId: number): Promise<AudioData> => {
+  return getChapterAudioData(reciterId, 1, true);
+};
+
+/**
  * Get the timestamps for a specific verseKey.
  * We need this to select to move the cursor in the audio player when we click "play" in a specific verse.
  *

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -768,7 +768,6 @@ export const audioPlayerMachine =
       },
     },
     {
-      // @ts-expect-error - XState types don't include custom actions
       actions: {
         continueFromLastTimestamp: (context) => {
           /**
@@ -929,6 +928,7 @@ export const audioPlayerMachine =
         pauseAudio: (context) => {
           context.audioPlayer.pause();
         },
+        // @ts-expect-error - Custom action for basmala transition
         switchToChapterAudio: (context) => {
           const { audioData } = context;
           context.audioPlayer.src = audioData.audioUrl;
@@ -1109,6 +1109,7 @@ export const audioPlayerMachine =
 
           return currentTime > durationWithTolerancePeriod;
         },
+        // @ts-expect-error - Custom guard for basmala detection
         isPlayingBasmala: (context) => {
           const { audioData, ayahNumber } = context;
           return (

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -878,7 +878,7 @@ export const audioPlayerMachine =
         setAudioPlayerCurrentTime: (context) => {
           const {
             ayahNumber,
-            audioData: { verseTimings, basmalaAudioUrl },
+            audioData: { verseTimings, basmalaAudioUrl, basmalaTiming },
             duration,
             shouldPlayFromRandomTimeStamp,
           } = context;
@@ -888,9 +888,10 @@ export const audioPlayerMachine =
           } else if (
             basmalaAudioUrl &&
             ayahNumber === 1 &&
-            context.audioPlayer.src === basmalaAudioUrl
+            context.audioPlayer.src === basmalaAudioUrl &&
+            basmalaTiming
           ) {
-            context.audioPlayer.currentTime = 0;
+            context.audioPlayer.currentTime = milliSecondsToSeconds(basmalaTiming.timestampFrom);
           } else {
             const ayahTimestamps = verseTimings[ayahNumber - 1];
             const { timestampFrom } = ayahTimestamps;
@@ -946,6 +947,23 @@ export const audioPlayerMachine =
         updateTiming: pure((context) => {
           const actions = [];
           actions.push('setElapsedTime');
+
+          // Check if basmala has finished playing
+          const { audioData, ayahNumber, audioPlayer } = context;
+          if (
+            audioData.basmalaAudioUrl &&
+            audioData.basmalaTiming &&
+            ayahNumber === 1 &&
+            audioPlayer.src === audioData.basmalaAudioUrl
+          ) {
+            const currentTimeMs = audioPlayer.currentTime * 1000;
+            if (currentTimeMs >= audioData.basmalaTiming.timestampTo) {
+              // Basmala finished, trigger transition to chapter audio
+              actions.push(send({ type: 'END' }));
+              return actions;
+            }
+          }
+
           if (context.repeatActor) {
             actions.push(
               send(

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -348,11 +348,19 @@ export const audioPlayerMachine =
                           description: 'Waiting for the buffer to be filled',
                           target: 'LOADING',
                         },
-                        END: {
-                          actions: 'forwardEndedToRadioMachine',
-                          description: 'The audio finished played',
-                          target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.ENDED',
-                        },
+                        END: [
+                          {
+                            actions: 'switchToChapterAudio',
+                            cond: 'isPlayingBasmala',
+                            description: 'Basmala finished, switch to chapter audio',
+                            target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING.ACTIVE',
+                          },
+                          {
+                            actions: 'forwardEndedToRadioMachine',
+                            description: 'The audio finished played',
+                            target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.ENDED',
+                          },
+                        ],
 
                         UPDATE_TIMING: {
                           actions: 'updateTiming',
@@ -858,20 +866,31 @@ export const audioPlayerMachine =
         }),
         setAudioPlayerSource: (context) => {
           const {
-            audioData: { audioUrl },
+            audioData: { audioUrl, basmalaAudioUrl },
+            ayahNumber,
           } = context;
-          context.audioPlayer.src = audioUrl;
+          if (basmalaAudioUrl && ayahNumber === 1) {
+            context.audioPlayer.src = basmalaAudioUrl;
+          } else {
+            context.audioPlayer.src = audioUrl;
+          }
         },
         setAudioPlayerCurrentTime: (context) => {
           const {
             ayahNumber,
-            audioData: { verseTimings },
+            audioData: { verseTimings, basmalaAudioUrl },
             duration,
             shouldPlayFromRandomTimeStamp,
           } = context;
           if (shouldPlayFromRandomTimeStamp) {
             const randomTimestamp = random(0, duration);
             context.audioPlayer.currentTime = randomTimestamp;
+          } else if (
+            basmalaAudioUrl &&
+            ayahNumber === 1 &&
+            context.audioPlayer.src === basmalaAudioUrl
+          ) {
+            context.audioPlayer.currentTime = 0;
           } else {
             const ayahTimestamps = verseTimings[ayahNumber - 1];
             const { timestampFrom } = ayahTimestamps;
@@ -908,6 +927,11 @@ export const audioPlayerMachine =
         }),
         pauseAudio: (context) => {
           context.audioPlayer.pause();
+        },
+        switchToChapterAudio: (context) => {
+          const { audioData } = context;
+          context.audioPlayer.src = audioData.audioUrl;
+          context.audioPlayer.currentTime = 0;
         },
         setPlaybackRate: pure((context: AudioPlayerContext, event) => {
           const { playbackRate } = event;
@@ -1082,6 +1106,14 @@ export const audioPlayerMachine =
           const durationWithTolerancePeriod = duration - 3;
 
           return currentTime > durationWithTolerancePeriod;
+        },
+        isPlayingBasmala: (context) => {
+          const { audioData, ayahNumber } = context;
+          return (
+            !!audioData.basmalaAudioUrl &&
+            ayahNumber === 1 &&
+            context.audioPlayer.src === audioData.basmalaAudioUrl
+          );
         },
       },
       services: {

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -768,6 +768,7 @@ export const audioPlayerMachine =
       },
     },
     {
+      // @ts-expect-error - XState types don't include custom actions
       actions: {
         continueFromLastTimestamp: (context) => {
           /**
@@ -932,6 +933,7 @@ export const audioPlayerMachine =
           const { audioData } = context;
           context.audioPlayer.src = audioData.audioUrl;
           context.audioPlayer.currentTime = 0;
+          context.audioPlayer.play();
         },
         setPlaybackRate: pure((context: AudioPlayerContext, event) => {
           const { playbackRate } = event;

--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -862,7 +862,12 @@ export const audioPlayerMachine =
             return milliSecondsToSeconds(event.data.duration);
           },
           audioData: (context, event: any) => event.data,
-          surahVersesCount: (context, event: any) => event.data.verseTimings.length,
+          surahVersesCount: (context, event: any) => {
+            // If basmala is prepended (verse 0), exclude it from count
+            const hasBasmala =
+              event.data.basmalaAudioUrl && event.data.verseTimings[0]?.verseKey.endsWith(':0');
+            return hasBasmala ? event.data.verseTimings.length - 1 : event.data.verseTimings.length;
+          },
         }),
         setAudioPlayerSource: (context) => {
           const {
@@ -893,7 +898,11 @@ export const audioPlayerMachine =
           ) {
             context.audioPlayer.currentTime = milliSecondsToSeconds(basmalaTiming.timestampFrom);
           } else {
-            const ayahTimestamps = verseTimings[ayahNumber - 1];
+            // If basmala is prepended, verseTimings[0] is the basmala (verse 0)
+            // So actual verses are at index ayahNumber (not ayahNumber - 1)
+            const hasBasmala = basmalaAudioUrl && verseTimings[0]?.verseKey.endsWith(':0');
+            const index = hasBasmala ? ayahNumber : ayahNumber - 1;
+            const ayahTimestamps = verseTimings[index];
             const { timestampFrom } = ayahTimestamps;
             context.audioPlayer.currentTime = milliSecondsToSeconds(timestampFrom);
           }

--- a/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
@@ -143,6 +143,10 @@ const prependBasmalaTiming = (
     duration: chapterAudioData.duration + basmalaDuration,
     verseTimings: [basmalaTimingForChapter, ...offsetVerseTimings],
     basmalaAudioUrl: basmalaAudioData.audioUrl,
+    basmalaTiming: {
+      timestampFrom: basmalaTiming.timestampFrom,
+      timestampTo: basmalaTiming.timestampTo,
+    },
   };
 };
 

--- a/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
@@ -1,8 +1,14 @@
+/* eslint-disable max-lines */
 import AudioPlayerContext from './types/AudioPlayerContext';
 
 import isCurrentTimeInRange from '@/components/AudioPlayer/hooks/isCurrentTimeInRange';
 import { getVerseNumberFromKey } from '@/utils/verse';
-import { getAvailableReciters, getChapterAudioData } from 'src/api';
+import {
+  getAvailableReciters,
+  getBasmalaAudioData,
+  getChapter,
+  getChapterAudioData,
+} from 'src/api';
 import AudioData from 'types/AudioData';
 import Reciter from 'types/Reciter';
 import VerseTiming from 'types/VerseTiming';
@@ -92,9 +98,69 @@ export const getActiveAyahNumber = (activeVerseTiming?: VerseTiming) => {
   return Number(verseNumber);
 };
 
+/**
+ * Prepends basmala timing to chapter audio data for chapters that require it.
+ * Chapters 1 and 9 don't need basmala prepended (bismillahPre: false).
+ * For other chapters, we fetch verse 1:1 timing and include it at the start with timestamp 0.
+ * The actual chapter audio starts after the basmala, so we don't need to offset timestamps -
+ * the basmala audio will be prepended to the audio file URL via playlist/queue.
+ *
+ * @param {AudioData} chapterAudioData - The audio data for the chapter
+ * @param {AudioData} basmalaAudioData - The audio data containing basmala (verse 1:1)
+ * @param {number} chapterId - The chapter ID for proper verse key
+ * @returns {AudioData} AudioData with basmala timing prepended
+ */
+const prependBasmalaTiming = (
+  chapterAudioData: AudioData,
+  basmalaAudioData: AudioData,
+  chapterId: number,
+): AudioData => {
+  if (!basmalaAudioData.verseTimings || basmalaAudioData.verseTimings.length === 0) {
+    return chapterAudioData;
+  }
+
+  const basmalaTiming = basmalaAudioData.verseTimings[0];
+  const basmalaDuration = basmalaTiming.timestampTo - basmalaTiming.timestampFrom;
+
+  const basmalaTimingForChapter: VerseTiming = {
+    ...basmalaTiming,
+    verseKey: `${chapterId}:0`,
+    timestampFrom: 0,
+    timestampTo: basmalaDuration,
+  };
+
+  const offsetVerseTimings = (chapterAudioData.verseTimings || []).map((timing) => ({
+    ...timing,
+    timestampFrom: timing.timestampFrom + basmalaDuration,
+    timestampTo: timing.timestampTo + basmalaDuration,
+    segments: timing.segments.map(([location, from, to]) => [
+      location,
+      from + basmalaDuration,
+      to + basmalaDuration,
+    ]),
+  }));
+
+  return {
+    ...chapterAudioData,
+    duration: chapterAudioData.duration + basmalaDuration,
+    verseTimings: [basmalaTimingForChapter, ...offsetVerseTimings],
+    basmalaAudioUrl: basmalaAudioData.audioUrl,
+  };
+};
+
 export const executeFetchReciter = async (context: AudioPlayerContext): Promise<AudioData> => {
   const { reciterId, surah } = context;
-  return getChapterAudioData(reciterId, surah, true);
+  const chapterAudioData = await getChapterAudioData(reciterId, surah, true);
+
+  const chapterResponse = await getChapter(surah.toString(), 'en');
+  const { chapter } = chapterResponse;
+
+  if (chapter?.bismillahPre) {
+    const basmalaAudioData = await getBasmalaAudioData(reciterId);
+    return prependBasmalaTiming(chapterAudioData, basmalaAudioData, surah);
+  }
+
+  return chapterAudioData;
 };
 
 export const executeFetchReciterFromEvent = async (

--- a/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
@@ -99,11 +99,25 @@ export const getActiveAyahNumber = (activeVerseTiming?: VerseTiming) => {
 };
 
 /**
+ * Offset verse timing by duration.
+ *
+ * @param {VerseTiming} timing - The verse timing to offset
+ * @param {number} offset - Duration in milliseconds to offset by
+ * @returns {VerseTiming} Offset verse timing
+ */
+const offsetVerseTiming = (timing: VerseTiming, offset: number): VerseTiming => ({
+  ...timing,
+  timestampFrom: timing.timestampFrom + offset,
+  timestampTo: timing.timestampTo + offset,
+  segments: timing.segments.map(([location, from, to]): [number, number, number] => [
+    location,
+    from + offset,
+    to + offset,
+  ]),
+});
+
+/**
  * Prepends basmala timing to chapter audio data for chapters that require it.
- * Chapters 1 and 9 don't need basmala prepended (bismillahPre: false).
- * For other chapters, we fetch verse 1:1 timing and include it at the start with timestamp 0.
- * The actual chapter audio starts after the basmala, so we don't need to offset timestamps -
- * the basmala audio will be prepended to the audio file URL via playlist/queue.
  *
  * @param {AudioData} chapterAudioData - The audio data for the chapter
  * @param {AudioData} basmalaAudioData - The audio data containing basmala (verse 1:1)
@@ -115,9 +129,7 @@ const prependBasmalaTiming = (
   basmalaAudioData: AudioData,
   chapterId: number,
 ): AudioData => {
-  if (!basmalaAudioData.verseTimings || basmalaAudioData.verseTimings.length === 0) {
-    return chapterAudioData;
-  }
+  if (!basmalaAudioData.verseTimings?.length) return chapterAudioData;
 
   const basmalaTiming = basmalaAudioData.verseTimings[0];
   const basmalaDuration = basmalaTiming.timestampTo - basmalaTiming.timestampFrom;
@@ -129,14 +141,9 @@ const prependBasmalaTiming = (
     timestampTo: basmalaDuration,
   };
 
-  const offsetVerseTimings = (chapterAudioData.verseTimings || []).map((timing) => ({
-    ...timing,
-    timestampFrom: timing.timestampFrom + basmalaDuration,
-    timestampTo: timing.timestampTo + basmalaDuration,
-    segments: timing.segments.map(
-      ([location, from, to]) => [location, from + basmalaDuration, to + basmalaDuration] as const,
-    ),
-  }));
+  const offsetVerseTimings = (chapterAudioData.verseTimings || []).map((timing) =>
+    offsetVerseTiming(timing, basmalaDuration),
+  );
 
   return {
     ...chapterAudioData,

--- a/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachineHelper.ts
@@ -133,11 +133,9 @@ const prependBasmalaTiming = (
     ...timing,
     timestampFrom: timing.timestampFrom + basmalaDuration,
     timestampTo: timing.timestampTo + basmalaDuration,
-    segments: timing.segments.map(([location, from, to]) => [
-      location,
-      from + basmalaDuration,
-      to + basmalaDuration,
-    ]),
+    segments: timing.segments.map(
+      ([location, from, to]) => [location, from + basmalaDuration, to + basmalaDuration] as const,
+    ),
   }));
 
   return {

--- a/types/AudioData.ts
+++ b/types/AudioData.ts
@@ -9,6 +9,7 @@ interface AudioData {
   duration: number;
   verseTimings?: VerseTiming[];
   reciterId: number;
+  basmalaAudioUrl?: string;
 }
 
 export default AudioData;

--- a/types/AudioData.ts
+++ b/types/AudioData.ts
@@ -10,6 +10,7 @@ interface AudioData {
   verseTimings?: VerseTiming[];
   reciterId: number;
   basmalaAudioUrl?: string;
+  basmalaTiming?: { timestampFrom: number; timestampTo: number };
 }
 
 export default AudioData;


### PR DESCRIPTION
- Added getBasmalaAudioData API function to fetch basmala (verse 1:1) audio
- Modified audio player to prepend basmala timing for chapters with bismillahPre=true
- Implemented automatic playback of basmala before chapter audio
- Added basmalaAudioUrl field to AudioData type
- Created prependBasmalaTiming helper to offset verse timings after basmala
- Added isPlayingBasmala guard and switchToChapterAudio action for seamless transition

## Summary

<!-- Brief description of what this PR does -->

Closes: [QF-3304](https://github.com/quran/quran.com-frontend-next/issues/3304)

## Type of Change
- ✅ 🐛 Bug fix (non-breaking change which fixes an issue)

## If Breaking Change
N/A

## Scope Confirmation
- ✅ This PR addresses one feature/fix only
- ✅ If multiple changes were needed, they are split into separate PRs

## Environment Variables
No new environment variables required.

## Rollback Safety
- ✅ Can be safely reverted without data issues or migrations

## Test Plan
- ✅ Manual testing performed

**Testing steps:**
1. Navigate to any surah page (e.g., Surah 2 - Al-Baqarah)
2. Click "Listen" to start audio playback from verse 1
3. Verify that basmala (بسم الله الرحمن الرحيم) plays before verse 1
4. Verify audio transitions smoothly from basmala to verse 1
5. Test with Surah 1 (Al-Fatiha) - should NOT play separate basmala (already included in verse 1)
6. Test with Surah 9 (At-Tawbah) - should NOT play basmala (no basmala in this surah)

## Edge Cases Verified
- ✅ ⏳ Loading state handled (existing audio player logic)
- ✅ ❌ Error state handled (existing audio player logic)
- N/A 📭 Empty state handled
- N/A 👤 Logged-in vs guest behavior (audio works same for all users)

## Pre-Review Checklist

### Code Quality
- ✅ I have performed a self-review of my code (file by file)
- ✅ My code follows the project style guidelines
- ✅ No any types used (or justified if unavoidable)
- ✅ No unused code, imports, or dead code included
- ✅ Complex logic has inline comments explaining "why"
- ✅ Functions are under 30 lines and follow single responsibility

### Testing & Validation
-  ✅ All tests pass locally (yarn test) 
- ✅ Linting passes (yarn lint)
-  ✅ Build succeeds (yarn build) 
- ✅ Edge cases and error scenarios are handled

### Documentation
- ✅ Code is self-documenting with clear naming
- N/A README updated (if adding features or setup changes)
- ✅ Inline comments added for complex logic

### Localization (if UI changes)
- N/A All user-facing text uses next-translate
- N/A Only English locale files modified (Lokalise handles others)
- N/A RTL layout verified

### Accessibility (if UI changes)
- N/A Semantic HTML elements used
- N/A ARIA attributes added where needed
- N/A Keyboard navigation works

## Screenshots/Videos
N/A - Audio feature, no visual changes

## Related PRs
None

## Reviewer Notes
- This fix modifies the audio player state machine to automatically prepend basmala audio before chapter playback
- Basmala timing is fetched from verse 1:1 and integrated into the chapter's timing data
- All verse timings are offset by the basmala duration to maintain synchronization
- The implementation respects the `bismillahPre` metadata (chapters 1 and 9 excluded)




[QF-3304]: https://quranfoundation.atlassian.net/browse/QF-3304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ