### PR TITLE
fix(qiraat): resolve overlapping reader colors in readers panel (#3286)

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/ReaderItem.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/ReaderItem.tsx
@@ -1,70 +1,42 @@
 import React from 'react';
 
+import {
+  DEFAULT_READING_COLOR,
+  TransmitterReadingAssignment,
+} from '../utils/transmitterReadingAssignments';
+
 import styles from './ReaderItem.module.scss';
 import RwayahTag from './RwayahTag';
 
 import HelpCircleIcon from '@/icons/help-circle.svg';
-import { QiraatReader, QiraatTransmitter, QiraatReading } from '@/types/Qiraat';
+import { QiraatReader, QiraatTransmitter } from '@/types/Qiraat';
 
 interface ReaderItemProps {
   reader: QiraatReader;
   transmitters: QiraatTransmitter[];
-  readings: QiraatReading[];
+  transmitterAssignments: Map<number, TransmitterReadingAssignment>;
   onInfoClick?: () => void;
   onTransmitterClick?: (transmitterId: number) => void;
   isClickable?: boolean;
 }
 
-const DEFAULT_COLOR = '#FFFFFF';
-
 /**
  * Display a single reader with their city and two transmitters (Rwayat).
- * Each transmitter tag is color-coded based on the reading they're associated with.
+ * Each transmitter tag is color-coded based on the reading assignment computed
+ * for the whole panel (see buildTransmitterReadingAssignments), so overlapping
+ * reader-level mappings still surface every reading color.
  * @returns {JSX.Element} Rendered ReaderItem component
  */
 const ReaderItem: React.FC<ReaderItemProps> = ({
   reader,
   transmitters,
-  readings,
+  transmitterAssignments,
   onInfoClick,
   onTransmitterClick,
   isClickable = false,
 }) => {
   // Get transmitters for this reader (should be 2 based on spec)
   const readerTransmitters = transmitters.filter((t) => t.readerId === reader.id);
-
-  /**
-   * Determines the color for a transmitter tag based on its association with a reading.
-   *
-   * Qiraat readings have colored matrix displays that show which transmitters and readers
-   * are part of that reading. When displaying a transmitter in the Readers panel, we need
-   * to find which reading it belongs to so we can color-code it appropriately.
-   *
-   * Two-step lookup process:
-   * 1. Direct match: Try to find a reading where this transmitter appears in the matrix
-   * 2. Inherited match: If not found directly, look for a reading where the transmitter's
-   *    parent reader appears (transmitters inherit their reader's color association)
-   * 3. Fallback: Return white if no association found
-   *
-   * @param {number} transmitterId - The ID of the transmitter to find a color for
-   * @returns {string} The hex color code for the transmitter's associated reading
-   */
-  const getTransmitterColor = (transmitterId: number): string => {
-    // 1. Find a reading where this transmitter appears directly in the matrix
-    const transmitterReading = readings.find(({ matrix }) =>
-      matrix?.transmitters?.includes(transmitterId),
-    );
-
-    if (transmitterReading) return transmitterReading.color || DEFAULT_COLOR;
-
-    // 2. If not found directly, the transmitter inherits color from its parent reader
-    // Find a reading where this reader appears in the matrix
-    const readerReading = readings.find(({ matrix }) => matrix?.readers?.includes(reader.id));
-    if (readerReading) return readerReading.color || DEFAULT_COLOR;
-
-    // 3. Default fallback - no association found
-    return DEFAULT_COLOR;
-  };
 
   return (
     <div className={styles.item}>
@@ -89,7 +61,7 @@ const ReaderItem: React.FC<ReaderItemProps> = ({
           <RwayahTag
             key={transmitter.id}
             transmitter={transmitter}
-            color={getTransmitterColor(transmitter.id)}
+            color={transmitterAssignments.get(transmitter.id)?.color ?? DEFAULT_READING_COLOR}
             onClick={() => onTransmitterClick?.(transmitter.id)}
             isClickable={isClickable}
           />

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/index.tsx
@@ -5,6 +5,7 @@ import useTranslation from 'next-translate/useTranslation';
 
 import colorStyles from '../color.module.scss';
 import { getColorClass } from '../utils/color';
+import { TransmitterReadingAssignment } from '../utils/transmitterReadingAssignments';
 
 import ReaderItem from './ReaderItem';
 import styles from './ReadersPanel.module.scss';
@@ -16,6 +17,7 @@ interface ReadersPanelProps {
   readers: QiraatReader[];
   transmitters: QiraatTransmitter[];
   readings: QiraatReading[];
+  transmitterAssignments: Map<number, TransmitterReadingAssignment>;
   isExpanded: boolean;
   onToggleExpand: () => void;
   onTransmitterClick?: (transmitterId: number) => void;
@@ -32,6 +34,7 @@ const ReadersPanel: React.FC<ReadersPanelProps> = ({
   readers,
   transmitters,
   readings,
+  transmitterAssignments,
   isExpanded,
   onToggleExpand,
   onTransmitterClick,
@@ -100,7 +103,7 @@ const ReadersPanel: React.FC<ReadersPanelProps> = ({
             key={reader.id}
             reader={reader}
             transmitters={transmitters}
-            readings={readings}
+            transmitterAssignments={transmitterAssignments}
             onInfoClick={() => onReaderInfoClick?.(reader.id)}
             onTransmitterClick={onTransmitterClick}
             isClickable={!!onTransmitterClick}

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/index.tsx
@@ -9,6 +9,7 @@ import JunctureTabs from './JunctureTabs';
 import QiraahCardList from './QiraahCardList';
 import ReadersPanel from './ReadersPanel';
 import styles from './StudyModeQiraatTab.module.scss';
+import { buildTransmitterReadingAssignments } from './utils/transmitterReadingAssignments';
 
 import Error from '@/components/Error';
 import { StudyModeTabId } from '@/components/QuranReader/ReadingView/StudyModeModal/StudyModeBottomActions';
@@ -103,52 +104,39 @@ const StudyModeQiraatTab: React.FC<StudyModeQiraatTabProps> = ({
   );
 
   /**
+   * Reading assignment (reading id + color) per transmitter tag for the selected
+   * juncture. Computed panel-wide so overlapping reader-level mappings resolve to
+   * distinct reading colors (#3286), and shared with the transmitter click handler
+   * so the tag color and the card it scrolls to always agree.
+   */
+  const transmitterAssignments = useMemo(
+    () =>
+      buildTransmitterReadingAssignments(
+        data?.readers ?? [],
+        data?.transmitters ?? [],
+        selectedJuncture?.readings ?? [],
+      ),
+    [data?.readers, data?.transmitters, selectedJuncture?.readings],
+  );
+
+  /**
    * Handles scrolling to the appropriate reading card when a transmitter is clicked.
    *
-   * When a user clicks on a transmitter tag in the Readers panel, we need to scroll
-   * to the corresponding reading card in the main content area. However, transmitters
-   * may or may not appear directly in a reading's matrix display.
-   *
-   * Two-step lookup process:
-   * 1. Direct match: Try to find a reading where this transmitter appears in the matrix
-   * 2. Inherited match: If not found directly, find the transmitter's parent reader and
-   *    scroll to a reading where that reader appears in the matrix
-   *
-   * This ensures users always see the relevant reading content when exploring
-   * transmitter-reader relationships.
+   * Scrolls to the reading the transmitter's tag is color-coded with (the assignment
+   * computed by buildTransmitterReadingAssignments), so the clicked tag and the
+   * highlighted card always match.
    *
    * @param transmitterId - The ID of the clicked transmitter
    */
   const handleTransmitterClick = useCallback(
     (transmitterId: number) => {
-      if (!selectedJuncture?.readings) return undefined;
+      const readingId = transmitterAssignments.get(transmitterId)?.readingId;
+      if (readingId === null || readingId === undefined) return;
 
-      // Helper function to scroll to a reading card by ID
-      const scrollToReading = (readingId: number): void => {
-        const cardElement = document.getElementById(`qiraat-card-${readingId}`);
-        cardElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      };
-
-      // 1. Try to find a reading where this transmitter appears directly in the matrix
-      const directReading = selectedJuncture.readings.find((reading) =>
-        reading.matrix?.transmitters?.includes(transmitterId),
-      );
-
-      if (directReading) return scrollToReading(directReading.id);
-
-      // 2. If not found directly, find the transmitter's parent reader
-      const transmitter = data?.transmitters?.find((tr) => tr.id === transmitterId);
-      if (!transmitter) return undefined;
-
-      // 3. Find and scroll to a reading where that reader appears in the matrix
-      const readerReading = selectedJuncture.readings.find((reading) =>
-        reading.matrix?.readers?.includes(transmitter.readerId),
-      );
-
-      if (readerReading) scrollToReading(readerReading.id);
-      return undefined;
+      const cardElement = document.getElementById(`qiraat-card-${readingId}`);
+      cardElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     },
-    [selectedJuncture?.readings, data?.transmitters],
+    [transmitterAssignments],
   );
 
   if (isLoading) {
@@ -187,6 +175,7 @@ const StudyModeQiraatTab: React.FC<StudyModeQiraatTabProps> = ({
             readers={data.readers}
             transmitters={data.transmitters}
             readings={selectedJuncture?.readings || []}
+            transmitterAssignments={transmitterAssignments}
             isExpanded={isReadersPanelExpanded}
             onToggleExpand={handleToggleReadersPanel}
             onTransmitterClick={handleTransmitterClick}

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.test.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.test.ts
@@ -107,6 +107,44 @@ describe('buildTransmitterReadingAssignments', () => {
     expect(assignments.get(21)).toEqual({ readingId: 102, color: BLUE });
   });
 
+  it('distributes ambiguous tags so multiple otherwise-hidden colors are all shown', () => {
+    // white has an unambiguous representative; green and pink are each reachable ONLY
+    // through the two ambiguous readers 2 and 3. Both colors must appear in the panel
+    // (a single-pass "prefer first unrepresented" would assign both tags green).
+    const readers = [makeReader(1, 1), makeReader(2, 2), makeReader(3, 3)];
+    const transmitters = [makeTransmitter(11, 1), makeTransmitter(21, 2), makeTransmitter(31, 3)];
+    const readings = [
+      makeReading(100, WHITE, [1, 2, 3]),
+      makeReading(101, GREEN, [2, 3]),
+      makeReading(102, PINK, [2, 3]),
+    ];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    const shownColors = new Set([21, 31].map((id) => assignments.get(id)?.color));
+    expect(shownColors).toEqual(new Set([GREEN, PINK]));
+  });
+
+  it('keeps sibling ambiguous tags on the same color when only one color is missing', () => {
+    // white has an unambiguous representative; pink is the only missing color and is
+    // reachable by three ambiguous readers — all three should map to pink (2:245 shape,
+    // not split across white/pink).
+    const readers = [makeReader(1, 1), makeReader(2, 2), makeReader(3, 3), makeReader(4, 4)];
+    const transmitters = [
+      makeTransmitter(11, 1),
+      makeTransmitter(21, 2),
+      makeTransmitter(31, 3),
+      makeTransmitter(41, 4),
+    ];
+    const readings = [makeReading(100, WHITE, [1, 2, 3, 4]), makeReading(101, PINK, [2, 3, 4])];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    expect(assignments.get(21)).toEqual({ readingId: 101, color: PINK });
+    expect(assignments.get(31)).toEqual({ readingId: 101, color: PINK });
+    expect(assignments.get(41)).toEqual({ readingId: 101, color: PINK });
+  });
+
   it('falls back to first-match order when every candidate color is already represented', () => {
     const readers = [makeReader(1, 1), makeReader(2, 2), makeReader(3, 3)];
     const transmitters = [makeTransmitter(11, 1), makeTransmitter(21, 2), makeTransmitter(31, 3)];

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.test.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.test.ts
@@ -1,0 +1,154 @@
+/* eslint-disable react-func/max-lines-per-function */
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildTransmitterReadingAssignments,
+  DEFAULT_READING_COLOR,
+} from './transmitterReadingAssignments';
+
+import { QiraatReader, QiraatReading, QiraatTransmitter } from '@/types/Qiraat';
+
+const makeReader = (id: number, position: number): QiraatReader =>
+  ({ id, position, name: `Reader ${id}` } as QiraatReader);
+
+const makeTransmitter = (id: number, readerId: number): QiraatTransmitter =>
+  ({ id, readerId, name: `Transmitter ${id}` } as QiraatTransmitter);
+
+const makeReading = (
+  id: number,
+  color: string | null,
+  readerIds: number[],
+  transmitterIds: number[] = [],
+): QiraatReading =>
+  ({
+    id,
+    color,
+    matrix: { readers: readerIds, transmitters: transmitterIds, cells: [] },
+  } as unknown as QiraatReading);
+
+const WHITE = '#ffffff';
+const PINK = '#ea9999';
+const GREEN = '#b7d7a8';
+const BLUE = '#a4c2f4';
+
+describe('buildTransmitterReadingAssignments', () => {
+  it('resolves overlapping reader-level mappings to unrepresented colors (2:245 shape)', () => {
+    // Readers: 5 = ʿĀṣim, 6 = Abū Jaʿfar, 8 = Ibn Kathīr, 1 = Nāfiʿ, 3 = Ibn ʿĀmir
+    const readers = [
+      makeReader(1, 1),
+      makeReader(3, 3),
+      makeReader(5, 5),
+      makeReader(6, 8),
+      makeReader(8, 2),
+    ];
+    const transmitters = [
+      makeTransmitter(11, 1),
+      makeTransmitter(12, 1),
+      makeTransmitter(31, 3),
+      makeTransmitter(32, 3),
+      makeTransmitter(51, 5),
+      makeTransmitter(52, 5),
+      makeTransmitter(61, 6),
+      makeTransmitter(62, 6),
+      makeTransmitter(81, 8),
+      makeTransmitter(82, 8),
+    ];
+    // White reading lists ʿĀṣim + Ibn Kathīr + Abū Jaʿfar; pink lists only the latter two.
+    const readings = [
+      makeReading(100, WHITE, [5, 8, 6]),
+      makeReading(101, GREEN, [3]),
+      makeReading(102, BLUE, [1]),
+      makeReading(103, PINK, [8, 6]),
+    ];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    // Unambiguous readers keep their only candidate
+    expect(assignments.get(51)).toEqual({ readingId: 100, color: WHITE });
+    expect(assignments.get(52)).toEqual({ readingId: 100, color: WHITE });
+    expect(assignments.get(31)).toEqual({ readingId: 101, color: GREEN });
+    expect(assignments.get(11)).toEqual({ readingId: 102, color: BLUE });
+
+    // Ambiguous readers (white + pink candidates) surface the otherwise-hidden pink
+    expect(assignments.get(81)).toEqual({ readingId: 103, color: PINK });
+    expect(assignments.get(82)).toEqual({ readingId: 103, color: PINK });
+    expect(assignments.get(61)).toEqual({ readingId: 103, color: PINK });
+    expect(assignments.get(62)).toEqual({ readingId: 103, color: PINK });
+  });
+
+  it('keeps direct transmitter matches authoritative over reader-level mappings', () => {
+    const readers = [makeReader(1, 1)];
+    const transmitters = [makeTransmitter(11, 1), makeTransmitter(12, 1)];
+    // Reader-level mapping points at the green reading, but transmitter 12 is
+    // explicitly listed in the pink reading's matrix.
+    const readings = [makeReading(100, GREEN, [1]), makeReading(101, PINK, [], [12])];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    expect(assignments.get(11)).toEqual({ readingId: 100, color: GREEN });
+    expect(assignments.get(12)).toEqual({ readingId: 101, color: PINK });
+  });
+
+  it('resolves duplicate transmitter-level mappings the same way (7:165 shape)', () => {
+    const readers = [makeReader(1, 1), makeReader(2, 2)];
+    const transmitters = [makeTransmitter(11, 1), makeTransmitter(12, 1), makeTransmitter(21, 2)];
+    // Transmitter 12 appears in two readings; transmitter 11 unambiguously
+    // represents green, so 12 should resolve to the otherwise-hidden pink.
+    const readings = [
+      makeReading(100, GREEN, [], [11, 12]),
+      makeReading(101, PINK, [], [12]),
+      makeReading(102, BLUE, [2]),
+    ];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    expect(assignments.get(11)).toEqual({ readingId: 100, color: GREEN });
+    expect(assignments.get(12)).toEqual({ readingId: 101, color: PINK });
+    expect(assignments.get(21)).toEqual({ readingId: 102, color: BLUE });
+  });
+
+  it('falls back to first-match order when every candidate color is already represented', () => {
+    const readers = [makeReader(1, 1), makeReader(2, 2), makeReader(3, 3)];
+    const transmitters = [makeTransmitter(11, 1), makeTransmitter(21, 2), makeTransmitter(31, 3)];
+    // Readers 1 and 2 unambiguously represent white and pink; reader 3 is
+    // ambiguous between them, so it keeps the previous first-match behavior.
+    const readings = [makeReading(100, WHITE, [1, 3]), makeReading(101, PINK, [2, 3])];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    expect(assignments.get(31)).toEqual({ readingId: 100, color: WHITE });
+  });
+
+  it('treats null colors as the default color for representation tracking', () => {
+    const readers = [makeReader(1, 1), makeReader(2, 2)];
+    const transmitters = [makeTransmitter(11, 1), makeTransmitter(21, 2)];
+    // The default reading carries a null color; reader 2 is ambiguous between it
+    // and pink, and the null color counts as white when tracking representation.
+    const readings = [makeReading(100, null, [1, 2]), makeReading(101, PINK, [2])];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    expect(assignments.get(11)).toEqual({ readingId: 100, color: DEFAULT_READING_COLOR });
+    expect(assignments.get(21)).toEqual({ readingId: 101, color: PINK });
+  });
+
+  it('returns the default color with no reading id when a transmitter matches nothing', () => {
+    const readers = [makeReader(1, 1)];
+    const transmitters = [makeTransmitter(11, 1)];
+    const readings = [makeReading(100, GREEN, [99])];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, readings);
+
+    expect(assignments.get(11)).toEqual({ readingId: null, color: DEFAULT_READING_COLOR });
+  });
+
+  it('returns default assignments for every transmitter when there are no readings', () => {
+    const readers = [makeReader(1, 1)];
+    const transmitters = [makeTransmitter(11, 1), makeTransmitter(12, 1)];
+
+    const assignments = buildTransmitterReadingAssignments(readers, transmitters, []);
+
+    expect(assignments.get(11)).toEqual({ readingId: null, color: DEFAULT_READING_COLOR });
+    expect(assignments.get(12)).toEqual({ readingId: null, color: DEFAULT_READING_COLOR });
+  });
+});

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.ts
@@ -68,6 +68,78 @@ const collectTagCandidates = (
   );
 
 /**
+ * Assigns every unambiguous tag (exactly one candidate reading) and records its
+ * color as represented in the panel. Tags with no candidate fall back to the
+ * default (white) color and a null reading id.
+ *
+ * @param {TransmitterCandidates[]} tags - Transmitter tags with their candidates
+ * @param {Map<number, TransmitterReadingAssignment>} assignments - Mutated in place
+ * @param {Set<string>} representedColors - Mutated in place with claimed colors
+ * @returns {void}
+ */
+const assignUnambiguousTags = (
+  tags: TransmitterCandidates[],
+  assignments: Map<number, TransmitterReadingAssignment>,
+  representedColors: Set<string>,
+): void => {
+  tags.forEach(({ transmitterId, candidates }) => {
+    if (candidates.length === 0) {
+      assignments.set(transmitterId, { readingId: null, color: DEFAULT_READING_COLOR });
+    } else if (candidates.length === 1) {
+      assignments.set(transmitterId, toAssignment(candidates[0]));
+      representedColors.add(normalizeColor(candidates[0].color));
+    }
+  });
+};
+
+/**
+ * Assigns every ambiguous tag (two or more candidate readings) in two sub-passes:
+ *
+ * - 2a: each ambiguous tag claims the first candidate color the panel does not show
+ *   yet, marking it represented. Marking as we go means that when several colors are
+ *   reachable only through ambiguous tags, each still-missing color gets covered by a
+ *   different tag instead of every tag piling onto the same first one.
+ * - 2b: tags whose candidate colors are all represented reuse a color already chosen
+ *   by another ambiguous tag (keeping sibling transmitters grouped — e.g. both
+ *   Abū Jaʿfar and Ibn Kathīr on pink for 2:245, since pink was the only missing
+ *   color there), falling back to the first candidate otherwise.
+ *
+ * @param {TransmitterCandidates[]} tags - Transmitter tags with their candidates
+ * @param {Map<number, TransmitterReadingAssignment>} assignments - Mutated in place
+ * @param {Set<string>} representedColors - Colors already claimed in pass 1
+ * @returns {void}
+ */
+const assignAmbiguousTags = (
+  tags: TransmitterCandidates[],
+  assignments: Map<number, TransmitterReadingAssignment>,
+  representedColors: Set<string>,
+): void => {
+  const deferred: TransmitterCandidates[] = [];
+  const ambiguousColors = new Set<string>();
+
+  tags.forEach((tag) => {
+    if (tag.candidates.length < 2) return;
+    const unrepresented = tag.candidates.find(
+      (reading) => !representedColors.has(normalizeColor(reading.color)),
+    );
+    if (!unrepresented) {
+      deferred.push(tag);
+      return;
+    }
+    assignments.set(tag.transmitterId, toAssignment(unrepresented));
+    representedColors.add(normalizeColor(unrepresented.color));
+    ambiguousColors.add(normalizeColor(unrepresented.color));
+  });
+
+  deferred.forEach(({ transmitterId, candidates }) => {
+    const sibling = candidates.find((reading) =>
+      ambiguousColors.has(normalizeColor(reading.color)),
+    );
+    assignments.set(transmitterId, toAssignment(sibling ?? candidates[0]));
+  });
+};
+
+/**
  * Builds the reading assignment (reading id + color) for every transmitter tag
  * shown in the Readers panel.
  *
@@ -75,15 +147,9 @@ const collectTagCandidates = (
  * transmitter-level disambiguation (e.g. 2:245, where Abū Jaʿfar and Ibn Kathīr
  * appear in both the default and the pink readings). A naive first-match lookup
  * always resolves such readers to the earliest reading, so the later reading's
- * color disappears from the panel entirely (#3286).
- *
- * Assignment strategy:
- * 1. Unambiguous tags (exactly one candidate reading) are assigned first and
- *    their colors are recorded as represented in the panel.
- * 2. Ambiguous tags (two or more candidates) take the first candidate whose
- *    color is not yet represented, falling back to the first candidate when
- *    every candidate color is already represented (the previous behavior).
- * 3. Tags with no candidates fall back to the default (white) color.
+ * color disappears from the panel entirely (#3286). Unambiguous tags are assigned
+ * first so their colors anchor the panel, then ambiguous tags are distributed to
+ * surface every still-missing reading color.
  *
  * @param {QiraatReader[]} readers - All canonical readers
  * @param {QiraatTransmitter[]} transmitters - All transmitters
@@ -99,24 +165,8 @@ export const buildTransmitterReadingAssignments = (
   const assignments = new Map<number, TransmitterReadingAssignment>();
   const representedColors = new Set<string>();
 
-  // Pass 1 — unambiguous tags claim their reading and mark its color as represented
-  tags.forEach(({ transmitterId, candidates }) => {
-    if (candidates.length === 0) {
-      assignments.set(transmitterId, { readingId: null, color: DEFAULT_READING_COLOR });
-    } else if (candidates.length === 1) {
-      assignments.set(transmitterId, toAssignment(candidates[0]));
-      representedColors.add(normalizeColor(candidates[0].color));
-    }
-  });
-
-  // Pass 2 — ambiguous tags prefer the first candidate color the panel doesn't show yet
-  tags.forEach(({ transmitterId, candidates }) => {
-    if (candidates.length < 2) return;
-    const unrepresented = candidates.find(
-      (reading) => !representedColors.has(normalizeColor(reading.color)),
-    );
-    assignments.set(transmitterId, toAssignment(unrepresented ?? candidates[0]));
-  });
+  assignUnambiguousTags(tags, assignments, representedColors);
+  assignAmbiguousTags(tags, assignments, representedColors);
 
   return assignments;
 };

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterReadingAssignments.ts
@@ -1,0 +1,122 @@
+import { QiraatReader, QiraatReading, QiraatTransmitter } from '@/types/Qiraat';
+
+export const DEFAULT_READING_COLOR = '#FFFFFF';
+
+export interface TransmitterReadingAssignment {
+  readingId: number | null;
+  color: string;
+}
+
+interface TransmitterCandidates {
+  transmitterId: number;
+  candidates: QiraatReading[];
+}
+
+const normalizeColor = (color: string | null | undefined): string =>
+  (color || DEFAULT_READING_COLOR).toLowerCase();
+
+const toAssignment = (reading: QiraatReading): TransmitterReadingAssignment => ({
+  readingId: reading.id,
+  color: reading.color || DEFAULT_READING_COLOR,
+});
+
+/**
+ * Collects the candidate readings a transmitter tag could be associated with.
+ *
+ * Readings expose membership through `matrix.transmitters` (authoritative when
+ * populated) and `matrix.readers` (fallback used when the payload carries no
+ * transmitter-level data for this transmitter).
+ *
+ * @param {number} transmitterId - The transmitter to collect candidates for
+ * @param {number} readerId - The transmitter's parent reader
+ * @param {QiraatReading[]} readings - Readings of the selected juncture
+ * @returns {QiraatReading[]} Candidate readings, in reading order
+ */
+const getCandidateReadings = (
+  transmitterId: number,
+  readerId: number,
+  readings: QiraatReading[],
+): QiraatReading[] => {
+  const directMatches = readings.filter((reading) =>
+    reading.matrix?.transmitters?.includes(transmitterId),
+  );
+  if (directMatches.length > 0) return directMatches;
+
+  return readings.filter((reading) => reading.matrix?.readers?.includes(readerId));
+};
+
+/**
+ * Pairs every transmitter tag shown in the panel with its candidate readings.
+ *
+ * @param {QiraatReader[]} readers - All canonical readers
+ * @param {QiraatTransmitter[]} transmitters - All transmitters
+ * @param {QiraatReading[]} readings - Readings of the selected juncture
+ * @returns {TransmitterCandidates[]} One entry per transmitter tag
+ */
+const collectTagCandidates = (
+  readers: QiraatReader[],
+  transmitters: QiraatTransmitter[],
+  readings: QiraatReading[],
+): TransmitterCandidates[] =>
+  readers.flatMap((reader) =>
+    transmitters
+      .filter((transmitter) => transmitter.readerId === reader.id)
+      .map((transmitter) => ({
+        transmitterId: transmitter.id,
+        candidates: getCandidateReadings(transmitter.id, reader.id, readings),
+      })),
+  );
+
+/**
+ * Builds the reading assignment (reading id + color) for every transmitter tag
+ * shown in the Readers panel.
+ *
+ * Some payloads list the same reader in multiple readings without
+ * transmitter-level disambiguation (e.g. 2:245, where Abū Jaʿfar and Ibn Kathīr
+ * appear in both the default and the pink readings). A naive first-match lookup
+ * always resolves such readers to the earliest reading, so the later reading's
+ * color disappears from the panel entirely (#3286).
+ *
+ * Assignment strategy:
+ * 1. Unambiguous tags (exactly one candidate reading) are assigned first and
+ *    their colors are recorded as represented in the panel.
+ * 2. Ambiguous tags (two or more candidates) take the first candidate whose
+ *    color is not yet represented, falling back to the first candidate when
+ *    every candidate color is already represented (the previous behavior).
+ * 3. Tags with no candidates fall back to the default (white) color.
+ *
+ * @param {QiraatReader[]} readers - All canonical readers
+ * @param {QiraatTransmitter[]} transmitters - All transmitters
+ * @param {QiraatReading[]} readings - Readings of the selected juncture
+ * @returns {Map<number, TransmitterReadingAssignment>} Assignment per transmitter id
+ */
+export const buildTransmitterReadingAssignments = (
+  readers: QiraatReader[],
+  transmitters: QiraatTransmitter[],
+  readings: QiraatReading[],
+): Map<number, TransmitterReadingAssignment> => {
+  const tags = collectTagCandidates(readers, transmitters, readings);
+  const assignments = new Map<number, TransmitterReadingAssignment>();
+  const representedColors = new Set<string>();
+
+  // Pass 1 — unambiguous tags claim their reading and mark its color as represented
+  tags.forEach(({ transmitterId, candidates }) => {
+    if (candidates.length === 0) {
+      assignments.set(transmitterId, { readingId: null, color: DEFAULT_READING_COLOR });
+    } else if (candidates.length === 1) {
+      assignments.set(transmitterId, toAssignment(candidates[0]));
+      representedColors.add(normalizeColor(candidates[0].color));
+    }
+  });
+
+  // Pass 2 — ambiguous tags prefer the first candidate color the panel doesn't show yet
+  tags.forEach(({ transmitterId, candidates }) => {
+    if (candidates.length < 2) return;
+    const unrepresented = candidates.find(
+      (reading) => !representedColors.has(normalizeColor(reading.color)),
+    );
+    assignments.set(transmitterId, toAssignment(unrepresented ?? candidates[0]));
+  });
+
+  return assignments;
+};


### PR DESCRIPTION
## Summary

Closes: #3286

On `/{chapter}:{verse}/qiraat`, the readers/transmitters panel dropped a reading color whenever a reader appeared in more than one reading. On `2:245`, the reading cards show four colors (white, green, blue, pink), but the left panel only showed three — the pink reading `فَيُضَعِّفُهُ` had no reader/transmitter association because Abū Jaʿfar and Ibn Kathīr are listed in both the default (white) and pink readings.

### Root cause

`ReaderItem` colored each transmitter tag with a per-item first-match lookup:

```ts
readings.find(({ matrix }) => matrix?.readers?.includes(reader.id))
```

Because the white reading is ordered before the pink reading, an ambiguous reader always resolved to white, and the pink candidate was never reached. The same first-match assumption existed in the transmitter click-to-scroll handler. Per the issue, this pattern also affects `6:145, 7:161, 10:35, 12:23, 18:44, 19:25, 20:63, 22:39` (reader-level) and `7:165` (duplicate transmitter-level).

### Fix

Replace the per-item lookup with a panel-wide assignment pass, `buildTransmitterReadingAssignments`, implementing the mitigation proposed in the issue:

1. Direct `matrix.transmitters` matches stay authoritative.
2. Unambiguous tags (one candidate reading) are assigned first; their colors are recorded as *represented* in the panel.
3. Ambiguous tags (two or more candidates) then prefer the first candidate whose color is not yet represented, falling back to the previous first-match behavior when every candidate color already appears.

The transmitter click-to-scroll handler reuses the same assignment, so a tag's color and the card it scrolls to always agree.

For `2:245` this resolves correctly: ʿĀṣim keeps white, while Abū Jaʿfar and Ibn Kathīr map to the otherwise-missing pink.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Scope Confirmation

- [x] This PR addresses **one** feature/fix only

## Rollback Safety

- [x] Can be safely reverted without data issues or migrations

## Test Plan

- [x] Unit tests added/updated
- [x] Manual testing performed

**Testing steps:**

1. Open `https://quran.com/2:245/qiraat`.
2. Select the junction for `فَيُضَـٰعِفَهُۥ`.
3. Confirm the left reader/transmitter panel now shows all four colors (white, green, blue, pink), with Abū Jaʿfar and Ibn Kathīr color-coded pink.
4. Click the pink transmitter tag and confirm it scrolls to the matching pink reading card.

New unit tests (`transmitterReadingAssignments.test.ts`) cover:
- the `2:245` regression (overlapping reader-level mappings),
- the `7:165` duplicate transmitter-level case,
- direct `matrix.transmitters` precedence over reader-level fallback,
- the all-candidates-already-represented fallback to first-match,
- `null` reading color normalization,
- the no-match and empty-readings edge cases.

### Edge Cases Verified

- [x] 📭 Empty state handled (no readings → default/white assignments)

## Pre-Review Checklist

### Code Quality

- [x] I have performed a **self-review** of my code (file by file)
- [x] No `any` types used in production code (test helpers cast fixture objects, isolated to the test file)
- [x] No unused code, imports, or dead code included

### Testing & Validation

- [x] New unit tests pass locally (`vitest run`)
- [x] Linting passes for the changed files (`eslint`)

## Reviewer Notes

This is a frontend-only mitigation that preserves the current API payload shape. As the issue notes, the cleaner long-term fix is transmitter-level disambiguation in the payload; this change prevents missing colors in the panel regardless.

## AI Assistance Disclosure

- [x] AI tools were used, and I have **thoroughly reviewed and validated** all generated code
