### PR TITLE
fix: remove dead link to quran.com-api repository (#3235)

### DIFF
--- a/src/pages/developers/index.tsx
+++ b/src/pages/developers/index.tsx
@@ -23,7 +23,6 @@ const DevelopersPage: NextPage = () => {
   const { t, lang } = useTranslation('developers');
   const projects = [
     { key: 'q-next', href: 'https://github.com/quran/quran.com-frontend-next' },
-    { key: 'q-api', href: 'https://github.com/quran/quran.com-api' },
     { key: 'q-android', href: 'https://github.com/quran/quran_android' },
     { key: 'q-ios', href: 'https://github.com/quran/quran-ios' },
     { key: 'q-audio', href: 'https://github.com/quran/audio.quran.com' },


### PR DESCRIPTION
The quran.com-api repository no longer exists at https://github.com/quran/quran.com-api (returns 404). This PR removes the dead link from the developers page.

![Screenshot_20260711_015904_com.github.android.jpg](https://github.com/user-attachments/assets/fc0d0b9a-714e-48b9-9147-e7063943e594)

Fixes #3235