### PR TITLE
Fix missing reading colors in qiraat ReadersPanel when reader overlaps readings

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/ReaderItem.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/ReaderItem.tsx
@@ -10,6 +10,7 @@ interface ReaderItemProps {
   reader: QiraatReader;
   transmitters: QiraatTransmitter[];
   readings: QiraatReading[];
+  readerColor?: string;
   onInfoClick?: () => void;
   onTransmitterClick?: (transmitterId: number) => void;
   isClickable?: boolean;
@@ -26,6 +27,7 @@ const ReaderItem: React.FC<ReaderItemProps> = ({
   reader,
   transmitters,
   readings,
+  readerColor,
   onInfoClick,
   onTransmitterClick,
   isClickable = false,
@@ -57,12 +59,14 @@ const ReaderItem: React.FC<ReaderItemProps> = ({
 
     if (transmitterReading) return transmitterReading.color || DEFAULT_COLOR;
 
-    // 2. If not found directly, the transmitter inherits color from its parent reader
-    // Find a reading where this reader appears in the matrix
+    // 2. If the parent component has pre-computed a color for this reader, use it
+    if (readerColor) return readerColor;
+
+    // 3. If not found directly, the transmitter inherits color from its parent reader
     const readerReading = readings.find(({ matrix }) => matrix?.readers?.includes(reader.id));
     if (readerReading) return readerReading.color || DEFAULT_COLOR;
 
-    // 3. Default fallback - no association found
+    // 4. Default fallback - no association found
     return DEFAULT_COLOR;
   };
 

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/index.tsx
@@ -22,6 +22,8 @@ interface ReadersPanelProps {
   onReaderInfoClick?: (readerId: number) => void;
 }
 
+const DEFAULT_COLOR = '#FFFFFF';
+
 /**
  * Responsive panel displaying all canonical readers with their transmitters.
  * Desktop: Always visible as a side panel.
@@ -58,6 +60,47 @@ const ReadersPanel: React.FC<ReadersPanelProps> = ({
         )),
     [readings],
   );
+
+  const readerColorMap = useMemo(() => {
+    const map = new Map<number, string>();
+    const usedColors = new Set<string>();
+
+    const readerCandidates = readers.map((reader) => ({
+      reader,
+      candidates: readings.filter(
+        ({ matrix }) => matrix?.readers?.includes(reader.id),
+      ),
+    }));
+
+    // First pass: assign unambiguous readers (single candidate)
+    for (const { reader, candidates } of readerCandidates) {
+      if (candidates.length === 1) {
+        const color = candidates[0].color || DEFAULT_COLOR;
+        map.set(reader.id, color);
+        usedColors.add(color);
+      }
+    }
+
+    // Second pass: for ambiguous readers, prefer a candidate color not yet used
+    for (const { reader, candidates } of readerCandidates) {
+      if (candidates.length <= 1) continue;
+
+      const unusedCandidate = candidates.find(
+        ({ color }) => color && !usedColors.has(color),
+      );
+
+      if (unusedCandidate) {
+        const color = unusedCandidate.color || DEFAULT_COLOR;
+        map.set(reader.id, color);
+        usedColors.add(color);
+      } else {
+        const color = candidates[0].color || DEFAULT_COLOR;
+        map.set(reader.id, color);
+      }
+    }
+
+    return map;
+  }, [readers, readings]);
 
   return (
     <div className={classNames(styles.panel, { [styles.expanded]: isExpanded })}>
@@ -101,6 +144,7 @@ const ReadersPanel: React.FC<ReadersPanelProps> = ({
             reader={reader}
             transmitters={transmitters}
             readings={readings}
+            readerColor={readerColorMap.get(reader.id)}
             onInfoClick={() => onReaderInfoClick?.(reader.id)}
             onTransmitterClick={onTransmitterClick}
             isClickable={!!onTransmitterClick}

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/index.tsx
@@ -16,13 +16,12 @@ interface ReadersPanelProps {
   readers: QiraatReader[];
   transmitters: QiraatTransmitter[];
   readings: QiraatReading[];
+  readerColorMap: Map<number, string>;
   isExpanded: boolean;
   onToggleExpand: () => void;
   onTransmitterClick?: (transmitterId: number) => void;
   onReaderInfoClick?: (readerId: number) => void;
 }
-
-const DEFAULT_COLOR = '#FFFFFF';
 
 /**
  * Responsive panel displaying all canonical readers with their transmitters.
@@ -34,6 +33,7 @@ const ReadersPanel: React.FC<ReadersPanelProps> = ({
   readers,
   transmitters,
   readings,
+  readerColorMap,
   isExpanded,
   onToggleExpand,
   onTransmitterClick,
@@ -60,47 +60,6 @@ const ReadersPanel: React.FC<ReadersPanelProps> = ({
         )),
     [readings],
   );
-
-  const readerColorMap = useMemo(() => {
-    const map = new Map<number, string>();
-    const usedColors = new Set<string>();
-
-    const readerCandidates = readers.map((reader) => ({
-      reader,
-      candidates: readings.filter(
-        ({ matrix }) => matrix?.readers?.includes(reader.id),
-      ),
-    }));
-
-    // First pass: assign unambiguous readers (single candidate)
-    for (const { reader, candidates } of readerCandidates) {
-      if (candidates.length === 1) {
-        const color = candidates[0].color || DEFAULT_COLOR;
-        map.set(reader.id, color);
-        usedColors.add(color);
-      }
-    }
-
-    // Second pass: for ambiguous readers, prefer a candidate color not yet used
-    for (const { reader, candidates } of readerCandidates) {
-      if (candidates.length <= 1) continue;
-
-      const unusedCandidate = candidates.find(
-        ({ color }) => color && !usedColors.has(color),
-      );
-
-      if (unusedCandidate) {
-        const color = unusedCandidate.color || DEFAULT_COLOR;
-        map.set(reader.id, color);
-        usedColors.add(color);
-      } else {
-        const color = candidates[0].color || DEFAULT_COLOR;
-        map.set(reader.id, color);
-      }
-    }
-
-    return map;
-  }, [readers, readings]);
 
   return (
     <div className={classNames(styles.panel, { [styles.expanded]: isExpanded })}>

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/index.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/index.tsx
@@ -20,6 +20,8 @@ import {
 } from '@/redux/slices/QuranReader/studyMode';
 import { openReaderBioModal } from '@/redux/slices/QuranReader/verseActionModal';
 
+const DEFAULT_COLOR = '#FFFFFF';
+
 interface StudyModeQiraatTabProps {
   chapterId: string;
   verseNumber: string;
@@ -70,6 +72,52 @@ const StudyModeQiraatTab: React.FC<StudyModeQiraatTabProps> = ({
     if (!data?.junctures || !selectedJunctureId) return null;
     return data.junctures.find((juncture) => juncture.id === selectedJunctureId) ?? null;
   }, [data?.junctures, selectedJunctureId]);
+
+  // Compute reader-to-color and reader-to-reading maps for disambiguation.
+  // When a reader appears in multiple readings, we assign the reader to the
+  // first candidate reading whose color hasn't been used by another reader.
+  // This ensures each reading gets a unique color in the Readers panel.
+  const { readerColorMap, readerReadingMap } = useMemo(() => {
+    const colorMap = new Map<number, string>();
+    const readingMap = new Map<number, number>();
+    const usedColors = new Set<string>();
+
+    const readingsList = selectedJuncture?.readings ?? [];
+
+    const readerCandidates = (data?.readers ?? []).map((reader) => ({
+      reader,
+      candidates: readingsList.filter(
+        ({ matrix }) => matrix?.readers?.includes(reader.id),
+      ),
+    }));
+
+    // First pass: assign unambiguous readers (single candidate)
+    for (const { reader, candidates } of readerCandidates) {
+      if (candidates.length === 1) {
+        const color = candidates[0].color || DEFAULT_COLOR;
+        colorMap.set(reader.id, color);
+        readingMap.set(reader.id, candidates[0].id);
+        usedColors.add(color);
+      }
+    }
+
+    // Second pass: for ambiguous readers, prefer a candidate color not yet used
+    for (const { reader, candidates } of readerCandidates) {
+      if (candidates.length <= 1) continue;
+
+      const unusedCandidate = candidates.find(
+        ({ color }) => color && !usedColors.has(color),
+      );
+
+      const chosen = unusedCandidate || candidates[0];
+      const color = chosen.color || DEFAULT_COLOR;
+      colorMap.set(reader.id, color);
+      readingMap.set(reader.id, chosen.id);
+      usedColors.add(color);
+    }
+
+    return { readerColorMap: colorMap, readerReadingMap: readingMap };
+  }, [data?.readers, selectedJuncture?.readings]);
 
   // Handlers
   const handleJunctureSelect = useCallback((junctureId: number) => {
@@ -140,15 +188,15 @@ const StudyModeQiraatTab: React.FC<StudyModeQiraatTabProps> = ({
       const transmitter = data?.transmitters?.find((tr) => tr.id === transmitterId);
       if (!transmitter) return undefined;
 
-      // 3. Find and scroll to a reading where that reader appears in the matrix
-      const readerReading = selectedJuncture.readings.find((reading) =>
-        reading.matrix?.readers?.includes(transmitter.readerId),
-      );
-
-      if (readerReading) scrollToReading(readerReading.id);
+      // 3. Use the same disambiguation result as the color assignment, so the
+      //    scroll target matches the reader's color in the Readers panel.
+      const readingId = readerReadingMap.get(transmitter.readerId);
+      if (readingId) {
+        scrollToReading(readingId);
+      }
       return undefined;
     },
-    [selectedJuncture?.readings, data?.transmitters],
+    [selectedJuncture?.readings, data?.transmitters, readerReadingMap],
   );
 
   if (isLoading) {
@@ -187,6 +235,7 @@ const StudyModeQiraatTab: React.FC<StudyModeQiraatTabProps> = ({
             readers={data.readers}
             transmitters={data.transmitters}
             readings={selectedJuncture?.readings || []}
+            readerColorMap={readerColorMap}
             isExpanded={isReadersPanelExpanded}
             onToggleExpand={handleToggleReadersPanel}
             onTransmitterClick={handleTransmitterClick}


### PR DESCRIPTION
Fixes #3286

## Summary

When a junction has reader-level overlap (a reader appearing in multiple reading colors) and no transmitter-level disambiguation, the Readers panel hides some reading colors because the color lookup uses first-match semantics via `readings.find()`.

For example, on `https://quran.com/2:245/qiraat`, readers Abū Jaʿfar (6) and Ibn Kathīr (8) appear in both the white reading and the pink reading. Because the white reading appeared first in the payload, both readers were assigned white, hiding the pink color entirely from the panel.

## Changes

**ReadersPanel/index.tsx**: Added a `readerColorMap` that:
1. Assigns unambiguous readers (matching exactly one reading) first
2. For ambiguous readers, prefers a candidate color not yet used by another reader
3. Falls back to first-match only when all candidate colors are already represented

**ReaderItem.tsx**: Added an optional `readerColor` prop. When provided, it takes priority over the inherited first-match fallback in `getTransmitterColor`, allowing the parent panel to control the color assignment.

## Result

All reading colors now appear in the Readers panel even when readers overlap across multiple readings. The fix is not specific to 2:245 and applies to all verses with the same ambiguous reader-level mapping pattern (6:145, 7:161, 10:35, 12:23, 18:44, 19:25, 20:63, 22:39).