### PR TITLE
fix: remove audio pause during zero-delay verse transitions

### DIFF
--- a/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
+++ b/src/xstate/actors/audioPlayer/audioPlayerMachine.ts
@@ -327,18 +327,33 @@ export const audioPlayerMachine =
                             'User either clicks on the pause button or presses the space key',
                           target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.PAUSED.ACTIVE',
                         },
-                        REPEAT_AYAH: {
-                          actions: [
-                            assign({
-                              ayahNumber: (context, event: any) => event.ayahNumber,
-                              verseDelay: (context, event: any) => event.verseDelay,
-                            }),
-                            'pauseAudio',
-                            'setAudioPlayerCurrentTime',
-                          ],
-                          description: 'Repeat the current ayah',
-                          target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.DELAYING',
-                        },
+                        REPEAT_AYAH: [
+                          {
+                            actions: [
+                              assign({
+                                ayahNumber: (context, event: any) => event.ayahNumber,
+                                verseDelay: (context, event: any) => event.verseDelay,
+                              }),
+                              'pauseAudio',
+                              'setAudioPlayerCurrentTime',
+                            ],
+                            cond: 'hasVerseDelay',
+                            description:
+                              'Repeat the current ayah with a configurable delay between verses',
+                            target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.DELAYING',
+                          },
+                          {
+                            actions: [
+                              assign({
+                                ayahNumber: (context, event: any) => event.ayahNumber,
+                              }),
+                              'setAudioPlayerCurrentTime',
+                            ],
+                            description:
+                              'Repeat the current ayah seamlessly without pausing the audio',
+                            target: '#audioPlayer.VISIBLE.AUDIO_PLAYER_INITIATED.PLAYING.ACTIVE',
+                          },
+                        ],
                         SEEKING: {
                           description:
                             'When the mouse or keyboard keys are clicked to jump forward/backward 5 or 10 seconds or when the user wants to navigate to a specific time.',
@@ -1075,6 +1090,9 @@ export const audioPlayerMachine =
           return context.surah === event.surah && reciterId === context.audioData?.reciterId;
         },
         isRepeatActive: (context) => !!context.repeatActor,
+        hasVerseDelay: (context, event: any) => {
+          return event.verseDelay > 0;
+        },
         isUsingCustomReciterId: (context, event) => !!event.reciterId,
         isAudioAlmostEnded: (context) => {
           const { currentTime } = context.audioPlayer;


### PR DESCRIPTION
## Problem

During repeat mode playback, the audio player always pauses before seeking to the next verse, even when the delay between verses is set to zero. This creates an audible gap (voice cutoff) at verse boundaries.

The issue is in the `REPEAT_AYAH` action of the audio player state machine, which unconditionally calls `pauseAudio` before `setAudioPlayerCurrentTime`.

## Root Cause

In `audioPlayerMachine.ts`, the `REPEAT_AYAH` transition in `PLAYING.ACTIVE` state always:

1. Pauses the audio element (`pauseAudio`)
2. Seeks to the next verse timestamp (`setAudioPlayerCurrentTime`)
3. Transitions to `DELAYING` state

Even when `verseDelay === 0` (no configured delay), the pause creates a brief silence between verses.

## Fix

Split the `REPEAT_AYAH` transition into two guarded paths:

- **When `verseDelay > 0`**: Preserves existing behavior (pause, seek, go to DELAYING state) for users who configured a delay between verses.
- **When `verseDelay === 0`**: Skips the pause entirely and seeks directly to the next verse timestamp while audio keeps playing, going straight back to `PLAYING.ACTIVE`. This produces seamless transitions with no voice cutoff.

## Changes

**`src/xstate/actors/audioPlayer/audioPlayerMachine.ts`**:

- Split `REPEAT_AYAH` handler from a single transition into two guarded transitions
- Added `hasVerseDelay` guard: `(context, event) => event.verseDelay > 0`
- First transition (with guard): preserves pause + seek + DELAYING for delay > 0
- Second transition (fallback): seek only, no pause, stays in PLAYING.ACTIVE

## Testing

Standalone state machine tests verified all assertions pass:

1. `verseDelay > 0`: machine pauses audio and enters DELAYING state
2. `verseDelay === 0`: machine skips pause and stays in PLAYING.ACTIVE  
3. Multiple consecutive transitions with zero delay: no pauses, all seamless
4. Ayah number and seek time correctly updated in all cases