### PR TITLE
Fix stale filter value on repeat-ayah combobox open (#2088)

### DIFF
--- a/src/components/dls/Forms/Combobox/index.test.tsx
+++ b/src/components/dls/Forms/Combobox/index.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DropdownItem } from './ComboboxItem';
+
+import Combobox from '.';
+
+vi.mock('./Icons/SearchInputIcon', () => ({ default: () => <span /> }));
+vi.mock('./Icons/ClearInputIcon', () => ({ default: () => null }));
+vi.mock('./Icons/CaretInputIcon', () => ({ default: () => null }));
+
+// jsdom doesn't implement scrollIntoView; ComboboxItems calls it on open.
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+// Builds the same shape of items the repeat-settings / advanced-copy verse
+// selectors build via `generateChapterVersesKeys`: one entry per ayah, value
+// and label both being the localized verse key (e.g. "36:1").
+const buildVerseItems = (chapterNumber: number, versesCount: number): DropdownItem[] =>
+  Array.from({ length: versesCount }, (unused, index) => {
+    const verseKey = `${chapterNumber}:${index + 1}`;
+    return {
+      id: verseKey,
+      value: verseKey,
+      name: verseKey,
+      label: verseKey,
+    };
+  });
+
+describe('Combobox', () => {
+  afterEach(cleanup);
+
+  // Regression test for https://github.com/quran/quran.com-frontend-next/issues/2088
+  // Root cause: `inputValue` was seeded from `initialInputValue` (the currently
+  // selected verse key) and never cleared on open, so the substring filter kept
+  // matching only labels containing that stale value (e.g. selecting "36:1" then
+  // reopening only showed "36:1", "36:10"-"36:19").
+  it('shows every ayah of a long surah after opening, not just ones matching the pre-seeded selection', () => {
+    // Ya-Sin (36) has 83 verses; the reported bug reproduces when the
+    // currently selected verse is the surah's first ayah (e.g. "36:1"),
+    // since every ayah from 10-19 also contains "36:1" as a substring while
+    // 2-9 and 20+ do not.
+    const items = buildVerseItems(36, 83);
+
+    render(
+      <Combobox
+        id="single"
+        items={items}
+        value="36:1"
+        initialInputValue="36:1"
+        placeholder="Search..."
+      />,
+    );
+
+    // Before opening, the combobox is closed; open it the same way a user
+    // would, by clicking the selector.
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const listbox = screen.getByRole('listbox');
+
+    // These ayahs never contained "36:1" as a substring, so they were hidden
+    // by the stale filter before the fix.
+    expect(within(listbox).getByText('36:2')).not.toBeNull();
+    expect(within(listbox).getByText('36:20')).not.toBeNull();
+    expect(within(listbox).getByText('36:83')).not.toBeNull();
+  });
+
+  it('still shows every ayah for a short surah after opening', () => {
+    // An-Nas (114) has 6 verses; make sure the fix doesn't break the short case.
+    const items = buildVerseItems(114, 6);
+
+    render(
+      <Combobox
+        id="single"
+        items={items}
+        value="114:1"
+        initialInputValue="114:1"
+        placeholder="Search..."
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const listbox = screen.getByRole('listbox');
+
+    expect(within(listbox).getByText('114:1')).not.toBeNull();
+    expect(within(listbox).getByText('114:6')).not.toBeNull();
+  });
+
+  it('still filters items once the user types after opening', () => {
+    const items = buildVerseItems(36, 83);
+
+    render(
+      <Combobox
+        id="single"
+        items={items}
+        value="36:1"
+        initialInputValue="36:1"
+        placeholder="Search..."
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.click(input);
+    fireEvent.change(input, { target: { value: '36:5' } });
+
+    const listbox = screen.getByRole('listbox');
+
+    expect(within(listbox).getByText('36:5')).not.toBeNull();
+    expect(within(listbox).queryByText('36:20')).toBeNull();
+  });
+});

--- a/src/components/dls/Forms/Combobox/index.tsx
+++ b/src/components/dls/Forms/Combobox/index.tsx
@@ -231,7 +231,20 @@ const Combobox: React.FC<Props> = ({
   );
 
   const onSelectorClicked = () => {
-    setIsOpened((prevIsOpened) => !prevIsOpened);
+    setIsOpened((prevIsOpened) => {
+      const willOpen = !prevIsOpened;
+      // Opening the combobox previously left `inputValue` seeded with the current
+      // selection's label (from `initialInputValue`). Since the item list is
+      // filtered by a substring match against `inputValue`, this hid every item
+      // whose label didn't contain that stale value (e.g. selecting "36:1" then
+      // reopening only showed "36:1", "36:10"-"36:19"). Clear it on open so every
+      // item is visible until the user actually types to filter.
+      // See https://github.com/quran/quran.com-frontend-next/issues/2088
+      if (willOpen && !isMultiSelect) {
+        setInputValue('');
+      }
+      return willOpen;
+    });
     // we need to focus on the input field whenever the user clicks anywhere inside the component.
     if (isMultiSelect) {
       focusInput();

--- a/src/utils/verse.test.ts
+++ b/src/utils/verse.test.ts
@@ -198,4 +198,19 @@ describe('generateChapterVersesKeys', () => {
     const result = generateChapterVersesKeys(chaptersData, chapterId, false);
     expect(result).toEqual(expectedKeys);
   });
+
+  // Regression test for https://github.com/quran/quran.com-frontend-next/issues/2088
+  // The repeat-settings "to ayah" dropdown must include every ayah in the surah,
+  // not just the first 19, for surahs that have more than 19 verses.
+  it('should generate keys for every verse of a surah with more than 19 verses', async () => {
+    const chapterId = '2'; // Al-Baqarah has 286 verses
+    const chaptersData = await getAllChaptersData();
+    const result = generateChapterVersesKeys(chaptersData, chapterId, false);
+
+    expect(result).toHaveLength(286);
+    expect(result[0]).toEqual('2:1');
+    expect(result[18]).toEqual('2:19');
+    expect(result[19]).toEqual('2:20');
+    expect(result[result.length - 1]).toEqual('2:286');
+  });
 });

--- a/src/utils/verse.test.ts
+++ b/src/utils/verse.test.ts
@@ -199,18 +199,15 @@ describe('generateChapterVersesKeys', () => {
     expect(result).toEqual(expectedKeys);
   });
 
-  // Regression test for https://github.com/quran/quran.com-frontend-next/issues/2088
-  // The repeat-settings "to ayah" dropdown must include every ayah in the surah,
-  // not just the first 19, for surahs that have more than 19 verses.
+  // Coverage for a long surah: the existing tests above only exercised
+  // chapters 1, 112, and the not-found case, none of which have more than 19
+  // verses, so a hypothetical 19-item cap would not have been caught here.
   it('should generate keys for every verse of a surah with more than 19 verses', async () => {
     const chapterId = '2'; // Al-Baqarah has 286 verses
     const chaptersData = await getAllChaptersData();
     const result = generateChapterVersesKeys(chaptersData, chapterId, false);
+    const expectedKeys = Array.from({ length: 286 }, (unused, index) => `2:${index + 1}`);
 
-    expect(result).toHaveLength(286);
-    expect(result[0]).toEqual('2:1');
-    expect(result[18]).toEqual('2:19');
-    expect(result[19]).toEqual('2:20');
-    expect(result[result.length - 1]).toEqual('2:286');
+    expect(result).toEqual(expectedKeys);
   });
 });


### PR DESCRIPTION
## Summary

An earlier version of this PR added a test-only regression check for `generateChapterVersesKeys()` and claimed the bug reported in #2088 (repeat-settings "to ayah" dropdown capped around ayah 19) had already been fixed by the 2022 xstate rewrite of the repeat modal. That claim was wrong, and a cold-start review on this PR traced it down: the 2022 rewrite (`c46b62df`) happened ~18 months *before* the issue was even filed, and `generateChapterVersesKeys` was already uncapped at the time of the report too. That function was never the cause.

This update fixes the actual root cause and corrects the PR accordingly.

## Real root cause

`src/components/dls/Forms/Combobox/index.tsx` seeds `inputValue` from `initialInputValue` on mount, and filters the dropdown's visible items by a **substring** match against `inputValue`:

```ts
const [inputValue, setInputValue] = useState<string>(initialInputValue || '');
...
setFilteredItems(
  !inputValue ? items : items.filter((item) => item.label.toLowerCase().includes(inputValue.toLowerCase())),
);
```

`SelectRepetitionMode.tsx` passes `initialInputValue={toLocalizedVerseKey(verseKey, lang)}` and `AdvancedCopy/SelectorContainer.tsx` passes `initialInputValue={value}` — i.e. the currently selected verse key (e.g. `"36:1"` for a surah whose selection starts at ayah 1). Opening the combobox (`onSelectorClicked`) only toggled `isOpened`; it never cleared `inputValue`. So the dropdown stayed filtered by the stale selected value, and only items whose label *contained* `"36:1"` as a substring matched: `36:1, 36:10, 36:11 … 36:19`. Ayahs 2-9 and 20+ were invisible — exactly the reported "capped around 19, with some missing depending on the surah."

## Fix

`onSelectorClicked` now clears `inputValue` when the combobox transitions from closed to open (single-select only; multi-select already cleared it on close), so every item is visible again until the user actually types to filter. `initialInputValue` still drives the closed-state display label (via `closeCombobox`'s restore-from-`valueToLabelMap` logic), so nothing about the collapsed view changes.

Verified against both a long surah (Ya-Sin, 83 verses, selection seeded at `"36:1"`) and a short surah (An-Nas, 6 verses) to confirm the short case isn't broken.

## What changed here

- `src/components/dls/Forms/Combobox/index.tsx` — clear `inputValue` on open (the actual fix).
- `src/components/dls/Forms/Combobox/index.test.tsx` — new component-level regression test: renders `Combobox` seeded with a stale selected value, opens it, and asserts ayahs outside the old substring match (e.g. `36:2`, `36:20`, `36:83`) are present; also covers the short-surah case and confirms typing still filters correctly. Verified these tests fail without the fix and pass with it.
- `src/utils/verse.test.ts` — kept the earlier long-surah coverage for `generateChapterVersesKeys` (harmless, just not the actual fix), but removed the false "regression test for #2088" framing and tightened the assertion to a full expected-array comparison per review feedback.

## Test plan

- [x] `npx vitest run src/components/dls/Forms/Combobox src/utils/verse.test.ts` — 26/26 pass
- [x] Confirmed the new Combobox tests fail on the pre-fix code and pass after the fix
- [x] `npx eslint` clean on all changed files
- [x] Manually traced both `SelectRepetitionMode.tsx` (repeat-ayah modal) and `AdvancedCopy/SelectorContainer.tsx` (advanced copy range selectors) — both feed `Combobox` through the same `initialInputValue` prop, so both consumers are fixed by this change

Closes #2088
