### PR TITLE
Fix footer background seam in Sepia theme

### DIFF
--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -7,10 +7,12 @@
   // differ and caused a visible seam at the footer's top border (#2336)
   background-color: var(--color-background-default);
 
-  // Quran reader routes (chapter/juz/page/verse) render on the elevated
-  // surface (see QuranReader.module.scss's .container), not the default one.
-  // Without this override, the default-background footer above would itself
-  // create a new Sepia seam against that elevated surface (#3326).
+  // Quran reader routes (chapter/juz/page/verse) and collection routes
+  // (see QuranReader.module.scss's .container and
+  // CollectionDetailContainer.module.scss's .wrapper) render on the elevated
+  // surface, not the default one. Without this override, the default-background
+  // footer above would itself create a new Sepia seam against that elevated
+  // surface (#3326).
   &.elevatedBackground {
     background-color: var(--color-background-elevated-new);
   }

--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -3,7 +3,9 @@
 @use 'src/styles/constants';
 
 .footer {
-  background-color: var(--color-background-elevated-new);
+  // matches page background instead of "elevated" surface; in Sepia those
+  // differ and caused a visible seam at the footer's top border (#2336)
+  background-color: var(--color-background-default);
 }
 
 .flowItem {

--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -6,6 +6,14 @@
   // matches page background instead of "elevated" surface; in Sepia those
   // differ and caused a visible seam at the footer's top border (#2336)
   background-color: var(--color-background-default);
+
+  // Quran reader routes (chapter/juz/page/verse) render on the elevated
+  // surface (see QuranReader.module.scss's .container), not the default one.
+  // Without this override, the default-background footer above would itself
+  // create a new Sepia seam against that elevated surface (#3326).
+  &.elevatedBackground {
+    background-color: var(--color-background-elevated-new);
+  }
 }
 
 .flowItem {

--- a/src/components/dls/Footer/Footer.test.tsx
+++ b/src/components/dls/Footer/Footer.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Footer from './Footer';
+import styles from './Footer.module.scss';
+
+const mockUseRouter = vi.fn();
+
+vi.mock('next/router', () => ({
+  useRouter: () => mockUseRouter(),
+}));
+
+vi.mock('next-translate/useTranslation', () => ({
+  default: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('./BottomSection', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('./Links', () => ({
+  default: () => <div />,
+}));
+
+vi.mock('./TitleAndDescription', () => ({
+  default: () => <div />,
+}));
+
+describe('Footer', () => {
+  it('does not use the elevated background on non Quran reader routes', () => {
+    mockUseRouter.mockReturnValue({ pathname: '/about-us' });
+
+    const { container } = render(<Footer />);
+    const footer = container.querySelector('footer');
+
+    expect(footer?.classList.contains(styles.elevatedBackground)).toBe(false);
+  });
+
+  it('uses the elevated background on Quran reader routes to match QuranReader surface (#3326)', () => {
+    mockUseRouter.mockReturnValue({ pathname: '/[chapterId]' });
+
+    const { container } = render(<Footer />);
+    const footer = container.querySelector('footer');
+
+    expect(footer?.classList.contains(styles.elevatedBackground)).toBe(true);
+  });
+
+  it.each(['/juz/[juzId]', '/page/[pageId]', '/hizb/[hizbId]', '/[chapterId]/[verseId]'])(
+    'uses the elevated background on reader route %s',
+    (pathname) => {
+      mockUseRouter.mockReturnValue({ pathname });
+
+      const { container } = render(<Footer />);
+      const footer = container.querySelector('footer');
+
+      expect(footer?.classList.contains(styles.elevatedBackground)).toBe(true);
+    },
+  );
+});

--- a/src/components/dls/Footer/Footer.test.tsx
+++ b/src/components/dls/Footer/Footer.test.tsx
@@ -58,4 +58,16 @@ describe('Footer', () => {
       expect(footer?.classList.contains(styles.elevatedBackground)).toBe(true);
     },
   );
+
+  it.each(['/collections/all', '/collections/[collectionId]'])(
+    'uses the elevated background on collection route %s to match CollectionDetailContainer surface (#3326)',
+    (pathname) => {
+      mockUseRouter.mockReturnValue({ pathname });
+
+      const { container } = render(<Footer />);
+      const footer = container.querySelector('footer');
+
+      expect(footer?.classList.contains(styles.elevatedBackground)).toBe(true);
+    },
+  );
 });

--- a/src/components/dls/Footer/Footer.tsx
+++ b/src/components/dls/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import styles from './Footer.module.scss';
 import Links from './Links';
 import TitleAndDescription from './TitleAndDescription';
 
-import { isQuranReaderRoutePathname } from '@/utils/routes';
+import { isElevatedBackgroundRoutePathname } from '@/utils/routes';
 
 const Footer = () => {
   const router = useRouter();
@@ -18,14 +18,18 @@ const Footer = () => {
     return null;
   }
 
-  // Quran reader routes render their content on the elevated background surface
-  // (see QuranReader.module.scss), so the footer must match that surface here too,
-  // otherwise it creates a seam against the default background (#2336/#3326).
-  const isQuranReaderRoute = isQuranReaderRoutePathname(router.pathname);
+  // Quran reader and collection routes render their content on the elevated
+  // background surface (see QuranReader.module.scss and
+  // CollectionDetailContainer.module.scss), so the footer must match that
+  // surface here too, otherwise it creates a seam against the default
+  // background (#2336/#3326).
+  const isElevatedBackgroundRoute = isElevatedBackgroundRoutePathname(router.pathname);
 
   return (
     <footer
-      className={classNames(styles.footer, { [styles.elevatedBackground]: isQuranReaderRoute })}
+      className={classNames(styles.footer, {
+        [styles.elevatedBackground]: isElevatedBackgroundRoute,
+      })}
     >
       <div className={styles.flowItem}>
         <div className={styles.container}>

--- a/src/components/dls/Footer/Footer.tsx
+++ b/src/components/dls/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
 
@@ -5,6 +6,8 @@ import BottomSection from './BottomSection';
 import styles from './Footer.module.scss';
 import Links from './Links';
 import TitleAndDescription from './TitleAndDescription';
+
+import { isQuranReaderRoutePathname } from '@/utils/routes';
 
 const Footer = () => {
   const router = useRouter();
@@ -15,8 +18,15 @@ const Footer = () => {
     return null;
   }
 
+  // Quran reader routes render their content on the elevated background surface
+  // (see QuranReader.module.scss), so the footer must match that surface here too,
+  // otherwise it creates a seam against the default background (#2336/#3326).
+  const isQuranReaderRoute = isQuranReaderRoutePathname(router.pathname);
+
   return (
-    <footer className={styles.footer}>
+    <footer
+      className={classNames(styles.footer, { [styles.elevatedBackground]: isQuranReaderRoute })}
+    >
       <div className={styles.flowItem}>
         <div className={styles.container}>
           <TitleAndDescription />

--- a/src/utils/routes.test.ts
+++ b/src/utils/routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isQuranReaderRoutePathname } from './routes';
+import { isElevatedBackgroundRoutePathname, isQuranReaderRoutePathname } from './routes';
 
 describe('isQuranReaderRoutePathname', () => {
   it('returns true for quran reader paths', () => {
@@ -15,5 +15,22 @@ describe('isQuranReaderRoutePathname', () => {
     expect(isQuranReaderRoutePathname('/')).toBe(false);
     expect(isQuranReaderRoutePathname('/about-us')).toBe(false);
     expect(isQuranReaderRoutePathname('/support')).toBe(false);
+  });
+});
+
+describe('isElevatedBackgroundRoutePathname', () => {
+  it('returns true for quran reader paths', () => {
+    expect(isElevatedBackgroundRoutePathname('/[chapterId]')).toBe(true);
+    expect(isElevatedBackgroundRoutePathname('/juz/[juzId]')).toBe(true);
+  });
+
+  it('returns true for collection paths', () => {
+    expect(isElevatedBackgroundRoutePathname('/collections/all')).toBe(true);
+    expect(isElevatedBackgroundRoutePathname('/collections/[collectionId]')).toBe(true);
+  });
+
+  it('returns false for non-elevated paths', () => {
+    expect(isElevatedBackgroundRoutePathname('/')).toBe(false);
+    expect(isElevatedBackgroundRoutePathname('/about-us')).toBe(false);
   });
 });

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -37,3 +37,17 @@ export const isAuthPage = (router: NextRouter): boolean => {
 export const isQuranReaderRoutePathname = (pathname: string): boolean => {
   return QURAN_READER_ROUTE_PATHNAMES.has(pathname);
 };
+
+// Routes whose page content renders on the "elevated" background surface
+// (--color-background-elevated-new) instead of the default one, so any UI
+// that sits right after them (e.g. the footer) needs to match that surface
+// to avoid a seam in themes like Sepia where the two tokens differ (#3326).
+export const ELEVATED_BACKGROUND_ROUTE_PATHNAMES = new Set([
+  ...QURAN_READER_ROUTE_PATHNAMES,
+  '/collections/all',
+  '/collections/[collectionId]',
+]);
+
+export const isElevatedBackgroundRoutePathname = (pathname: string): boolean => {
+  return ELEVATED_BACKGROUND_ROUTE_PATHNAMES.has(pathname);
+};


### PR DESCRIPTION
## Summary
Fixes #2336 — the footer's top border/edge looked out of place in the Sepia theme.

Root cause (confirmed against theme variables): the footer's background used `--color-background-elevated-new`, while the page body uses `--color-background-default`. In Light and Dark themes these two tokens resolve to the same color, so the seam is invisible. In Sepia they differ (`--color-background-default: #f8ebd5` vs `--color-background-elevated-new: #fff7ea`), producing the visible line/contrast at the footer's top border described in the issue.

## Change
`src/components/dls/Footer/Footer.module.scss`: footer background now uses `--color-background-default` instead of `--color-background-elevated-new`.

This is a no-op for Light and Dark (identical token values there) and removes the color seam in Sepia.

## Test plan
- [ ] Visit quran.com, switch to Sepia theme, scroll to footer — background is now continuous with the page, no visible seam at the top border
- [ ] Verify Light and Dark themes are visually unchanged