### PR TITLE
Fix IndoPak text overlap in Translation/Tafsir mode

### DIFF
--- a/src/components/Verse/VerseText.module.scss
+++ b/src/components/Verse/VerseText.module.scss
@@ -82,6 +82,12 @@
 @include utility.generate-font-scales('fallback_qpc_uthmani_hafs');
 @include utility.generate-font-scales('tajweed');
 
+// Compensate the line-height for the 1.2x font-size bump applied to
+// `.tafsirOrTranslationMode` (see below), so IndoPak text doesn't overlap
+// between lines in Translation/Tafsir mode. See quran/quran.com-frontend-next#1925.
+@include utility.generate-translation-mode-line-height-fix('text_indopak_15_lines');
+@include utility.generate-translation-mode-line-height-fix('text_indopak_16_lines');
+
 .highlighted {
   background-color: var(--color-background-alternative-faded);
 }

--- a/src/styles/_utility.scss
+++ b/src/styles/_utility.scss
@@ -834,6 +834,26 @@ $line-width-map: (
   }
 }
 
+// `.tafsirOrTranslationMode` (see VerseText.module.scss) bumps --font-size by
+// 1.2x on tablet+ for translation/tafsir views, but --line-height keeps the
+// value tuned for the un-scaled font-size. IndoPak's diacritics are tall
+// enough that this mismatch makes them overlap the line below it, so scale
+// --line-height by the same 1.2x for IndoPak specifically when combined with
+// `.tafsirOrTranslationMode`.
+@mixin generate-translation-mode-line-height-fix($name) {
+  $tablet-line-height-scales: get-scales($name, 'tablet', $line-heights-map);
+
+  @for $i from 1 through constants.$maximum-font-step {
+    @if map.has-key($tablet-line-height-scales, $i) {
+      .tafsirOrTranslationMode.#{$name}-font-size-#{$i} {
+        @include breakpoints.tablet {
+          --line-height: calc(1.2 * #{map.get($tablet-line-height-scales, $i)});
+        }
+      }
+    }
+  }
+}
+
 // Sets a max-width based on the device width. Inspired by the bootstrap container (https://getbootstrap.com/docs/5.0/layout/containers/).
 $large-device-width-ratio: 95%;
 $quran-max-container-width: 112rem;


### PR DESCRIPTION
## Summary

Fixes #1925 — IndoPak font text overlaps with itself between lines in Translation (and Tafsir) mode.

### Root cause

`.tafsirOrTranslationMode` (applied to the verse container whenever the reader is **not** in reading mode) bumps `--font-size` by `1.2x` on tablet+ viewports:

```scss
.tafsirOrTranslationMode {
  font-size: calc(1.2 * var(--font-size));
}
```

`--line-height` is a fixed `vh` value generated per font-size step by `generate-font-scales`, tuned for the *un-scaled* `--font-size`. It isn't recalculated when the 1.2x bump is applied. Most fonts have enough headroom that this goes unnoticed, but IndoPak's diacritics/vowel marks are tall enough relative to its tuned line-height that the scaled-up glyphs from one line overlap the line below it — exactly what's shown in the issue's screenshot.

### Fix

Added a new mixin, `generate-translation-mode-line-height-fix`, that emits a `--line-height` override scaled by the same `1.2x` factor, scoped narrowly to the combination of `.tafsirOrTranslationMode` with each IndoPak `text_indopak_15_lines-font-size-N` / `text_indopak_16_lines-font-size-N` class, on tablet+ only (mobile already uses `line-height: normal`, which scales with font-size automatically).

This only affects IndoPak in translation/tafsir mode — reading mode and all other fonts (Uthmani Hafs, Tajweed, etc.) are untouched.

## Test plan

- [x] `stylelint` passes on both changed files
- [x] Compiled the changed SCSS with `sass` directly and confirmed the generated CSS contains the expected `--line-height: calc(1.2 * <value>)` overrides for all 10 font-size steps, for both `text_indopak_15_lines` and `text_indopak_16_lines`
- [ ] Manual visual check in a running dev server against `/2:1` (or any surah) with IndoPak font selected in Translation view on a tablet/desktop viewport (I don't have a running dev environment in this sandbox — would appreciate a maintainer/CI visual check before merge)

Closes #1925