### PR TITLE
fix(footer): use page background token to remove Sepia seam

### DIFF
--- a/src/components/dls/Footer/Footer.module.scss
+++ b/src/components/dls/Footer/Footer.module.scss
@@ -3,7 +3,10 @@
 @use 'src/styles/constants';
 
 .footer {
-  background-color: var(--color-background-elevated-new);
+  // Matches the page body background so no seam shows between content and
+  // footer. Identical to elevated-new in Light/Dark; in Sepia the tokens
+  // differ (#f8ebd5 vs #fff7ea) and elevated-new drew a visible line.
+  background-color: var(--color-background-default);
 }
 
 .flowItem {


### PR DESCRIPTION
Fixes #3326 (root cause of #2336).\n\nThe footer background used \--color-background-elevated-new\ while the page body uses \--color-background-default\\. I confirmed against \src/styles/themes/_{light,dark,sepia}.scss\\: Light (#fff vs #ffffff) and Dark (#1f2125 vs #1f2125) resolve identically, but Sepia differs (#fff7ea vs #f8ebd5) — hence the visible line at the footer's top edge only in Sepia.\n\nOne-token change, no-op for Light/Dark. Remaining footer colors all use theme-aware text/border tokens, so nothing else depended on the old value.\n\nCould not run a visual check in my environment; the fix follows directly from the token values. Light/Dark rendering is provably unchanged (identical resolved colors).