### PR TITLE
fix(redux): migration 18 copy-paste error in audioPlayerState (#3088)

### DIFF
--- a/src/redux/migrations.ts
+++ b/src/redux/migrations.ts
@@ -121,7 +121,7 @@ export default {
   18: (state) => ({
     ...state,
     audioPlayerState: {
-      ...state.readingPreferences,
+      ...state.audioPlayerState,
       showTooltipWhenPlayingAudio: false,
     },
   }),


### PR DESCRIPTION
Fixes #3088

## Summary

Migration 18 in \src/redux/migrations.ts\ had a copy-paste error. Instead of spreading the existing \udioPlayerState\, it spread \state.readingPreferences\ into \udioPlayerState\, which would corrupt the audio player state by overwriting it with reading preferences data.

### Before

\\\	ypescript
18: (state) => ({
  ...state,
  audioPlayerState: {
    ...state.readingPreferences, // BUG: overwrites audioPlayerState with readingPreferences
    showTooltipWhenPlayingAudio: false,
  },
}),
\\\

### After

\\\	ypescript
18: (state) => ({
  ...state,
  audioPlayerState: {
    ...state.audioPlayerState, // preserves existing audio player state
    showTooltipWhenPlayingAudio: false,
  },
}),
\\\

This doesn't change migration behavior for states where \udioPlayerState\ was previously spread over \eadingPreferences\ (which produced identical keys only for \showTooltipWhenPlayingAudio\), but it stops leaking reading preference keys (e.g. \wordByWordContentType\, \eadingPreference\) into the audio player state on migration.