### PR TITLE
fix(qiraat): color panel tags from matrix cells when top-level lists miss

### DIFF
--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/ReaderItem.tsx
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/ReadersPanel/ReaderItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import styles from './ReaderItem.module.scss';
 import RwayahTag from './RwayahTag';
+import { getTransmitterColor } from '../utils/transmitterColor';
 
 import HelpCircleIcon from '@/icons/help-circle.svg';
 import { QiraatReader, QiraatTransmitter, QiraatReading } from '@/types/Qiraat';
@@ -15,10 +16,7 @@ interface ReaderItemProps {
   isClickable?: boolean;
 }
 
-const DEFAULT_COLOR = '#FFFFFF';
-
 /**
- * Display a single reader with their city and two transmitters (Rwayat).
  * Each transmitter tag is color-coded based on the reading they're associated with.
  * @returns {JSX.Element} Rendered ReaderItem component
  */
@@ -33,38 +31,8 @@ const ReaderItem: React.FC<ReaderItemProps> = ({
   // Get transmitters for this reader (should be 2 based on spec)
   const readerTransmitters = transmitters.filter((t) => t.readerId === reader.id);
 
-  /**
-   * Determines the color for a transmitter tag based on its association with a reading.
-   *
-   * Qiraat readings have colored matrix displays that show which transmitters and readers
-   * are part of that reading. When displaying a transmitter in the Readers panel, we need
-   * to find which reading it belongs to so we can color-code it appropriately.
-   *
-   * Two-step lookup process:
-   * 1. Direct match: Try to find a reading where this transmitter appears in the matrix
-   * 2. Inherited match: If not found directly, look for a reading where the transmitter's
-   *    parent reader appears (transmitters inherit their reader's color association)
-   * 3. Fallback: Return white if no association found
-   *
-   * @param {number} transmitterId - The ID of the transmitter to find a color for
-   * @returns {string} The hex color code for the transmitter's associated reading
-   */
-  const getTransmitterColor = (transmitterId: number): string => {
-    // 1. Find a reading where this transmitter appears directly in the matrix
-    const transmitterReading = readings.find(({ matrix }) =>
-      matrix?.transmitters?.includes(transmitterId),
-    );
-
-    if (transmitterReading) return transmitterReading.color || DEFAULT_COLOR;
-
-    // 2. If not found directly, the transmitter inherits color from its parent reader
-    // Find a reading where this reader appears in the matrix
-    const readerReading = readings.find(({ matrix }) => matrix?.readers?.includes(reader.id));
-    if (readerReading) return readerReading.color || DEFAULT_COLOR;
-
-    // 3. Default fallback - no association found
-    return DEFAULT_COLOR;
-  };
+  const getColor = (transmitterId: number): string =>
+    getTransmitterColor(transmitterId, reader.id, readings);
 
   return (
     <div className={styles.item}>
@@ -89,7 +57,7 @@ const ReaderItem: React.FC<ReaderItemProps> = ({
           <RwayahTag
             key={transmitter.id}
             transmitter={transmitter}
-            color={getTransmitterColor(transmitter.id)}
+            color={getColor(transmitter.id)}
             onClick={() => onTransmitterClick?.(transmitter.id)}
             isClickable={isClickable}
           />

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterColor.test.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterColor.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { QiraatReading } from '@/types/Qiraat';
+
+import { DEFAULT_READER_COLOR, getTransmitterColor } from './transmitterColor';
+
+const reading = (overrides: Partial<QiraatReading>): QiraatReading => ({
+  id: 1,
+  position: 1,
+  text: '',
+  textUthmani: '',
+  textImlaei: null,
+  grammaticalForm: null,
+  rootLetters: null,
+  color: '#EA9999',
+  translation: null,
+  translations: null,
+  transliteration: null,
+  explanation: null,
+  explanations: null,
+  matrix: { readers: [], transmitters: [], cells: [] },
+  ...overrides,
+});
+
+describe('getTransmitterColor', () => {
+  it('uses the direct matrix membership first', () => {
+    const readings = [
+      reading({
+        color: '#B7D7A8',
+        matrix: { readers: [], transmitters: [7], cells: [] },
+      }),
+    ];
+
+    expect(getTransmitterColor(7, 3, readings)).toBe('#B7D7A8');
+  });
+
+  it('inherits the color from the parent reader', () => {
+    const readings = [
+      reading({
+        color: '#A4C2F4',
+        matrix: { readers: [3], transmitters: [], cells: [] },
+      }),
+    ];
+
+    expect(getTransmitterColor(7, 3, readings)).toBe('#A4C2F4');
+  });
+
+  it('falls back to matrix cells when top-level lists miss (refs #3286)', () => {
+    // Models 2:245: the pink reading does not list the transmitter (or its
+    // reader) in the top-level matrix arrays — only the cells do.
+    const readings = [
+      reading({
+        color: '#EA9999',
+        matrix: {
+          readers: [],
+          transmitters: [],
+          cells: [
+            { readerId: 9, transmitterId: 21, type: 'transmitter' },
+            { readerId: 9, transmitterId: null, type: 'reader' },
+          ],
+        },
+      }),
+    ];
+
+    expect(getTransmitterColor(21, 9, readings)).toBe('#EA9999');
+    expect(getTransmitterColor(99, 9, readings)).toBe('#EA9999');
+  });
+
+  it('prefers direct and inherited matches over cells', () => {
+    const readings = [
+      reading({
+        color: '#B7D7A8',
+        matrix: {
+          readers: [],
+          transmitters: [7],
+          cells: [{ readerId: 9, transmitterId: 7, type: 'transmitter' }],
+        },
+      }),
+      reading({
+        color: '#EA9999',
+        matrix: { readers: [], transmitters: [], cells: [] },
+      }),
+    ];
+
+    expect(getTransmitterColor(7, 3, readings)).toBe('#B7D7A8');
+  });
+
+  it('falls back to white when nothing associates the transmitter', () => {
+    const readings = [
+      reading({
+        color: '#B7D7A8',
+        matrix: { readers: [1], transmitters: [2], cells: [] },
+      }),
+    ];
+
+    expect(getTransmitterColor(7, 3, readings)).toBe(DEFAULT_READER_COLOR);
+    expect(getTransmitterColor(7, 3, [])).toBe(DEFAULT_READER_COLOR);
+  });
+});

--- a/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterColor.ts
+++ b/src/components/QuranReader/ReadingView/StudyModeModal/tabs/StudyModeQiraatTab/utils/transmitterColor.ts
@@ -1,0 +1,49 @@
+import { QiraatReading } from '@/types/Qiraat';
+
+export const DEFAULT_READER_COLOR = '#FFFFFF';
+
+/**
+ * Color for a transmitter tag based on its association with a reading.
+ *
+ * Transmitter tags are color-coded like the reading cards. Association is
+ * resolved in four steps:
+ * 1. Direct match: a reading listing this transmitter in its matrix.
+ * 2. Inherited match: a reading listing this transmitter's parent reader.
+ * 3. Cell match: a reading whose matrix *cells* reference the transmitter
+ *    (or, failing that, the parent reader). Some readings only associate
+ *    participants at cell granularity, so steps 1-2 alone leave their tags
+ *    white while the cards show color.
+ * 4. Fallback: white (no association found).
+ *
+ * Later steps never override earlier ones.
+ *
+ * @param {number} transmitterId the transmitter shown in the tag
+ * @param {number} readerId the transmitter's parent reader
+ * @param {QiraatReading[]} readings the selected juncture's readings
+ * @returns {string} the hex color code for the tag
+ */
+export const getTransmitterColor = (
+  transmitterId: number,
+  readerId: number,
+  readings: QiraatReading[],
+): string => {
+  const directReading = readings.find(({ matrix }) =>
+    matrix?.transmitters?.includes(transmitterId),
+  );
+  if (directReading) return directReading.color || DEFAULT_READER_COLOR;
+
+  const readerReading = readings.find(({ matrix }) => matrix?.readers?.includes(readerId));
+  if (readerReading) return readerReading.color || DEFAULT_READER_COLOR;
+
+  const cellReading = readings.find(({ matrix }) =>
+    matrix?.cells?.some((cell) => cell.transmitterId === transmitterId),
+  );
+  if (cellReading) return cellReading.color || DEFAULT_READER_COLOR;
+
+  const readerCellReading = readings.find(({ matrix }) =>
+    matrix?.cells?.some((cell) => cell.readerId === readerId),
+  );
+  if (readerCellReading) return readerCellReading.color || DEFAULT_READER_COLOR;
+
+  return DEFAULT_READER_COLOR;
+};


### PR DESCRIPTION
# Pull Request

## Summary

Closes #3286. On `/2:245/qiraat`, the pink reading's cards show color but its reader/transmitter
tags in the left panel stay white: the panel resolved tag colors only through the top-level
`matrix.transmitters` / `matrix.readers` arrays, while that reading associates Abū Jaʿfar and
Ibn Kathīr at matrix-*cell* granularity.

## Change

- `getTransmitterColor` extracted from `ReaderItem.tsx` into a pure, unit-tested util, extended
  with two fallback steps: match `matrix.cells[].transmitterId`, then `matrix.cells[].readerId`.
  The existing direct/inherited steps are untouched and keep priority, so no currently-colored
  tag changes color — this only turns white tags into their card color.
- `ReaderItem` uses the shared helper (dead local copy removed).

## Verification

- 5 new `vitest` cases (direct/inherited priority, cell fallback reproducing the 2:245 shape,
  white fallback).
- `tsc --noEmit`: zero errors in touched files (repo has 9 pre-existing errors elsewhere).
- New code follows the repo's lint rules (no `for..of`, typed JSDoc); repo-wide lint/type noise
  (CRLF, resolver env) is pre-existing and untouched.
